### PR TITLE
fix  In-browser-compilation

### DIFF
--- a/src/rapydscript.pyj
+++ b/src/rapydscript.pyj
@@ -97,7 +97,7 @@ exports.compile = compile = def(code, options):
     }))
 
     # account for unused baselib methods
-    if not options.omit_baselib:
+    if not options.omit_baselib and not browser_env:
         if not toplevel.baselib['AssertionError']:
             toplevel.baselib['extends'] -= 1
         if not toplevel.baselib['IndexError']:


### PR DESCRIPTION
In-browser-compilation  the embedded baselib string is used instead of parsing a file, so `toplevel.baselib['...']>0` if only it is used in user code