### PR TITLE
allow es6 hash short notatation

### DIFF
--- a/src/parser.pyj
+++ b/src/parser.pyj
@@ -1822,22 +1822,14 @@ def parse($TEXT, options):
                 if not options.es6:
                     croak("Spread operator in object literals is only allowed in ES6 mode")
                 a.push(maybe_unary(True))
-<<<<<<< HEAD
                 first = False
                 continue
-=======
->>>>>>> origin/master
             else:
                 ctx = S.input.context()
                 orig = ctx.expect_object_literal_key
                 ctx.expect_object_literal_key = True
-<<<<<<< HEAD
                 if first and not (peek().value in [':', ',']):
                     # possibly dict comprehension
-=======
-                if first and peek().value is not ':':
-                # possibly dict comprehension
->>>>>>> origin/master
                     maybe_dict_comprehension = True
                     key = expression(False)
                     name = None
@@ -1849,10 +1841,6 @@ def parse($TEXT, options):
                         expect('(')
                         key = expression(False)
                         expect(')')
-<<<<<<< HEAD
-=======
-                        computed = True
->>>>>>> origin/master
                     else:
                         # regular key
                         key_ = as_property_name()
@@ -1893,7 +1881,6 @@ def parse($TEXT, options):
                 value = key
             else:
                 expect(":")
-<<<<<<< HEAD
                 value = expression(False)
 
             a.push(ast.ObjectKeyVal({
@@ -1902,14 +1889,6 @@ def parse($TEXT, options):
                 value: value,
                 end: prev()
             }))
-=======
-                a.push(ast.ObjectKeyVal({
-                    start: start,
-                    key: key,
-                    value: expression(False),
-                    end: prev()
-                }))
->>>>>>> origin/master
 
             if first and is_('keyword', 'for'):
                 return read_comprehension(ast.DictComprehension({

--- a/src/parser.pyj
+++ b/src/parser.pyj
@@ -1817,20 +1817,27 @@ def parse($TEXT, options):
 
             start = S.token
             type = start.type
-            computed = False
-            saw_starargs = False
             if is_("operator", "*"):
                 # spread operator
-                saw_starargs = True
                 if not options.es6:
                     croak("Spread operator in object literals is only allowed in ES6 mode")
                 a.push(maybe_unary(True))
+<<<<<<< HEAD
+                first = False
+                continue
+=======
+>>>>>>> origin/master
             else:
                 ctx = S.input.context()
                 orig = ctx.expect_object_literal_key
                 ctx.expect_object_literal_key = True
+<<<<<<< HEAD
+                if first and not (peek().value in [':', ',']):
+                    # possibly dict comprehension
+=======
                 if first and peek().value is not ':':
                 # possibly dict comprehension
+>>>>>>> origin/master
                     maybe_dict_comprehension = True
                     key = expression(False)
                     name = None
@@ -1842,7 +1849,10 @@ def parse($TEXT, options):
                         expect('(')
                         key = expression(False)
                         expect(')')
+<<<<<<< HEAD
+=======
                         computed = True
+>>>>>>> origin/master
                     else:
                         # regular key
                         key_ = as_property_name()
@@ -1874,24 +1884,41 @@ def parse($TEXT, options):
                             })
                 ctx.expect_object_literal_key = orig
 
-                if type is "name" and not is_("punc", ":"):
-                    a.push(accessor_(name, start, False))
-                    continue
+                #if type is "name" and not is_("punc", ":"):
+                #    a.push(accessor_(name, start, False))
+                #    continue
 
-            if not saw_starargs:
+            if is_('punc', ',') and isinstance(key, ast.Identifier):
+                # es6 short notation
+                value = key
+            else:
                 expect(":")
+<<<<<<< HEAD
+                value = expression(False)
+
+            a.push(ast.ObjectKeyVal({
+                start: start,
+                key: key,
+                value: value,
+                end: prev()
+            }))
+=======
                 a.push(ast.ObjectKeyVal({
                     start: start,
                     key: key,
                     value: expression(False),
                     end: prev()
                 }))
+>>>>>>> origin/master
 
-                if a.length is 1 and is_('keyword', 'for'):
-                    return read_comprehension(ast.DictComprehension({
-                        statement: maybe_dict_comprehension ? key : as_atom_node(a[0].start),
-                        value_statement: a[0].value
-                    }))
+            if first and is_('keyword', 'for'):
+                return read_comprehension(ast.DictComprehension({
+                    statement: maybe_dict_comprehension ? key : as_atom_node(a[0].start),
+                    value_statement: a[0].value
+                }))
+                maybe_dict_comprehension = False
+            elif maybe_dict_comprehension:
+                unexpected()
 
             first = False
 

--- a/test/basic/features_es6.pyj
+++ b/test/basic/features_es6.pyj
@@ -153,4 +153,11 @@ assert.equal(tmp.next({prop: 'blah'}).value, 'blah-blah-blah')
 assert.equal(tmp.next().value, 5)
 assert.equal(tmp.next(10).value, 12)
 
+# es6 hash short notation
+key_val = 'val'
+es6_hash = {a:'av', key_val, b:'bv'}
+assert.equal(es6_hash['key_val'], 'val')
+
+es6_hash = { key_val, b:'bv'}
+assert.equal(es6_hash['key_val'], 'val')
 


### PR DESCRIPTION
now, it is allowed `{foo, bar}` that will be unpacked to `{foo:foo, bar:bar}`
