### PR TITLE
fix parser's readfile default option value

### DIFF
--- a/lib/rapydscript.js
+++ b/lib/rapydscript.js
@@ -4187,7 +4187,8 @@ var ՐՏ_modules = {};
             dropDecorators: [],
             dropImports: [],
             dropDocstrings: false,
-            classes: null
+            classes: null,
+            readfile: require("fs").readFileSync
         });
         module_id = options.module_id;
         import_dirs = options.import_dirs.slice(0);
@@ -4757,7 +4758,7 @@ var ՐՏ_modules = {};
             contents = parse(src_code, {
                 filename: filename,
                 toplevel: null,
-                readfile: options.readfile || require("fs").readFileSync,
+                readfile: options.readfile,
                 basedir: options.basedir,
                 libdir: options.libdir,
                 module_id: key,

--- a/src/parser.pyj
+++ b/src/parser.pyj
@@ -221,7 +221,8 @@ def parse($TEXT, options):
         dropDecorators: [],     # Decorators to omit from compilation
         dropImports: [],        # Imports to omit from compilation
         dropDocstrings: False,  # If true, omit docstrings from compilation
-        classes: None           # Map of class names to ast.Class that are available in the global namespace (used by the REPL)
+        classes: None,          # Map of class names to ast.Class that are available in the global namespace (used by the REPL)
+        readfile: require('fs').readFileSync,  # File reader
     })
     module_id = options.module_id
 
@@ -752,7 +753,7 @@ def parse($TEXT, options):
         contents = parse(src_code, {
             filename: filename,
             toplevel: None,
-            readfile: options.readfile or require('fs').readFileSync,
+            readfile: options.readfile,
             basedir: options.basedir,
             libdir: options.libdir,
             module_id: key,


### PR DESCRIPTION
The `readfile` option default value should be move upstream.
The linter is currently broken because of that bug.