### PR TITLE
add import with

### DIFF
--- a/src/parser.pyj
+++ b/src/parser.pyj
@@ -814,6 +814,7 @@ def parse($TEXT, options):
 
     def import_(from_import):
         ans = ast.Imports({'imports':[]})
+        imp_with = None
         while True:
             package_pref = ''
             # allow import submodules into __init__.pyj
@@ -844,7 +845,16 @@ def parse($TEXT, options):
                 })
             alias = None
             if not from_import:
-                if is_('keyword', 'as'):
+                if imp_with is None:
+                    if  is_('keyword', 'with'):
+                        imp_with = key
+                        next()
+                        continue
+                    else:
+                        imp_with = ''
+                if imp_with:
+                    key = imp_with + '.' + key
+                elif is_('keyword', 'as'):
                     next()
                     alias = as_symbol(ast.SymbolAlias)
                 # assume `import .module` is shortcut for `import package.module as module`       

--- a/test/basic/imports_with.pyj
+++ b/test/basic/imports_with.pyj
@@ -1,0 +1,10 @@
+console.log('imports_with.pyj .......')
+import import_two with  sub, subpack.nested_mod 
+
+
+assert.equal(import_two.subpack.nested_mod.NESTED_MOD_VAR, 'nested_var')
+assert.equal(new import_two.subpack.Foo().name, 'nested_foo')
+assert.equal('sub', import_two.sub.sub_var)
+
+console.log('ok!\n')
+


### PR DESCRIPTION
`import pack with module1,  module2, subpack.nested_module`
is a shortcut for 
`import pack.module1, pack.module2, pack.subpack.nested_module`