### PR TITLE
fixed variable typo preventing to use the REPL in some cases

### DIFF
--- a/tools/repl.js
+++ b/tools/repl.js
@@ -51,7 +51,7 @@ var enum_global = "var global = Function('return this')(); Object.getOwnProperty
 function expanduser(x) {
   if (!x) return x;
   if (x === '~') return homedir;
-  if (x.slice(0, 2) != '~/') return path;
+  if (x.slice(0, 2) != '~/') return x;
   return path.join(homedir, x.slice(2));
 }
 


### PR DESCRIPTION
My $XDG_CACHE_HOME is set to an absolute path, hence I encountered the bug when starting the REPL