### PR TITLE
Mechanic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ node_js:
     - 10
     - 11
 
-before_script: "npm run-script build-self"
+before_script:
+    "npm run-script build-self"
 
-script: "npm run-script test && npm run-script test6"
+script:
+    "npm run-script test && npm run-script test6"

--- a/lib/baselib.js
+++ b/lib/baselib.js
@@ -43,15 +43,16 @@ function ՐՏ_bind(fn, thisArg) {
     return ret;
 }
 function ՐՏ_rebindAll(thisArg, rebind) {
+    var ՐՏ_45, ՐՏ_46, ՐՏ_47, ՐՏ_48, ՐՏ_49, ՐՏ_50;
     if (rebind === void 0) {
         rebind = true;
     }
     for (var p in thisArg) {
-        if (thisArg[p] && thisArg[p].orig) {
+        if ((ՐՏ_45 = thisArg)[p] && (ՐՏ_46 = thisArg)[p].orig) {
             if (rebind) {
-                thisArg[p] = ՐՏ_bind(thisArg[p], thisArg);
+                (ՐՏ_47 = thisArg)[p] = ՐՏ_bind((ՐՏ_48 = thisArg)[p], thisArg);
             } else {
-                thisArg[p] = thisArg[p].orig;
+                (ՐՏ_49 = thisArg)[p] = (ՐՏ_50 = thisArg)[p].orig;
             }
         }
     }
@@ -59,6 +60,50 @@ function ՐՏ_rebindAll(thisArg, rebind) {
 function ՐՏ_with__name__(fn, name) {
     fn.__name__ = name;
     return fn;
+}
+function ՐՏ_def_modules() {
+    var modules;
+    modules = {};
+    function mounter(mod_id) {
+        var ՐՏ_51, ՐՏ_52;
+        var rs_mod_id, rs_mod;
+        rs_mod_id = "ՐՏ:" + mod_id;
+        rs_mod = (ՐՏ_51 = modules)[rs_mod_id] = {
+            "body": null,
+            "exports": null
+        };
+        (ՐՏ_52 = rs_mod)["export"] = function(prop, get, set) {
+            var ՐՏ_53, ՐՏ_54, ՐՏ_55;
+            if (!(ՐՏ_53 = rs_mod)["exports"]) {
+                (ՐՏ_54 = rs_mod)["exports"] = {};
+            }
+            Object.defineProperty((ՐՏ_55 = rs_mod)["exports"], prop, {
+                configurable: true,
+                enumerable: true,
+                get: get,
+                set: set
+            });
+        };
+        Object.defineProperty(modules, mod_id, {
+            enumerable: true,
+            get: function() {
+                var ՐՏ_56, ՐՏ_57, ՐՏ_58;
+                var mod;
+                return (ՐՏ_56 = (mod = (ՐՏ_57 = modules)[rs_mod_id]))["exports"] || (ՐՏ_58 = mod)["body"]();
+            },
+            set: function(v) {
+                var ՐՏ_59, ՐՏ_60;
+                (ՐՏ_59 = (ՐՏ_60 = modules)[rs_mod_id])["exports"] = v;
+            }
+        });
+        return rs_mod;
+    }
+    Object.defineProperty(modules, "ՐՏ_def", {
+        configurable: false,
+        enumerable: false,
+        value: mounter
+    });
+    return modules;
 }
 function cmp(a, b) {
     return a < b ? -1 : a > b ? 1 : 0;
@@ -73,11 +118,12 @@ function dir(item) {
     return arr;
 }
 function enumerate(item) {
+    var ՐՏ_61, ՐՏ_62;
     var arr, iter, i;
     arr = [];
     iter = ՐՏ_Iterable(item);
     for (i = 0; i < iter.length; i++) {
-        arr[arr.length] = [ i, item[i] ];
+        (ՐՏ_61 = arr)[arr.length] = [ i, (ՐՏ_62 = item)[i] ];
     }
     return arr;
 }
@@ -158,11 +204,11 @@ function min(a) {
     return Math.min.apply(null, Array.isArray(a) ? a : arguments);
 }
 function ՐՏ_merge(target, source, overwrite) {
-    var ՐՏitr10, ՐՏidx10;
+    var ՐՏ_63, ՐՏ_64, ՐՏitr10, ՐՏidx10;
     var prop;
     for (var i in source) {
         if (source.hasOwnProperty(i) && (overwrite || typeof target[i] === "undefined")) {
-            target[i] = source[i];
+            (ՐՏ_63 = target)[i] = (ՐՏ_64 = source)[i];
         }
     }
     ՐՏitr10 = ՐՏ_Iterable(Object.getOwnPropertyNames(source.prototype));
@@ -198,17 +244,18 @@ function ՐՏ_print() {
     }
 }
 function range(start, stop, step) {
+    var ՐՏ_65, ՐՏ_66;
     var length, idx, range;
     if (arguments.length <= 1) {
         stop = start || 0;
         start = 0;
     }
-    step = arguments[2] || 1;
+    step = (ՐՏ_65 = arguments)[2] || 1;
     length = Math.max(Math.ceil((stop - start) / step), 0);
     idx = 0;
     range = new Array(length);
     while (idx < length) {
-        range[idx++] = start;
+        (ՐՏ_66 = range)[idx++] = start;
         start += step;
     }
     return range;
@@ -236,27 +283,30 @@ function ՐՏ_type(obj) {
     return obj && obj.constructor && obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1);
 }
 function zip(a, b) {
+    var ՐՏ_67, ՐՏ_68;
     var i;
     return (function() {
         var ՐՏidx13, ՐՏitr13 = ՐՏ_Iterable(range(Math.min(a.length, b.length))), ՐՏres = [], i;
         for (ՐՏidx13 = 0; ՐՏidx13 < ՐՏitr13.length; ՐՏidx13++) {
             i = ՐՏitr13[ՐՏidx13];
-            ՐՏres.push([ a[i], b[i] ]);
+            ՐՏres.push([ (ՐՏ_67 = a)[i], (ՐՏ_68 = b)[i] ]);
         }
         return ՐՏres;
     })();
 }
 function getattr(obj, name) {
-    return obj[name];
+    var ՐՏ_69;
+    return (ՐՏ_69 = obj)[name];
 }
 function setattr(obj, name, value) {
-    obj[name] = value;
+    var ՐՏ_70;
+    (ՐՏ_70 = obj)[name] = value;
 }
 function hasattr(obj, name) {
     return name in obj;
 }
 function ՐՏ_eq(a, b) {
-    var ՐՏitr14, ՐՏidx14;
+    var ՐՏ_71, ՐՏ_72, ՐՏitr14, ՐՏidx14, ՐՏ_73, ՐՏ_74;
     var i;
     if (a === b) {
         return true;
@@ -272,7 +322,7 @@ function ՐՏ_eq(a, b) {
             return false;
         }
         for (i = 0; i < a.length; i++) {
-            if (!ՐՏ_eq(a[i], b[i])) {
+            if (!ՐՏ_eq((ՐՏ_71 = a)[i], (ՐՏ_72 = b)[i])) {
                 return false;
             }
         }
@@ -284,7 +334,7 @@ function ՐՏ_eq(a, b) {
         ՐՏitr14 = ՐՏ_Iterable(a);
         for (ՐՏidx14 = 0; ՐՏidx14 < ՐՏitr14.length; ՐՏidx14++) {
             i = ՐՏitr14[ՐՏidx14];
-            if (!ՐՏ_eq(a[i], b[i])) {
+            if (!ՐՏ_eq((ՐՏ_73 = a)[i], (ՐՏ_74 = b)[i])) {
                 return false;
             }
         }
@@ -307,23 +357,25 @@ function ՐՏ_eq(a, b) {
     return false;
 }
 function kwargs(f) {
+    var ՐՏ_75, ՐՏ_76, ՐՏ_77, ՐՏ_78;
     var argNames;
-    argNames = f.toString().match(/\(([^\)]+)/)[1];
-    if (!kwargs.memo[argNames]) {
-        kwargs.memo[argNames] = argNames ? argNames.split(",").map(function(s) {
+    argNames = (ՐՏ_75 = f.toString().match(/\(([^\)]+)/))[1];
+    if (!(ՐՏ_76 = kwargs.memo)[argNames]) {
+        (ՐՏ_77 = kwargs.memo)[argNames] = argNames ? argNames.split(",").map(function(s) {
             return s.trim();
         }) : [];
     }
-    argNames = kwargs.memo[argNames];
+    argNames = (ՐՏ_78 = kwargs.memo)[argNames];
     return function() {
+        var ՐՏ_79, ՐՏ_80, ՐՏ_81, ՐՏ_82, ՐՏ_83;
         var args, kw, i;
         args = [].slice.call(arguments);
         if (args.length) {
-            kw = args[args.length-1];
+            kw = (ՐՏ_79 = args)[ՐՏ_79.length-1];
             if (typeof kw === "object") {
                 for (i = 0; i < argNames.length; i++) {
-                    if (ՐՏ_in(argNames[i], kw)) {
-                        args[i] = kw[argNames[i]];
+                    if (ՐՏ_in((ՐՏ_80 = argNames)[i], kw)) {
+                        (ՐՏ_81 = args)[i] = (ՐՏ_82 = kw)[(ՐՏ_83 = argNames)[i]];
                     }
                 }
             } else {
@@ -342,9 +394,9 @@ function kwargs(f) {
     };
 }
 kwargs.memo = {};
-var AssertionError = (ՐՏ_6 = function AssertionError() {
+var AssertionError = (ՐՏ_84 = function AssertionError() {
     AssertionError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_6, Error), Object.defineProperties(ՐՏ_6.prototype, {
+}, ՐՏ_extends(ՐՏ_84, Error), Object.defineProperties(ՐՏ_84.prototype, {
     __init__: {
         enumerable: true, 
         writable: true, 
@@ -355,10 +407,10 @@ var AssertionError = (ՐՏ_6 = function AssertionError() {
         }
 
     }
-}), ՐՏ_6);
-var IndexError = (ՐՏ_7 = function IndexError() {
+}), ՐՏ_84);
+var IndexError = (ՐՏ_85 = function IndexError() {
     IndexError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_7, Error), Object.defineProperties(ՐՏ_7.prototype, {
+}, ՐՏ_extends(ՐՏ_85, Error), Object.defineProperties(ՐՏ_85.prototype, {
     __init__: {
         enumerable: true, 
         writable: true, 
@@ -369,10 +421,10 @@ var IndexError = (ՐՏ_7 = function IndexError() {
         }
 
     }
-}), ՐՏ_7);
-var KeyError = (ՐՏ_8 = function KeyError() {
+}), ՐՏ_85);
+var KeyError = (ՐՏ_86 = function KeyError() {
     KeyError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_8, Error), Object.defineProperties(ՐՏ_8.prototype, {
+}, ՐՏ_extends(ՐՏ_86, Error), Object.defineProperties(ՐՏ_86.prototype, {
     __init__: {
         enumerable: true, 
         writable: true, 
@@ -383,10 +435,10 @@ var KeyError = (ՐՏ_8 = function KeyError() {
         }
 
     }
-}), ՐՏ_8);
-var TypeError = (ՐՏ_9 = function TypeError() {
+}), ՐՏ_86);
+var TypeError = (ՐՏ_87 = function TypeError() {
     TypeError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_9, Error), Object.defineProperties(ՐՏ_9.prototype, {
+}, ՐՏ_extends(ՐՏ_87, Error), Object.defineProperties(ՐՏ_87.prototype, {
     __init__: {
         enumerable: true, 
         writable: true, 
@@ -397,10 +449,10 @@ var TypeError = (ՐՏ_9 = function TypeError() {
         }
 
     }
-}), ՐՏ_9);
-var ValueError = (ՐՏ_10 = function ValueError() {
+}), ՐՏ_87);
+var ValueError = (ՐՏ_88 = function ValueError() {
     ValueError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_10, Error), Object.defineProperties(ՐՏ_10.prototype, {
+}, ՐՏ_extends(ՐՏ_88, Error), Object.defineProperties(ՐՏ_88.prototype, {
     __init__: {
         enumerable: true, 
         writable: true, 
@@ -411,7 +463,7 @@ var ValueError = (ՐՏ_10 = function ValueError() {
         }
 
     }
-}), ՐՏ_10);
+}), ՐՏ_88);
 ({
     "abs": function abs(n) {
         return Math.abs(n);
@@ -458,15 +510,16 @@ var ValueError = (ՐՏ_10 = function ValueError() {
         return ret;
     },
     "rebind_all": function ՐՏ_rebindAll(thisArg, rebind) {
+        var ՐՏ_1, ՐՏ_2, ՐՏ_3, ՐՏ_4, ՐՏ_5, ՐՏ_6;
         if (rebind === void 0) {
             rebind = true;
         }
         for (var p in thisArg) {
-            if (thisArg[p] && thisArg[p].orig) {
+            if ((ՐՏ_1 = thisArg)[p] && (ՐՏ_2 = thisArg)[p].orig) {
                 if (rebind) {
-                    thisArg[p] = ՐՏ_bind(thisArg[p], thisArg);
+                    (ՐՏ_3 = thisArg)[p] = ՐՏ_bind((ՐՏ_4 = thisArg)[p], thisArg);
                 } else {
-                    thisArg[p] = thisArg[p].orig;
+                    (ՐՏ_5 = thisArg)[p] = (ՐՏ_6 = thisArg)[p].orig;
                 }
             }
         }
@@ -474,6 +527,50 @@ var ValueError = (ՐՏ_10 = function ValueError() {
     "with__name__": function ՐՏ_with__name__(fn, name) {
         fn.__name__ = name;
         return fn;
+    },
+    "def_modules": function ՐՏ_def_modules() {
+        var modules;
+        modules = {};
+        function mounter(mod_id) {
+            var ՐՏ_7, ՐՏ_8;
+            var rs_mod_id, rs_mod;
+            rs_mod_id = "ՐՏ:" + mod_id;
+            rs_mod = (ՐՏ_7 = modules)[rs_mod_id] = {
+                "body": null,
+                "exports": null
+            };
+            (ՐՏ_8 = rs_mod)["export"] = function(prop, get, set) {
+                var ՐՏ_9, ՐՏ_10, ՐՏ_11;
+                if (!(ՐՏ_9 = rs_mod)["exports"]) {
+                    (ՐՏ_10 = rs_mod)["exports"] = {};
+                }
+                Object.defineProperty((ՐՏ_11 = rs_mod)["exports"], prop, {
+                    configurable: true,
+                    enumerable: true,
+                    get: get,
+                    set: set
+                });
+            };
+            Object.defineProperty(modules, mod_id, {
+                enumerable: true,
+                get: function() {
+                    var ՐՏ_12, ՐՏ_13, ՐՏ_14;
+                    var mod;
+                    return (ՐՏ_12 = (mod = (ՐՏ_13 = modules)[rs_mod_id]))["exports"] || (ՐՏ_14 = mod)["body"]();
+                },
+                set: function(v) {
+                    var ՐՏ_15, ՐՏ_16;
+                    (ՐՏ_15 = (ՐՏ_16 = modules)[rs_mod_id])["exports"] = v;
+                }
+            });
+            return rs_mod;
+        }
+        Object.defineProperty(modules, "ՐՏ_def", {
+            configurable: false,
+            enumerable: false,
+            value: mounter
+        });
+        return modules;
     },
     "cmp": function cmp(a, b) {
         return a < b ? -1 : a > b ? 1 : 0;
@@ -490,11 +587,12 @@ var ValueError = (ՐՏ_10 = function ValueError() {
         return arr;
     },
     "enumerate": function enumerate(item) {
+        var ՐՏ_17, ՐՏ_18;
         var arr, iter, i;
         arr = [];
         iter = ՐՏ_Iterable(item);
         for (i = 0; i < iter.length; i++) {
-            arr[arr.length] = [ i, item[i] ];
+            (ՐՏ_17 = arr)[arr.length] = [ i, (ՐՏ_18 = item)[i] ];
         }
         return arr;
     },
@@ -575,11 +673,11 @@ var ValueError = (ՐՏ_10 = function ValueError() {
         return Math.min.apply(null, Array.isArray(a) ? a : arguments);
     },
     "merge": function ՐՏ_merge(target, source, overwrite) {
-        var ՐՏitr3, ՐՏidx3;
+        var ՐՏ_19, ՐՏ_20, ՐՏitr3, ՐՏidx3;
         var prop;
         for (var i in source) {
             if (source.hasOwnProperty(i) && (overwrite || typeof target[i] === "undefined")) {
-                target[i] = source[i];
+                (ՐՏ_19 = target)[i] = (ՐՏ_20 = source)[i];
             }
         }
         ՐՏitr3 = ՐՏ_Iterable(Object.getOwnPropertyNames(source.prototype));
@@ -615,17 +713,18 @@ var ValueError = (ՐՏ_10 = function ValueError() {
         }
     },
     "range": function range(start, stop, step) {
+        var ՐՏ_21, ՐՏ_22;
         var length, idx, range;
         if (arguments.length <= 1) {
             stop = start || 0;
             start = 0;
         }
-        step = arguments[2] || 1;
+        step = (ՐՏ_21 = arguments)[2] || 1;
         length = Math.max(Math.ceil((stop - start) / step), 0);
         idx = 0;
         range = new Array(length);
         while (idx < length) {
-            range[idx++] = start;
+            (ՐՏ_22 = range)[idx++] = start;
             start += step;
         }
         return range;
@@ -653,27 +752,30 @@ var ValueError = (ՐՏ_10 = function ValueError() {
         return obj && obj.constructor && obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1);
     },
     "zip": function zip(a, b) {
+        var ՐՏ_23, ՐՏ_24;
         var i;
         return (function() {
             var ՐՏidx6, ՐՏitr6 = ՐՏ_Iterable(range(Math.min(a.length, b.length))), ՐՏres = [], i;
             for (ՐՏidx6 = 0; ՐՏidx6 < ՐՏitr6.length; ՐՏidx6++) {
                 i = ՐՏitr6[ՐՏidx6];
-                ՐՏres.push([ a[i], b[i] ]);
+                ՐՏres.push([ (ՐՏ_23 = a)[i], (ՐՏ_24 = b)[i] ]);
             }
             return ՐՏres;
         })();
     },
     "getattr": function getattr(obj, name) {
-        return obj[name];
+        var ՐՏ_25;
+        return (ՐՏ_25 = obj)[name];
     },
     "setattr": function setattr(obj, name, value) {
-        obj[name] = value;
+        var ՐՏ_26;
+        (ՐՏ_26 = obj)[name] = value;
     },
     "hasattr": function hasattr(obj, name) {
         return name in obj;
     },
     "eq": function ՐՏ_eq(a, b) {
-        var ՐՏitr7, ՐՏidx7;
+        var ՐՏ_27, ՐՏ_28, ՐՏitr7, ՐՏidx7, ՐՏ_29, ՐՏ_30;
         var i;
         if (a === b) {
             return true;
@@ -689,7 +791,7 @@ var ValueError = (ՐՏ_10 = function ValueError() {
                 return false;
             }
             for (i = 0; i < a.length; i++) {
-                if (!ՐՏ_eq(a[i], b[i])) {
+                if (!ՐՏ_eq((ՐՏ_27 = a)[i], (ՐՏ_28 = b)[i])) {
                     return false;
                 }
             }
@@ -701,7 +803,7 @@ var ValueError = (ՐՏ_10 = function ValueError() {
             ՐՏitr7 = ՐՏ_Iterable(a);
             for (ՐՏidx7 = 0; ՐՏidx7 < ՐՏitr7.length; ՐՏidx7++) {
                 i = ՐՏitr7[ՐՏidx7];
-                if (!ՐՏ_eq(a[i], b[i])) {
+                if (!ՐՏ_eq((ՐՏ_29 = a)[i], (ՐՏ_30 = b)[i])) {
                     return false;
                 }
             }
@@ -725,23 +827,25 @@ var ValueError = (ՐՏ_10 = function ValueError() {
     },
     "kwargs": function() {
         function kwargs(f) {
+            var ՐՏ_31, ՐՏ_32, ՐՏ_33, ՐՏ_34;
             var argNames;
-            argNames = f.toString().match(/\(([^\)]+)/)[1];
-            if (!kwargs.memo[argNames]) {
-                kwargs.memo[argNames] = argNames ? argNames.split(",").map(function(s) {
+            argNames = (ՐՏ_31 = f.toString().match(/\(([^\)]+)/))[1];
+            if (!(ՐՏ_32 = kwargs.memo)[argNames]) {
+                (ՐՏ_33 = kwargs.memo)[argNames] = argNames ? argNames.split(",").map(function(s) {
                     return s.trim();
                 }) : [];
             }
-            argNames = kwargs.memo[argNames];
+            argNames = (ՐՏ_34 = kwargs.memo)[argNames];
             return function() {
+                var ՐՏ_35, ՐՏ_36, ՐՏ_37, ՐՏ_38, ՐՏ_39;
                 var args, kw, i;
                 args = [].slice.call(arguments);
                 if (args.length) {
-                    kw = args[args.length-1];
+                    kw = (ՐՏ_35 = args)[ՐՏ_35.length-1];
                     if (typeof kw === "object") {
                         for (i = 0; i < argNames.length; i++) {
-                            if (ՐՏ_in(argNames[i], kw)) {
-                                args[i] = kw[argNames[i]];
+                            if (ՐՏ_in((ՐՏ_36 = argNames)[i], kw)) {
+                                (ՐՏ_37 = args)[i] = (ՐՏ_38 = kw)[(ՐՏ_39 = argNames)[i]];
                             }
                         }
                     } else {
@@ -762,10 +866,10 @@ var ValueError = (ՐՏ_10 = function ValueError() {
         kwargs.memo = {};
     },
     "AssertionError": function() {
-        var ՐՏ_1;
-        var AssertionError = (ՐՏ_1 = function AssertionError() {
+        var ՐՏ_40;
+        var AssertionError = (ՐՏ_40 = function AssertionError() {
             AssertionError.prototype.__init__.apply(this, arguments);
-        }, ՐՏ_extends(ՐՏ_1, Error), Object.defineProperties(ՐՏ_1.prototype, {
+        }, ՐՏ_extends(ՐՏ_40, Error), Object.defineProperties(ՐՏ_40.prototype, {
             __init__: {
                 enumerable: true, 
                 writable: true, 
@@ -776,13 +880,13 @@ var ValueError = (ՐՏ_10 = function ValueError() {
                 }
 
             }
-        }), ՐՏ_1);
+        }), ՐՏ_40);
     },
     "IndexError": function() {
-        var ՐՏ_2;
-        var IndexError = (ՐՏ_2 = function IndexError() {
+        var ՐՏ_41;
+        var IndexError = (ՐՏ_41 = function IndexError() {
             IndexError.prototype.__init__.apply(this, arguments);
-        }, ՐՏ_extends(ՐՏ_2, Error), Object.defineProperties(ՐՏ_2.prototype, {
+        }, ՐՏ_extends(ՐՏ_41, Error), Object.defineProperties(ՐՏ_41.prototype, {
             __init__: {
                 enumerable: true, 
                 writable: true, 
@@ -793,13 +897,13 @@ var ValueError = (ՐՏ_10 = function ValueError() {
                 }
 
             }
-        }), ՐՏ_2);
+        }), ՐՏ_41);
     },
     "KeyError": function() {
-        var ՐՏ_3;
-        var KeyError = (ՐՏ_3 = function KeyError() {
+        var ՐՏ_42;
+        var KeyError = (ՐՏ_42 = function KeyError() {
             KeyError.prototype.__init__.apply(this, arguments);
-        }, ՐՏ_extends(ՐՏ_3, Error), Object.defineProperties(ՐՏ_3.prototype, {
+        }, ՐՏ_extends(ՐՏ_42, Error), Object.defineProperties(ՐՏ_42.prototype, {
             __init__: {
                 enumerable: true, 
                 writable: true, 
@@ -810,13 +914,13 @@ var ValueError = (ՐՏ_10 = function ValueError() {
                 }
 
             }
-        }), ՐՏ_3);
+        }), ՐՏ_42);
     },
     "TypeError": function() {
-        var ՐՏ_4;
-        var TypeError = (ՐՏ_4 = function TypeError() {
+        var ՐՏ_43;
+        var TypeError = (ՐՏ_43 = function TypeError() {
             TypeError.prototype.__init__.apply(this, arguments);
-        }, ՐՏ_extends(ՐՏ_4, Error), Object.defineProperties(ՐՏ_4.prototype, {
+        }, ՐՏ_extends(ՐՏ_43, Error), Object.defineProperties(ՐՏ_43.prototype, {
             __init__: {
                 enumerable: true, 
                 writable: true, 
@@ -827,13 +931,13 @@ var ValueError = (ՐՏ_10 = function ValueError() {
                 }
 
             }
-        }), ՐՏ_4);
+        }), ՐՏ_43);
     },
     "ValueError": function() {
-        var ՐՏ_5;
-        var ValueError = (ՐՏ_5 = function ValueError() {
+        var ՐՏ_44;
+        var ValueError = (ՐՏ_44 = function ValueError() {
             ValueError.prototype.__init__.apply(this, arguments);
-        }, ՐՏ_extends(ՐՏ_5, Error), Object.defineProperties(ՐՏ_5.prototype, {
+        }, ՐՏ_extends(ՐՏ_44, Error), Object.defineProperties(ՐՏ_44.prototype, {
             __init__: {
                 enumerable: true, 
                 writable: true, 
@@ -844,6 +948,6 @@ var ValueError = (ՐՏ_10 = function ValueError() {
                 }
 
             }
-        }), ՐՏ_5);
+        }), ՐՏ_44);
     }
-});var ՐՏ_6, ՐՏ_7, ՐՏ_8, ՐՏ_9, ՐՏ_10;
+});var ՐՏ_84, ՐՏ_85, ՐՏ_86, ՐՏ_87, ՐՏ_88;

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,69 +1,3 @@
-function abs(n) {
-    return Math.abs(n);
-}
-function all(a) {
-    var ՐՏitr1, ՐՏidx1;
-    var e;
-    ՐՏitr1 = ՐՏ_Iterable(a);
-    for (ՐՏidx1 = 0; ՐՏidx1 < ՐՏitr1.length; ՐՏidx1++) {
-        e = ՐՏitr1[ՐՏidx1];
-        if (!e) {
-            return false;
-        }
-    }
-    return true;
-}
-function any(a) {
-    var ՐՏitr2, ՐՏidx2;
-    var e;
-    ՐՏitr2 = ՐՏ_Iterable(a);
-    for (ՐՏidx2 = 0; ՐՏidx2 < ՐՏitr2.length; ՐՏidx2++) {
-        e = ՐՏitr2[ՐՏidx2];
-        if (e) {
-            return true;
-        }
-    }
-    return false;
-}
-function bin(a) {
-    return "0b" + (a >>> 0).toString(2);
-}
-function ՐՏ_bind(fn, thisArg) {
-    var ret;
-    if (fn.orig) {
-        fn = fn.orig;
-    }
-    if (thisArg === false) {
-        return fn;
-    }
-    ret = function() {
-        return fn.apply(thisArg, arguments);
-    };
-    ret.orig = fn;
-    return ret;
-}
-function ՐՏ_rebindAll(thisArg, rebind) {
-    if (rebind === void 0) {
-        rebind = true;
-    }
-    for (var p in thisArg) {
-        if (thisArg[p] && thisArg[p].orig) {
-            if (rebind) {
-                thisArg[p] = ՐՏ_bind(thisArg[p], thisArg);
-            } else {
-                thisArg[p] = thisArg[p].orig;
-            }
-        }
-    }
-}
-function ՐՏ_with__name__(fn, name) {
-    fn.__name__ = name;
-    return fn;
-}
-function cmp(a, b) {
-    return a < b ? -1 : a > b ? 1 : 0;
-}
-var chr = String.fromCharCode;
 function dir(item) {
     var arr;
     arr = [];
@@ -71,62 +5,6 @@ function dir(item) {
         arr.push(i);
     }
     return arr;
-}
-function enumerate(item) {
-    var arr, iter, i;
-    arr = [];
-    iter = ՐՏ_Iterable(item);
-    for (i = 0; i < iter.length; i++) {
-        arr[arr.length] = [ i, item[i] ];
-    }
-    return arr;
-}
-function ՐՏ_eslice(arr, step, start, end) {
-    var isString;
-    arr = arr.slice(0);
-    if (typeof arr === "string" || arr instanceof String) {
-        isString = true;
-        arr = arr.split("");
-    }
-    if (step < 0) {
-        step = -step;
-        arr.reverse();
-        if (typeof start !== "undefined") {
-            start = arr.length - start - 1;
-        }
-        if (typeof end !== "undefined") {
-            end = arr.length - end - 1;
-        }
-    }
-    if (typeof start === "undefined") {
-        start = 0;
-    }
-    if (typeof end === "undefined") {
-        end = arr.length;
-    }
-    arr = arr.slice(start, end).filter(function(e, i) {
-        return i % step === 0;
-    });
-    return isString ? arr.join("") : arr;
-}
-function ՐՏ_extends(child, parent) {
-    child.prototype = Object.create(parent.prototype);
-    child.prototype.__base__ = parent;
-    child.prototype.constructor = child;
-}
-function filter(oper, arr) {
-    return arr.filter(oper);
-}
-function hex(a) {
-    return "0x" + (a >>> 0).toString(16);
-}
-function ՐՏ_in(val, arr) {
-    if (typeof arr.indexOf === "function") {
-        return arr.indexOf(val) !== -1;
-    } else if (typeof arr.has === "function") {
-        return arr.has(val);
-    }
-    return arr.hasOwnProperty(val);
 }
 function ՐՏ_Iterable(iterable) {
     var tmp;
@@ -138,125 +16,25 @@ function ՐՏ_Iterable(iterable) {
     }
     return Object.keys(iterable);
 }
-function len(obj) {
-    var tmp;
-    if (obj.constructor === [].constructor || obj.constructor === "".constructor || (tmp = Array.prototype.slice.call(obj)).length) {
-        return (tmp || obj).length;
-    }
-    if (Set && obj.constructor === Set) {
-        return obj.size;
-    }
-    return Object.keys(obj).length;
-}
-function map(oper, arr) {
-    return arr.map(oper);
-}
-function max(a) {
-    return Math.max.apply(null, Array.isArray(a) ? a : arguments);
-}
-function min(a) {
-    return Math.min.apply(null, Array.isArray(a) ? a : arguments);
-}
-function ՐՏ_merge(target, source, overwrite) {
-    var ՐՏitr3, ՐՏidx3;
-    var prop;
-    for (var i in source) {
-        if (source.hasOwnProperty(i) && (overwrite || typeof target[i] === "undefined")) {
-            target[i] = source[i];
-        }
-    }
-    ՐՏitr3 = ՐՏ_Iterable(Object.getOwnPropertyNames(source.prototype));
-    for (ՐՏidx3 = 0; ՐՏidx3 < ՐՏitr3.length; ՐՏidx3++) {
-        prop = ՐՏitr3[ՐՏidx3];
-        if (overwrite || typeof target.prototype[prop] === "undefined") {
-            Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop));
-        }
-    }
-}
-function ՐՏ_mixin() {
-    var classes = [].slice.call(arguments, 0);
-    return function(baseClass) {
-        var ՐՏitr4, ՐՏidx4, ՐՏitr5, ՐՏidx5;
-        var cls, key;
-        ՐՏitr4 = ՐՏ_Iterable(classes);
-        for (ՐՏidx4 = 0; ՐՏidx4 < ՐՏitr4.length; ՐՏidx4++) {
-            cls = ՐՏitr4[ՐՏidx4];
-            ՐՏitr5 = ՐՏ_Iterable(Object.getOwnPropertyNames(cls.prototype));
-            for (ՐՏidx5 = 0; ՐՏidx5 < ՐՏitr5.length; ՐՏidx5++) {
-                key = ՐՏitr5[ՐՏidx5];
-                if (!(ՐՏ_in(key, baseClass.prototype))) {
-                    Object.defineProperty(baseClass.prototype, key, Object.getOwnPropertyDescriptor(cls.prototype, key));
-                }
-            }
-        }
-        return baseClass;
-    };
-}
-function ՐՏ_print() {
-    if (typeof console === "object") {
-        console.log.apply(console, arguments);
-    }
-}
 function range(start, stop, step) {
+    var ՐՏ_11, ՐՏ_12;
     var length, idx, range;
     if (arguments.length <= 1) {
         stop = start || 0;
         start = 0;
     }
-    step = arguments[2] || 1;
+    step = (ՐՏ_11 = arguments)[2] || 1;
     length = Math.max(Math.ceil((stop - start) / step), 0);
     idx = 0;
     range = new Array(length);
     while (idx < length) {
-        range[idx++] = start;
+        (ՐՏ_12 = range)[idx++] = start;
         start += step;
     }
     return range;
 }
-function reduce(f, a) {
-    return Array.prototype.reduce.call(a, f);
-}
-function reversed(arr) {
-    var tmp;
-    tmp = arr.slice(0);
-    return tmp.reverse();
-}
-function sorted(arr) {
-    var tmp;
-    tmp = arr.slice(0);
-    return tmp.sort();
-}
-function sum(arr, start) {
-    start = start === void 0 ? 0 : start;
-    return arr.reduce(function(prev, cur) {
-        return prev + cur;
-    }, start);
-}
-function ՐՏ_type(obj) {
-    return obj && obj.constructor && obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1);
-}
-function zip(a, b) {
-    var i;
-    return (function() {
-        var ՐՏidx6, ՐՏitr6 = ՐՏ_Iterable(range(Math.min(a.length, b.length))), ՐՏres = [], i;
-        for (ՐՏidx6 = 0; ՐՏidx6 < ՐՏitr6.length; ՐՏidx6++) {
-            i = ՐՏitr6[ՐՏidx6];
-            ՐՏres.push([ a[i], b[i] ]);
-        }
-        return ՐՏres;
-    })();
-}
-function getattr(obj, name) {
-    return obj[name];
-}
-function setattr(obj, name, value) {
-    obj[name] = value;
-}
-function hasattr(obj, name) {
-    return name in obj;
-}
 function ՐՏ_eq(a, b) {
-    var ՐՏitr7, ՐՏidx7;
+    var ՐՏ_13, ՐՏ_14, ՐՏitr1, ՐՏidx1, ՐՏ_15, ՐՏ_16;
     var i;
     if (a === b) {
         return true;
@@ -272,7 +50,7 @@ function ՐՏ_eq(a, b) {
             return false;
         }
         for (i = 0; i < a.length; i++) {
-            if (!ՐՏ_eq(a[i], b[i])) {
+            if (!ՐՏ_eq((ՐՏ_13 = a)[i], (ՐՏ_14 = b)[i])) {
                 return false;
             }
         }
@@ -281,10 +59,10 @@ function ՐՏ_eq(a, b) {
         if (Object.keys(a).length !== Object.keys(b).length) {
             return false;
         }
-        ՐՏitr7 = ՐՏ_Iterable(a);
-        for (ՐՏidx7 = 0; ՐՏidx7 < ՐՏitr7.length; ՐՏidx7++) {
-            i = ՐՏitr7[ՐՏidx7];
-            if (!ՐՏ_eq(a[i], b[i])) {
+        ՐՏitr1 = ՐՏ_Iterable(a);
+        for (ՐՏidx1 = 0; ՐՏidx1 < ՐՏitr1.length; ՐՏidx1++) {
+            i = ՐՏitr1[ՐՏidx1];
+            if (!ՐՏ_eq((ՐՏ_15 = a)[i], (ՐՏ_16 = b)[i])) {
                 return false;
             }
         }
@@ -306,112 +84,6 @@ function ՐՏ_eq(a, b) {
     }
     return false;
 }
-function kwargs(f) {
-    var argNames;
-    argNames = f.toString().match(/\(([^\)]+)/)[1];
-    if (!kwargs.memo[argNames]) {
-        kwargs.memo[argNames] = argNames ? argNames.split(",").map(function(s) {
-            return s.trim();
-        }) : [];
-    }
-    argNames = kwargs.memo[argNames];
-    return function() {
-        var args, kw, i;
-        args = [].slice.call(arguments);
-        if (args.length) {
-            kw = args[args.length-1];
-            if (typeof kw === "object") {
-                for (i = 0; i < argNames.length; i++) {
-                    if (ՐՏ_in(argNames[i], kw)) {
-                        args[i] = kw[argNames[i]];
-                    }
-                }
-            } else {
-                args.push(kw);
-            }
-        }
-        try {
-            return f.apply(this, args);
-        } catch (ՐՏ_Exception) {
-            var e = ՐՏ_Exception;
-            if (/Class constructor \w+ cannot be invoked without 'new'/.test(e)) {
-                return new f(args);
-            }
-            throw ՐՏ_Exception;
-        }
-    };
-}
-kwargs.memo = {};
-var AssertionError = (ՐՏ_1 = function AssertionError() {
-    AssertionError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_1, Error), Object.defineProperties(ՐՏ_1.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "AssertionError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_1);
-var IndexError = (ՐՏ_2 = function IndexError() {
-    IndexError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_2, Error), Object.defineProperties(ՐՏ_2.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "IndexError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_2);
-var KeyError = (ՐՏ_3 = function KeyError() {
-    KeyError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_3, Error), Object.defineProperties(ՐՏ_3.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "KeyError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_3);
-var TypeError = (ՐՏ_4 = function TypeError() {
-    TypeError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_4, Error), Object.defineProperties(ՐՏ_4.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "TypeError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_4);
-var ValueError = (ՐՏ_5 = function ValueError() {
-    ValueError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_5, Error), Object.defineProperties(ՐՏ_5.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "ValueError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_5);
 var fs, path, rapydscript;
 fs = require("fs");
 path = require("path");
@@ -432,6 +104,7 @@ function read_whole_file(filename, cb) {
     }
 }
 module.exports = function(start_time, argv, base_path, src_path, lib_path) {
+    var ՐՏ_10;
     var files, metrics, num_of_files, dropDecorators, dropImports, parseOpts;
     files = argv.files.slice(0);
     metrics = {};
@@ -454,7 +127,7 @@ module.exports = function(start_time, argv, base_path, src_path, lib_path) {
         strict_names: argv.strict_names
     };
     if (!argv.omit_baselib) {
-        parseOpts.baselib = rapydscript.parse_baselib(src_path, parseOpts.beautify);
+        parseOpts.baselib = rapydscript.parse_baselib(src_path, parseOpts.es6);
     }
     if (argv.comments) {
         if (/^\//.test(argv.comments)) {
@@ -473,6 +146,7 @@ module.exports = function(start_time, argv, base_path, src_path, lib_path) {
         }
     }
     function write_output(output) {
+        var ՐՏ_1;
         if (argv.output) {
             fs.writeFileSync(argv.output, output, "utf8");
         } else if (argv.execute) {
@@ -487,32 +161,34 @@ module.exports = function(start_time, argv, base_path, src_path, lib_path) {
                 "require": require,
                 "root": typeof window === "object" ? window : global
             }, {
-                "filename": files[0]
+                "filename": (ՐՏ_1 = files)[0]
             });
         } else {
             console.log(output);
         }
     }
     function time_it(name, cont) {
+        var ՐՏ_2, ՐՏ_3, ՐՏ_4;
         var t1, ret, spent;
         t1 = new Date().getTime();
         ret = cont();
         spent = new Date().getTime() - t1;
-        if (metrics[name]) {
-            metrics[name] += spent;
+        if ((ՐՏ_2 = metrics)[name]) {
+            (ՐՏ_3 = metrics)[name] += spent;
         } else {
-            metrics[name] = spent;
+            (ՐՏ_4 = metrics)[name] = spent;
         }
         return ret;
     }
     function compile_single_file(err, code) {
+        var ՐՏ_5, ՐՏ_6, ՐՏ_7, ՐՏ_8, ՐՏ_9;
         var output, i;
         if (err) {
-            console.error("ERROR: can't read file: " + files[0]);
+            console.error("ERROR: can't read file: " + (ՐՏ_5 = files)[0]);
             process.exit(1);
         }
-        parseOpts.filename = files[0];
-        parseOpts.basedir = path.dirname(files[0]);
+        parseOpts.filename = (ՐՏ_6 = files)[0];
+        parseOpts.basedir = path.dirname((ՐՏ_7 = files)[0]);
         if (argv.stats) {
             time_it("parse", function() {
                 var toplevel;
@@ -527,7 +203,7 @@ module.exports = function(start_time, argv, base_path, src_path, lib_path) {
         write_output(output);
         files = files.slice(1);
         if (files.length) {
-            setImmediate(read_whole_file, files[0], compile_single_file);
+            setImmediate(read_whole_file, (ՐՏ_8 = files)[0], compile_single_file);
             return;
         }
         if (argv.stats) {
@@ -538,7 +214,7 @@ module.exports = function(start_time, argv, base_path, src_path, lib_path) {
                 if (metrics.hasOwnProperty(i)) {
                     console.error(rapydscript.string_template("- {name}: {time}s", {
                         name: i,
-                        time: (metrics[i] / 1e3).toFixed(3)
+                        time: ((ՐՏ_9 = metrics)[i] / 1e3).toFixed(3)
                     }));
                 }
             }
@@ -550,5 +226,5 @@ module.exports = function(start_time, argv, base_path, src_path, lib_path) {
         console.error("ERROR: Can read a single file from STDIN (two or more dashes specified)");
         process.exit(1);
     }
-    setImmediate(read_whole_file, files[0], compile_single_file);
-};var ՐՏ_1, ՐՏ_2, ՐՏ_3, ՐՏ_4, ՐՏ_5;
+    setImmediate(read_whole_file, (ՐՏ_10 = files)[0], compile_single_file);
+};

--- a/lib/rapydscript.js
+++ b/lib/rapydscript.js
@@ -1,62 +1,4 @@
-var ՐՏ_1, ՐՏ_2, ՐՏ_3, ՐՏ_4, ՐՏ_5, ՐՏ_6, ՐՏ_7, ՐՏ_8, ՐՏ_9, ՐՏ_10, ՐՏ_11, ՐՏ_12, ՐՏ_13, ՐՏ_14, ՐՏ_15, ՐՏ_16, ՐՏ_17, ՐՏ_18, ՐՏ_19, ՐՏ_20, ՐՏ_21, ՐՏ_22, ՐՏ_23, ՐՏ_24, ՐՏ_25, ՐՏ_26, ՐՏ_27, ՐՏ_28, ՐՏ_29, ՐՏ_31, ՐՏ_32, ՐՏ_33, ՐՏ_34, ՐՏ_35, ՐՏ_36, ՐՏ_37, ՐՏ_38, ՐՏ_39, ՐՏ_40, ՐՏ_41, ՐՏ_42, ՐՏ_43, ՐՏ_44, ՐՏ_45, ՐՏ_46, ՐՏ_47, ՐՏ_48, ՐՏ_49, ՐՏ_50, ՐՏ_51, ՐՏ_52, ՐՏ_53, ՐՏ_54, ՐՏ_55, ՐՏ_56, ՐՏ_57, ՐՏ_58, ՐՏ_59, ՐՏ_60, ՐՏ_62, ՐՏ_63, ՐՏ_64, ՐՏ_65, ՐՏ_66, ՐՏ_67, ՐՏ_68, ՐՏ_69, ՐՏ_70, ՐՏ_71, ՐՏ_72, ՐՏ_73, ՐՏ_74, ՐՏ_75, ՐՏ_76, ՐՏ_77, ՐՏ_78, ՐՏ_79, ՐՏ_80, ՐՏ_81, ՐՏ_82, ՐՏ_83, ՐՏ_84, ՐՏ_85, ՐՏ_86, ՐՏ_87, ՐՏ_88, ՐՏ_89, ՐՏ_90, ՐՏ_91, ՐՏ_92, ՐՏ_93, ՐՏ_94, ՐՏ_95, ՐՏ_96, ՐՏ_97, ՐՏ_98, ՐՏ_99, ՐՏ_100, ՐՏ_101, ՐՏ_102, ՐՏ_103, ՐՏ_104, ՐՏ_105, ՐՏ_106, ՐՏ_107, ՐՏ_108, ՐՏ_109, ՐՏ_110, ՐՏ_111, ՐՏ_112, ՐՏ_113, ՐՏ_114, ՐՏ_115;
-function abs(n) {
-    return Math.abs(n);
-}
-function all(a) {
-    var ՐՏitr91, ՐՏidx91;
-    var e;
-    ՐՏitr91 = ՐՏ_Iterable(a);
-    for (ՐՏidx91 = 0; ՐՏidx91 < ՐՏitr91.length; ՐՏidx91++) {
-        e = ՐՏitr91[ՐՏidx91];
-        if (!e) {
-            return false;
-        }
-    }
-    return true;
-}
-function any(a) {
-    var ՐՏitr92, ՐՏidx92;
-    var e;
-    ՐՏitr92 = ՐՏ_Iterable(a);
-    for (ՐՏidx92 = 0; ՐՏidx92 < ՐՏitr92.length; ՐՏidx92++) {
-        e = ՐՏitr92[ՐՏidx92];
-        if (e) {
-            return true;
-        }
-    }
-    return false;
-}
-function bin(a) {
-    return "0b" + (a >>> 0).toString(2);
-}
-function ՐՏ_bind(fn, thisArg) {
-    var ret;
-    if (fn.orig) {
-        fn = fn.orig;
-    }
-    if (thisArg === false) {
-        return fn;
-    }
-    ret = function() {
-        return fn.apply(thisArg, arguments);
-    };
-    ret.orig = fn;
-    return ret;
-}
-function ՐՏ_rebindAll(thisArg, rebind) {
-    if (rebind === void 0) {
-        rebind = true;
-    }
-    for (var p in thisArg) {
-        if (thisArg[p] && thisArg[p].orig) {
-            if (rebind) {
-                thisArg[p] = ՐՏ_bind(thisArg[p], thisArg);
-            } else {
-                thisArg[p] = thisArg[p].orig;
-            }
-        }
-    }
-}
+var ՐՏ_4, ՐՏ_5, ՐՏ_35, ՐՏ_38, ՐՏ_39, ՐՏ_42, ՐՏ_43, ՐՏ_44, ՐՏ_45, ՐՏ_46, ՐՏ_47, ՐՏ_48, ՐՏ_49, ՐՏ_50, ՐՏ_51, ՐՏ_52, ՐՏ_53, ՐՏ_54, ՐՏ_55, ՐՏ_56, ՐՏ_57, ՐՏ_58, ՐՏ_59, ՐՏ_60, ՐՏ_61, ՐՏ_62, ՐՏ_63, ՐՏ_64, ՐՏ_65, ՐՏ_71, ՐՏ_72, ՐՏ_73, ՐՏ_74, ՐՏ_75, ՐՏ_76, ՐՏ_77, ՐՏ_78, ՐՏ_79, ՐՏ_80, ՐՏ_81, ՐՏ_82, ՐՏ_83, ՐՏ_84, ՐՏ_85, ՐՏ_86, ՐՏ_87, ՐՏ_88, ՐՏ_89, ՐՏ_90, ՐՏ_91, ՐՏ_92, ՐՏ_93, ՐՏ_94, ՐՏ_95, ՐՏ_96, ՐՏ_97, ՐՏ_98, ՐՏ_99, ՐՏ_100, ՐՏ_121, ՐՏ_124, ՐՏ_125, ՐՏ_128, ՐՏ_129, ՐՏ_132, ՐՏ_137, ՐՏ_138, ՐՏ_139, ՐՏ_140, ՐՏ_141, ՐՏ_142, ՐՏ_143, ՐՏ_144, ՐՏ_145, ՐՏ_146, ՐՏ_148, ՐՏ_149, ՐՏ_153, ՐՏ_154, ՐՏ_155, ՐՏ_156, ՐՏ_157, ՐՏ_158, ՐՏ_159, ՐՏ_160, ՐՏ_161, ՐՏ_162, ՐՏ_163, ՐՏ_164, ՐՏ_165, ՐՏ_166, ՐՏ_167, ՐՏ_168, ՐՏ_169, ՐՏ_170, ՐՏ_171, ՐՏ_175, ՐՏ_176, ՐՏ_177, ՐՏ_178, ՐՏ_179, ՐՏ_180, ՐՏ_181, ՐՏ_182, ՐՏ_183, ՐՏ_184, ՐՏ_185, ՐՏ_186, ՐՏ_187, ՐՏ_188, ՐՏ_189, ՐՏ_190, ՐՏ_191;
 function ՐՏ_with__name__(fn, name) {
     fn.__name__ = name;
     return fn;
@@ -64,7 +6,6 @@ function ՐՏ_with__name__(fn, name) {
 function cmp(a, b) {
     return a < b ? -1 : a > b ? 1 : 0;
 }
-var chr = String.fromCharCode;
 function dir(item) {
     var arr;
     arr = [];
@@ -74,52 +15,19 @@ function dir(item) {
     return arr;
 }
 function enumerate(item) {
+    var ՐՏ_554, ՐՏ_555;
     var arr, iter, i;
     arr = [];
     iter = ՐՏ_Iterable(item);
     for (i = 0; i < iter.length; i++) {
-        arr[arr.length] = [ i, item[i] ];
+        (ՐՏ_554 = arr)[arr.length] = [ i, (ՐՏ_555 = item)[i] ];
     }
     return arr;
-}
-function ՐՏ_eslice(arr, step, start, end) {
-    var isString;
-    arr = arr.slice(0);
-    if (typeof arr === "string" || arr instanceof String) {
-        isString = true;
-        arr = arr.split("");
-    }
-    if (step < 0) {
-        step = -step;
-        arr.reverse();
-        if (typeof start !== "undefined") {
-            start = arr.length - start - 1;
-        }
-        if (typeof end !== "undefined") {
-            end = arr.length - end - 1;
-        }
-    }
-    if (typeof start === "undefined") {
-        start = 0;
-    }
-    if (typeof end === "undefined") {
-        end = arr.length;
-    }
-    arr = arr.slice(start, end).filter(function(e, i) {
-        return i % step === 0;
-    });
-    return isString ? arr.join("") : arr;
 }
 function ՐՏ_extends(child, parent) {
     child.prototype = Object.create(parent.prototype);
     child.prototype.__base__ = parent;
     child.prototype.constructor = child;
-}
-function filter(oper, arr) {
-    return arr.filter(oper);
-}
-function hex(a) {
-    return "0x" + (a >>> 0).toString(16);
 }
 function ՐՏ_in(val, arr) {
     if (typeof arr.indexOf === "function") {
@@ -149,115 +57,49 @@ function len(obj) {
     }
     return Object.keys(obj).length;
 }
-function map(oper, arr) {
-    return arr.map(oper);
-}
-function max(a) {
-    return Math.max.apply(null, Array.isArray(a) ? a : arguments);
-}
-function min(a) {
-    return Math.min.apply(null, Array.isArray(a) ? a : arguments);
-}
 function ՐՏ_merge(target, source, overwrite) {
-    var ՐՏitr93, ՐՏidx93;
+    var ՐՏ_556, ՐՏ_557, ՐՏitr96, ՐՏidx96;
     var prop;
     for (var i in source) {
         if (source.hasOwnProperty(i) && (overwrite || typeof target[i] === "undefined")) {
-            target[i] = source[i];
+            (ՐՏ_556 = target)[i] = (ՐՏ_557 = source)[i];
         }
     }
-    ՐՏitr93 = ՐՏ_Iterable(Object.getOwnPropertyNames(source.prototype));
-    for (ՐՏidx93 = 0; ՐՏidx93 < ՐՏitr93.length; ՐՏidx93++) {
-        prop = ՐՏitr93[ՐՏidx93];
+    ՐՏitr96 = ՐՏ_Iterable(Object.getOwnPropertyNames(source.prototype));
+    for (ՐՏidx96 = 0; ՐՏidx96 < ՐՏitr96.length; ՐՏidx96++) {
+        prop = ՐՏitr96[ՐՏidx96];
         if (overwrite || typeof target.prototype[prop] === "undefined") {
             Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop));
         }
     }
 }
-function ՐՏ_mixin() {
-    var classes = [].slice.call(arguments, 0);
-    return function(baseClass) {
-        var ՐՏitr94, ՐՏidx94, ՐՏitr95, ՐՏidx95;
-        var cls, key;
-        ՐՏitr94 = ՐՏ_Iterable(classes);
-        for (ՐՏidx94 = 0; ՐՏidx94 < ՐՏitr94.length; ՐՏidx94++) {
-            cls = ՐՏitr94[ՐՏidx94];
-            ՐՏitr95 = ՐՏ_Iterable(Object.getOwnPropertyNames(cls.prototype));
-            for (ՐՏidx95 = 0; ՐՏidx95 < ՐՏitr95.length; ՐՏidx95++) {
-                key = ՐՏitr95[ՐՏidx95];
-                if (!(ՐՏ_in(key, baseClass.prototype))) {
-                    Object.defineProperty(baseClass.prototype, key, Object.getOwnPropertyDescriptor(cls.prototype, key));
-                }
-            }
-        }
-        return baseClass;
-    };
-}
-function ՐՏ_print() {
-    if (typeof console === "object") {
-        console.log.apply(console, arguments);
-    }
-}
 function range(start, stop, step) {
+    var ՐՏ_558, ՐՏ_559;
     var length, idx, range;
     if (arguments.length <= 1) {
         stop = start || 0;
         start = 0;
     }
-    step = arguments[2] || 1;
+    step = (ՐՏ_558 = arguments)[2] || 1;
     length = Math.max(Math.ceil((stop - start) / step), 0);
     idx = 0;
     range = new Array(length);
     while (idx < length) {
-        range[idx++] = start;
+        (ՐՏ_559 = range)[idx++] = start;
         start += step;
     }
     return range;
-}
-function reduce(f, a) {
-    return Array.prototype.reduce.call(a, f);
 }
 function reversed(arr) {
     var tmp;
     tmp = arr.slice(0);
     return tmp.reverse();
 }
-function sorted(arr) {
-    var tmp;
-    tmp = arr.slice(0);
-    return tmp.sort();
-}
-function sum(arr, start) {
-    start = start === void 0 ? 0 : start;
-    return arr.reduce(function(prev, cur) {
-        return prev + cur;
-    }, start);
-}
 function ՐՏ_type(obj) {
     return obj && obj.constructor && obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1);
 }
-function zip(a, b) {
-    var i;
-    return (function() {
-        var ՐՏidx96, ՐՏitr96 = ՐՏ_Iterable(range(Math.min(a.length, b.length))), ՐՏres = [], i;
-        for (ՐՏidx96 = 0; ՐՏidx96 < ՐՏitr96.length; ՐՏidx96++) {
-            i = ՐՏitr96[ՐՏidx96];
-            ՐՏres.push([ a[i], b[i] ]);
-        }
-        return ՐՏres;
-    })();
-}
-function getattr(obj, name) {
-    return obj[name];
-}
-function setattr(obj, name, value) {
-    obj[name] = value;
-}
-function hasattr(obj, name) {
-    return name in obj;
-}
 function ՐՏ_eq(a, b) {
-    var ՐՏitr97, ՐՏidx97;
+    var ՐՏ_560, ՐՏ_561, ՐՏitr97, ՐՏidx97, ՐՏ_562, ՐՏ_563;
     var i;
     if (a === b) {
         return true;
@@ -273,7 +115,7 @@ function ՐՏ_eq(a, b) {
             return false;
         }
         for (i = 0; i < a.length; i++) {
-            if (!ՐՏ_eq(a[i], b[i])) {
+            if (!ՐՏ_eq((ՐՏ_560 = a)[i], (ՐՏ_561 = b)[i])) {
                 return false;
             }
         }
@@ -285,7 +127,7 @@ function ՐՏ_eq(a, b) {
         ՐՏitr97 = ՐՏ_Iterable(a);
         for (ՐՏidx97 = 0; ՐՏidx97 < ՐՏitr97.length; ՐՏidx97++) {
             i = ՐՏitr97[ՐՏidx97];
-            if (!ՐՏ_eq(a[i], b[i])) {
+            if (!ՐՏ_eq((ՐՏ_562 = a)[i], (ՐՏ_563 = b)[i])) {
                 return false;
             }
         }
@@ -308,23 +150,25 @@ function ՐՏ_eq(a, b) {
     return false;
 }
 function kwargs(f) {
+    var ՐՏ_564, ՐՏ_565, ՐՏ_566, ՐՏ_567;
     var argNames;
-    argNames = f.toString().match(/\(([^\)]+)/)[1];
-    if (!kwargs.memo[argNames]) {
-        kwargs.memo[argNames] = argNames ? argNames.split(",").map(function(s) {
+    argNames = (ՐՏ_564 = f.toString().match(/\(([^\)]+)/))[1];
+    if (!(ՐՏ_565 = kwargs.memo)[argNames]) {
+        (ՐՏ_566 = kwargs.memo)[argNames] = argNames ? argNames.split(",").map(function(s) {
             return s.trim();
         }) : [];
     }
-    argNames = kwargs.memo[argNames];
+    argNames = (ՐՏ_567 = kwargs.memo)[argNames];
     return function() {
+        var ՐՏ_568, ՐՏ_569, ՐՏ_570, ՐՏ_571, ՐՏ_572;
         var args, kw, i;
         args = [].slice.call(arguments);
         if (args.length) {
-            kw = args[args.length-1];
+            kw = (ՐՏ_568 = args)[ՐՏ_568.length-1];
             if (typeof kw === "object") {
                 for (i = 0; i < argNames.length; i++) {
-                    if (ՐՏ_in(argNames[i], kw)) {
-                        args[i] = kw[argNames[i]];
+                    if (ՐՏ_in((ՐՏ_569 = argNames)[i], kw)) {
+                        (ՐՏ_570 = args)[i] = (ՐՏ_571 = kw)[(ՐՏ_572 = argNames)[i]];
                     }
                 }
             } else {
@@ -343,86 +187,60 @@ function kwargs(f) {
     };
 }
 kwargs.memo = {};
-var AssertionError = (ՐՏ_128 = function AssertionError() {
-    AssertionError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_128, Error), Object.defineProperties(ՐՏ_128.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "AssertionError";
-            self.message = message;
-        }
-
+function ՐՏ_def_modules() {
+    var modules;
+    modules = {};
+    function mounter(mod_id) {
+        var ՐՏ_573, ՐՏ_574;
+        var rs_mod_id, rs_mod;
+        rs_mod_id = "ՐՏ:" + mod_id;
+        rs_mod = (ՐՏ_573 = modules)[rs_mod_id] = {
+            "body": null,
+            "exports": null
+        };
+        (ՐՏ_574 = rs_mod)["export"] = function(prop, get, set) {
+            var ՐՏ_575, ՐՏ_576, ՐՏ_577;
+            if (!(ՐՏ_575 = rs_mod)["exports"]) {
+                (ՐՏ_576 = rs_mod)["exports"] = {};
+            }
+            Object.defineProperty((ՐՏ_577 = rs_mod)["exports"], prop, {
+                configurable: true,
+                enumerable: true,
+                get: get,
+                set: set
+            });
+        };
+        Object.defineProperty(modules, mod_id, {
+            enumerable: true,
+            get: function() {
+                var ՐՏ_578, ՐՏ_579, ՐՏ_580;
+                var mod;
+                return (ՐՏ_578 = (mod = (ՐՏ_579 = modules)[rs_mod_id]))["exports"] || (ՐՏ_580 = mod)["body"]();
+            },
+            set: function(v) {
+                var ՐՏ_581, ՐՏ_582;
+                (ՐՏ_581 = (ՐՏ_582 = modules)[rs_mod_id])["exports"] = v;
+            }
+        });
+        return rs_mod;
     }
-}), ՐՏ_128);
-var IndexError = (ՐՏ_129 = function IndexError() {
-    IndexError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_129, Error), Object.defineProperties(ՐՏ_129.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "IndexError";
-            self.message = message;
-        }
+    Object.defineProperty(modules, "ՐՏ_def", {
+        configurable: false,
+        enumerable: false,
+        value: mounter
+    });
+    return modules;
+}
+var ՐՏ_modules = ՐՏ_def_modules();
+ՐՏ_modules.ՐՏ_def("utils");
+ՐՏ_modules.ՐՏ_def("ast");
+ՐՏ_modules.ՐՏ_def("tokenizer");
+ՐՏ_modules.ՐՏ_def("parser");
+ՐՏ_modules.ՐՏ_def("_baselib");
+ՐՏ_modules.ՐՏ_def("stream");
+ՐՏ_modules.ՐՏ_def("output");
 
-    }
-}), ՐՏ_129);
-var KeyError = (ՐՏ_130 = function KeyError() {
-    KeyError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_130, Error), Object.defineProperties(ՐՏ_130.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "KeyError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_130);
-var TypeError = (ՐՏ_131 = function TypeError() {
-    TypeError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_131, Error), Object.defineProperties(ՐՏ_131.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "TypeError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_131);
-var ValueError = (ՐՏ_132 = function ValueError() {
-    ValueError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_132, Error), Object.defineProperties(ՐՏ_132.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "ValueError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_132);
-var ՐՏ_modules = {};
-ՐՏ_modules["utils"] = {};
-ՐՏ_modules["ast"] = {};
-ՐՏ_modules["tokenizer"] = {};
-ՐՏ_modules["parser"] = {};
-ՐՏ_modules["_baselib"] = {};
-ՐՏ_modules["stream"] = {};
-ՐՏ_modules["output"] = {};
-
-(function(){
+ՐՏ_modules["ՐՏ:utils"].body = function(){
     var __name__ = "utils";
 
     var RAPYD_PREFIX, MAP, colors;
@@ -431,22 +249,23 @@ var ՐՏ_modules = {};
         return Array.prototype.slice.call(a, start || 0);
     }
     function member(name, array) {
-        var ՐՏitr1, ՐՏidx1;
+        var ՐՏitr1, ՐՏidx1, ՐՏ_1;
         var i;
         ՐՏitr1 = ՐՏ_Iterable(range(array.length - 1, -1, -1));
         for (ՐՏidx1 = 0; ՐՏidx1 < ՐՏitr1.length; ՐՏidx1++) {
             i = ՐՏitr1[ՐՏidx1];
-            if (array[i] === name) {
+            if ((ՐՏ_1 = array)[i] === name) {
                 return true;
             }
         }
         return false;
     }
     function find_if(func, array) {
+        var ՐՏ_2, ՐՏ_3;
         var i;
         for (i = 0; i < len(array); i++) {
-            if (func(array[i])) {
-                return array[i];
+            if (func((ՐՏ_2 = array)[i])) {
+                return (ՐՏ_3 = array)[i];
             }
         }
     }
@@ -469,9 +288,9 @@ var ՐՏ_modules = {};
         this.msg = msg;
         this.defs = defs;
     }
-    var ImportError = (ՐՏ_1 = function ImportError() {
+    var ImportError = (ՐՏ_4 = function ImportError() {
         ImportError.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_1, Error), Object.defineProperties(ՐՏ_1.prototype, {
+    }, ՐՏ_extends(ՐՏ_4, Error), Object.defineProperties(ՐՏ_4.prototype, {
         __init__: {
             enumerable: true, 
             writable: true, 
@@ -483,10 +302,10 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_1);
-    var ParseError = (ՐՏ_2 = function ParseError() {
+    }), ՐՏ_4);
+    var ParseError = (ՐՏ_5 = function ParseError() {
         ParseError.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_2, Error), Object.defineProperties(ՐՏ_2.prototype, {
+    }, ՐՏ_extends(ՐՏ_5, Error), Object.defineProperties(ՐՏ_5.prototype, {
         __init__: {
             enumerable: true, 
             writable: true, 
@@ -511,9 +330,9 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_2);
+    }), ՐՏ_5);
     function defaults(args, defs, croak) {
-        var ՐՏitr2, ՐՏidx2, ՐՏitr3, ՐՏidx3;
+        var ՐՏitr2, ՐՏidx2, ՐՏitr3, ՐՏidx3, ՐՏ_6, ՐՏ_7, ՐՏ_8;
         var ret, key;
         if (args === true) {
             args = {};
@@ -531,17 +350,17 @@ var ՐՏ_modules = {};
         ՐՏitr3 = ՐՏ_Iterable(defs);
         for (ՐՏidx3 = 0; ՐՏidx3 < ՐՏitr3.length; ՐՏidx3++) {
             key = ՐՏitr3[ՐՏidx3];
-            ret[key] = args && ՐՏ_in(key, args) ? args[key] : defs[key];
+            (ՐՏ_6 = ret)[key] = args && ՐՏ_in(key, args) ? (ՐՏ_7 = args)[key] : (ՐՏ_8 = defs)[key];
         }
         return ret;
     }
     function merge(obj, ext) {
-        var ՐՏitr4, ՐՏidx4;
+        var ՐՏitr4, ՐՏidx4, ՐՏ_9, ՐՏ_10;
         var key;
         ՐՏitr4 = ՐՏ_Iterable(ext);
         for (ՐՏidx4 = 0; ՐՏidx4 < ՐՏitr4.length; ՐՏidx4++) {
             key = ՐՏitr4[ՐՏidx4];
-            obj[key] = ext[key];
+            (ՐՏ_9 = obj)[key] = (ՐՏ_10 = ext)[key];
         }
         return obj;
     }
@@ -555,8 +374,9 @@ var ՐՏ_modules = {};
             ret = [];
             top = [];
             function doit() {
+                var ՐՏ_11;
                 var val, is_last;
-                val = f(a[i], i);
+                val = f((ՐՏ_11 = a)[i], i);
                 is_last = val instanceof Last;
                 if (is_last) {
                     val = val.v;
@@ -634,16 +454,17 @@ var ՐՏ_modules = {};
     }
     function string_template(text, props) {
         return text.replace(/\{(.+?)\}/g, function(str_, p) {
-            return props[p];
+            var ՐՏ_12;
+            return (ՐՏ_12 = props)[p];
         });
     }
     function remove(array, el) {
-        var ՐՏitr6, ՐՏidx6;
+        var ՐՏitr6, ՐՏidx6, ՐՏ_13;
         var idx;
         ՐՏitr6 = ՐՏ_Iterable(range(array.length - 1, -1, -1));
         for (ՐՏidx6 = 0; ՐՏidx6 < ՐՏitr6.length; ՐՏidx6++) {
             idx = ՐՏitr6[ՐՏidx6];
-            if (array[idx] === el) {
+            if ((ՐՏ_13 = array)[idx] === el) {
                 array.splice(i, 1);
             }
         }
@@ -653,17 +474,18 @@ var ՐՏ_modules = {};
             return array.slice();
         }
         function merge(a, b) {
+            var ՐՏ_14, ՐՏ_15, ՐՏ_16, ՐՏ_17, ՐՏ_18, ՐՏ_19;
             var r, ai, bi, i;
             r = [];
             ai = 0;
             bi = 0;
             i = 0;
             while (ai < a.length && bi < b.length) {
-                if (cmp(a[ai], b[bi]) <= 0) {
-                    r[i] = a[ai];
+                if (cmp((ՐՏ_14 = a)[ai], (ՐՏ_15 = b)[bi]) <= 0) {
+                    (ՐՏ_16 = r)[i] = (ՐՏ_17 = a)[ai];
                     ++ai;
                 } else {
-                    r[i] = b[bi];
+                    (ՐՏ_18 = r)[i] = (ՐՏ_19 = b)[bi];
                     ++bi;
                 }
                 ++i;
@@ -701,6 +523,7 @@ var ՐՏ_modules = {};
         });
     }
     function makePredicate(words) {
+        var ՐՏ_20, ՐՏ_21, ՐՏ_22, ՐՏ_23, ՐՏ_24, ՐՏ_25, ՐՏ_28, ՐՏ_29;
         var f, cats, i, skip, j, cat;
         if (!Array.isArray(words)) {
             words = words.split(" ");
@@ -710,24 +533,25 @@ var ՐՏ_modules = {};
         for (i = 0; i < len(words); i++) {
             skip = false;
             for (j = 0; j < len(cats); j++) {
-                if (cats[j][0].length === words[i].length) {
-                    cats[j].push(words[i]);
+                if ((ՐՏ_20 = (ՐՏ_21 = cats)[j])[0].length === (ՐՏ_22 = words)[i].length) {
+                    (ՐՏ_23 = cats)[j].push((ՐՏ_24 = words)[i]);
                     skip = true;
                     break;
                 }
             }
             if (!skip) {
-                cats.push([ words[i] ]);
+                cats.push([ (ՐՏ_25 = words)[i] ]);
             }
         }
         function compareTo(arr) {
+            var ՐՏ_26, ՐՏ_27;
             var i;
             if (arr.length === 1) {
-                return f += "return str === " + JSON.stringify(arr[0]) + ";";
+                return f += "return str === " + JSON.stringify((ՐՏ_26 = arr)[0]) + ";";
             }
             f += "switch(str){";
             for (i = 0; i < len(arr); i++) {
-                f += "case " + JSON.stringify(arr[i]) + ":";
+                f += "case " + JSON.stringify((ՐՏ_27 = arr)[i]) + ":";
             }
             f += "return true}return false;";
         }
@@ -737,8 +561,8 @@ var ՐՏ_modules = {};
             });
             f += "switch(str.length){";
             for (i = 0; i < len(cats); i++) {
-                cat = cats[i];
-                f += "case " + cat[0].length + ":";
+                cat = (ՐՏ_28 = cats)[i];
+                f += "case " + (ՐՏ_29 = cat)[0].length + ":";
                 compareTo(cat);
             }
             f += "}";
@@ -753,10 +577,11 @@ var ՐՏ_modules = {};
     }
     Dictionary.prototype = {
         set: function(key, val) {
+            var ՐՏ_30;
             if (!this.has(key)) {
                 ++this._size;
             }
-            this._values["$" + key] = val;
+            (ՐՏ_30 = this._values)["$" + key] = val;
             return this;
         },
         add: function(key, val) {
@@ -768,12 +593,14 @@ var ՐՏ_modules = {};
             return this;
         },
         get: function(key) {
-            return this._values["$" + key];
+            var ՐՏ_31;
+            return (ՐՏ_31 = this._values)["$" + key];
         },
         del_: function(key) {
+            var ՐՏ_32;
             if (this.has(key)) {
                 --this._size;
-                delete this._values["$" + key];
+                delete (ՐՏ_32 = this._values)["$" + key];
             }
             return this;
         },
@@ -781,19 +608,21 @@ var ՐՏ_modules = {};
             return ՐՏ_in("$" + key, this._values);
         },
         each: function(f) {
+            var ՐՏ_33;
             var i;
             for (i in this._values) {
-                f(this._values[i], i.substr(1));
+                f((ՐՏ_33 = this._values)[i], i.substr(1));
             }
         },
         size: function() {
             return this._size;
         },
         map: function(f) {
+            var ՐՏ_34;
             var ret, i;
             ret = [];
             for (i in this._values) {
-                ret.push(f(this._values[i], i.substr(1)));
+                ret.push(f((ՐՏ_34 = this._values)[i], i.substr(1)));
             }
             return ret;
         }
@@ -814,38 +643,37 @@ var ՐՏ_modules = {};
         }
         return prefix.join("") + string + ansi(0);
     }
-    ՐՏ_modules["utils"]["RAPYD_PREFIX"] = RAPYD_PREFIX;
-    ՐՏ_modules["utils"]["MAP"] = MAP;
-    ՐՏ_modules["utils"]["colors"] = colors;
-    ՐՏ_modules["utils"]["slice"] = slice;
-    ՐՏ_modules["utils"]["member"] = member;
-    ՐՏ_modules["utils"]["find_if"] = find_if;
-    ՐՏ_modules["utils"]["repeat_string"] = repeat_string;
-    ՐՏ_modules["utils"]["DefaultsError"] = DefaultsError;
-    ՐՏ_modules["utils"]["ImportError"] = ImportError;
-    ՐՏ_modules["utils"]["ParseError"] = ParseError;
-    ՐՏ_modules["utils"]["defaults"] = defaults;
-    ՐՏ_modules["utils"]["merge"] = merge;
-    ՐՏ_modules["utils"]["noop"] = noop;
-    ՐՏ_modules["utils"]["push_uniq"] = push_uniq;
-    ՐՏ_modules["utils"]["string_template"] = string_template;
-    ՐՏ_modules["utils"]["remove"] = remove;
-    ՐՏ_modules["utils"]["mergeSort"] = mergeSort;
-    ՐՏ_modules["utils"]["set_difference"] = set_difference;
-    ՐՏ_modules["utils"]["set_intersection"] = set_intersection;
-    ՐՏ_modules["utils"]["makePredicate"] = makePredicate;
-    ՐՏ_modules["utils"]["Dictionary"] = Dictionary;
-    ՐՏ_modules["utils"]["ansi"] = ansi;
-    ՐՏ_modules["utils"]["colored"] = colored;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:utils"];
+    ՐՏ_mod.export("RAPYD_PREFIX", function(){return RAPYD_PREFIX;}, function(ՐՏ_v){if (typeof RAPYD_PREFIX !== "undefined") {RAPYD_PREFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("MAP", function(){return MAP;}, function(ՐՏ_v){if (typeof MAP !== "undefined") {MAP = ՐՏ_v;};});
+    ՐՏ_mod.export("colors", function(){return colors;}, function(ՐՏ_v){if (typeof colors !== "undefined") {colors = ՐՏ_v;};});
+    ՐՏ_mod.export("slice", function(){return slice;}, function(ՐՏ_v){if (typeof slice !== "undefined") {slice = ՐՏ_v;};});
+    ՐՏ_mod.export("member", function(){return member;}, function(ՐՏ_v){if (typeof member !== "undefined") {member = ՐՏ_v;};});
+    ՐՏ_mod.export("find_if", function(){return find_if;}, function(ՐՏ_v){if (typeof find_if !== "undefined") {find_if = ՐՏ_v;};});
+    ՐՏ_mod.export("repeat_string", function(){return repeat_string;}, function(ՐՏ_v){if (typeof repeat_string !== "undefined") {repeat_string = ՐՏ_v;};});
+    ՐՏ_mod.export("DefaultsError", function(){return DefaultsError;}, function(ՐՏ_v){if (typeof DefaultsError !== "undefined") {DefaultsError = ՐՏ_v;};});
+    ՐՏ_mod.export("ImportError", function(){return ImportError;}, function(ՐՏ_v){if (typeof ImportError !== "undefined") {ImportError = ՐՏ_v;};});
+    ՐՏ_mod.export("ParseError", function(){return ParseError;}, function(ՐՏ_v){if (typeof ParseError !== "undefined") {ParseError = ՐՏ_v;};});
+    ՐՏ_mod.export("defaults", function(){return defaults;}, function(ՐՏ_v){if (typeof defaults !== "undefined") {defaults = ՐՏ_v;};});
+    ՐՏ_mod.export("merge", function(){return merge;}, function(ՐՏ_v){if (typeof merge !== "undefined") {merge = ՐՏ_v;};});
+    ՐՏ_mod.export("noop", function(){return noop;}, function(ՐՏ_v){if (typeof noop !== "undefined") {noop = ՐՏ_v;};});
+    ՐՏ_mod.export("push_uniq", function(){return push_uniq;}, function(ՐՏ_v){if (typeof push_uniq !== "undefined") {push_uniq = ՐՏ_v;};});
+    ՐՏ_mod.export("string_template", function(){return string_template;}, function(ՐՏ_v){if (typeof string_template !== "undefined") {string_template = ՐՏ_v;};});
+    ՐՏ_mod.export("remove", function(){return remove;}, function(ՐՏ_v){if (typeof remove !== "undefined") {remove = ՐՏ_v;};});
+    ՐՏ_mod.export("mergeSort", function(){return mergeSort;}, function(ՐՏ_v){if (typeof mergeSort !== "undefined") {mergeSort = ՐՏ_v;};});
+    ՐՏ_mod.export("set_difference", function(){return set_difference;}, function(ՐՏ_v){if (typeof set_difference !== "undefined") {set_difference = ՐՏ_v;};});
+    ՐՏ_mod.export("set_intersection", function(){return set_intersection;}, function(ՐՏ_v){if (typeof set_intersection !== "undefined") {set_intersection = ՐՏ_v;};});
+    ՐՏ_mod.export("makePredicate", function(){return makePredicate;}, function(ՐՏ_v){if (typeof makePredicate !== "undefined") {makePredicate = ՐՏ_v;};});
+    ՐՏ_mod.export("Dictionary", function(){return Dictionary;}, function(ՐՏ_v){if (typeof Dictionary !== "undefined") {Dictionary = ՐՏ_v;};});
+    ՐՏ_mod.export("ansi", function(){return ansi;}, function(ՐՏ_v){if (typeof ansi !== "undefined") {ansi = ՐՏ_v;};});
+    ՐՏ_mod.export("colored", function(){return colored;}, function(ՐՏ_v){if (typeof colored !== "undefined") {colored = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:ast"].body = function(){
     var __name__ = "ast";
 
-    var noop = ՐՏ_modules["utils"].noop;
-    var string_template = ՐՏ_modules["utils"].string_template;
-    var colored = ՐՏ_modules["utils"].colored;
-    
+    var noop = ՐՏ_modules["utils"].noop;var string_template = ՐՏ_modules["utils"].string_template;var colored = ՐՏ_modules["utils"].colored;
     function memoized(f) {
         return function(x) {
             if (!this.computedType) {
@@ -854,11 +682,11 @@ var ՐՏ_modules = {};
             return this.computedType;
         };
     }
-    var AST = (ՐՏ_3 = function AST() {
+    var AST = (ՐՏ_35 = function AST() {
         AST.prototype.__init__.apply(this, arguments);
     }, (function(){
         var properties = {};
-        Object.defineProperties(ՐՏ_3.prototype, {
+        Object.defineProperties(ՐՏ_35.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -868,13 +696,14 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: function __init__(initializer){
+                    var ՐՏ_36, ՐՏ_37;
                     var self = this;
                     var obj, i;
                     if (initializer) {
                         obj = self;
                         while (obj) {
                             for (i in obj.properties) {
-                                self[i] = initializer[i];
+                                (ՐՏ_36 = self)[i] = (ՐՏ_37 = initializer)[i];
                             }
                             obj = Object.getPrototypeOf(obj);
                         }
@@ -891,10 +720,10 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_3);
-    var Token = (ՐՏ_4 = function Token() {
+        })    })(), ՐՏ_35);
+    var Token = (ՐՏ_38 = function Token() {
         AST.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_4, AST), (function(){
+    }, ՐՏ_extends(ՐՏ_38, AST), (function(){
         var properties = {
             "type": "The type of the token",
             "subtype": "The subtype of the token",
@@ -909,22 +738,22 @@ var ՐՏ_modules = {};
             "comma_expected": "True if comma was expected instead of this token",
             "file": "Name of the file currently being parsed"
         };
-        Object.defineProperties(ՐՏ_4.prototype, {
+        Object.defineProperties(ՐՏ_38.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_4);
-    var Node = (ՐՏ_5 = function Node() {
+        })    })(), ՐՏ_38);
+    var Node = (ՐՏ_39 = function Node() {
         AST.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_5, AST), (function(){
+    }, ՐՏ_extends(ՐՏ_39, AST), (function(){
         var properties = {
             "start": "[Token] The first token of this node",
             "end": "[Token] The last token of this node"
         };
         var computedType = null;
-        Object.defineProperties(ՐՏ_5.prototype, {
+        Object.defineProperties(ՐՏ_39.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -966,7 +795,7 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: function _dump(depth, omit, offset, include_name, compact){
-                    var ՐՏitr7, ՐՏidx7, ՐՏitr8, ՐՏidx8, ՐՏitr9, ՐՏidx9, ՐՏitr10, ՐՏidx10;
+                    var ՐՏitr7, ՐՏidx7, ՐՏ_40, ՐՏitr8, ՐՏidx8, ՐՏitr9, ՐՏidx9, ՐՏitr10, ՐՏidx10, ՐՏ_41;
                     var self = this;
                     var key, colored_key, value, element, property;
                     function out(string) {
@@ -984,7 +813,7 @@ var ՐՏ_modules = {};
                             continue;
                         }
                         colored_key = colored(key + ": ", "blue");
-                        value = self[key];
+                        value = (ՐՏ_40 = self)[key];
                         if (Array.isArray(value)) {
                             if (value.length) {
                                 out(" " + colored_key + "[");
@@ -1017,7 +846,7 @@ var ՐՏ_modules = {};
                                         ՐՏitr10 = ՐՏ_Iterable(value);
                                         for (ՐՏidx10 = 0; ՐՏidx10 < ՐՏitr10.length; ՐՏidx10++) {
                                             property = ՐՏitr10[ՐՏidx10];
-                                            out("   " + colored(property + ": ", "blue") + value[property]);
+                                            out("   " + colored(property + ": ", "blue") + (ՐՏ_41 = value)[property]);
                                         }
                                     }
                                 } else {
@@ -1056,7 +885,7 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), Object.defineProperties(ՐՏ_5, {
+        })    })(), Object.defineProperties(ՐՏ_39, {
         warn_function: {
             enumerable: true, 
             writable: true, 
@@ -1074,34 +903,34 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_5);
-    var Statement = (ՐՏ_6 = function Statement() {
+    }), ՐՏ_39);
+    var Statement = (ՐՏ_42 = function Statement() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_6, Node), ՐՏ_6);
-    var Debugger = (ՐՏ_7 = function Debugger() {
+    }, ՐՏ_extends(ՐՏ_42, Node), ՐՏ_42);
+    var Debugger = (ՐՏ_43 = function Debugger() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_7, Statement), ՐՏ_7);
-    var Directive = (ՐՏ_8 = function Directive() {
+    }, ՐՏ_extends(ՐՏ_43, Statement), ՐՏ_43);
+    var Directive = (ՐՏ_44 = function Directive() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_8, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_44, Statement), (function(){
         var properties = {
             value: "[string] The value of this directive as a plain string (it's not a String!)",
             scope: "[Scope/S] The scope that this directive affects"
         };
-        Object.defineProperties(ՐՏ_8.prototype, {
+        Object.defineProperties(ՐՏ_44.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_8);
-    var SimpleStatement = (ՐՏ_9 = function SimpleStatement() {
+        })    })(), ՐՏ_44);
+    var SimpleStatement = (ՐՏ_45 = function SimpleStatement() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_9, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_45, Statement), (function(){
         var properties = {
             body: "[Node] an expression node (should not be instanceof Statement)"
         };
-        Object.defineProperties(ՐՏ_9.prototype, {
+        Object.defineProperties(ՐՏ_45.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1120,7 +949,7 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_9);
+        })    })(), ՐՏ_45);
     function walk_body(node, visitor) {
         var ՐՏitr11, ՐՏidx11;
         var stat;
@@ -1134,13 +963,13 @@ var ՐՏ_modules = {};
             }
         }
     }
-    var Block = (ՐՏ_10 = function Block() {
+    var Block = (ՐՏ_46 = function Block() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_10, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_46, Statement), (function(){
         var properties = {
             body: "[Statement*] an array of statements"
         };
-        Object.defineProperties(ՐՏ_10.prototype, {
+        Object.defineProperties(ՐՏ_46.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1157,13 +986,13 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_10);
-    var BlockStatement = (ՐՏ_11 = function BlockStatement() {
+        })    })(), ՐՏ_46);
+    var BlockStatement = (ՐՏ_47 = function BlockStatement() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_11, Block), ՐՏ_11);
-    var EmptyStatement = (ՐՏ_12 = function EmptyStatement() {
+    }, ՐՏ_extends(ՐՏ_47, Block), ՐՏ_47);
+    var EmptyStatement = (ՐՏ_48 = function EmptyStatement() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_12, Statement), Object.defineProperties(ՐՏ_12.prototype, {
+    }, ՐՏ_extends(ՐՏ_48, Statement), Object.defineProperties(ՐՏ_48.prototype, {
         _walk: {
             enumerable: true, 
             writable: true, 
@@ -1173,14 +1002,14 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_12);
-    var StatementWithBody = (ՐՏ_13 = function StatementWithBody() {
+    }), ՐՏ_48);
+    var StatementWithBody = (ՐՏ_49 = function StatementWithBody() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_13, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_49, Statement), (function(){
         var properties = {
             body: "[Statement] the body; this should always be present, even if it's an EmptyStatement"
         };
-        Object.defineProperties(ՐՏ_13.prototype, {
+        Object.defineProperties(ՐՏ_49.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1197,14 +1026,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_13);
-    var LabeledStatement = (ՐՏ_14 = function LabeledStatement() {
+        })    })(), ՐՏ_49);
+    var LabeledStatement = (ՐՏ_50 = function LabeledStatement() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_14, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_50, StatementWithBody), (function(){
         var properties = {
             label: "[Label] a label definition"
         };
-        Object.defineProperties(ՐՏ_14.prototype, {
+        Object.defineProperties(ՐՏ_50.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1222,14 +1051,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_14);
-    var DWLoop = (ՐՏ_15 = function DWLoop() {
+        })    })(), ՐՏ_50);
+    var DWLoop = (ՐՏ_51 = function DWLoop() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_15, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_51, StatementWithBody), (function(){
         var properties = {
             condition: "[Node] the loop condition.  Should not be instanceof Statement"
         };
-        Object.defineProperties(ՐՏ_15.prototype, {
+        Object.defineProperties(ՐՏ_51.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1247,22 +1076,22 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_15);
-    var Do = (ՐՏ_16 = function Do() {
+        })    })(), ՐՏ_51);
+    var Do = (ՐՏ_52 = function Do() {
         DWLoop.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_16, DWLoop), ՐՏ_16);
-    var While = (ՐՏ_17 = function While() {
+    }, ՐՏ_extends(ՐՏ_52, DWLoop), ՐՏ_52);
+    var While = (ՐՏ_53 = function While() {
         DWLoop.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_17, DWLoop), ՐՏ_17);
-    var ForIn = (ՐՏ_18 = function ForIn() {
+    }, ՐՏ_extends(ՐՏ_53, DWLoop), ՐՏ_53);
+    var ForIn = (ՐՏ_54 = function ForIn() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_18, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_54, StatementWithBody), (function(){
         var properties = {
             init: "[Node] the `for/in` initialization code",
             name: "[SymbolRef?] the loop variable, only if `init` is Var",
             object: "[Node] the object that we're looping through"
         };
-        Object.defineProperties(ՐՏ_18.prototype, {
+        Object.defineProperties(ՐՏ_54.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1281,28 +1110,28 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_18);
-    var ForJS = (ՐՏ_19 = function ForJS() {
+        })    })(), ՐՏ_54);
+    var ForJS = (ՐՏ_55 = function ForJS() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_19, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_55, StatementWithBody), (function(){
         var properties = {
             condition: "[Verbatim] raw JavaScript conditional"
         };
-        Object.defineProperties(ՐՏ_19.prototype, {
+        Object.defineProperties(ՐՏ_55.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_19);
-    var ListComprehension = (ՐՏ_20 = function ListComprehension() {
+        })    })(), ՐՏ_55);
+    var ListComprehension = (ՐՏ_56 = function ListComprehension() {
         ForIn.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_20, ForIn), (function(){
+    }, ՐՏ_extends(ՐՏ_56, ForIn), (function(){
         var properties = {
             condition: "[Node] the `if` condition",
             statement: "[Node] statement to perform on each element before returning it"
         };
-        Object.defineProperties(ՐՏ_20.prototype, {
+        Object.defineProperties(ՐՏ_56.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1323,14 +1152,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_20);
-    var DictComprehension = (ՐՏ_21 = function DictComprehension() {
+        })    })(), ՐՏ_56);
+    var DictComprehension = (ՐՏ_57 = function DictComprehension() {
         ListComprehension.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_21, ListComprehension), (function(){
+    }, ՐՏ_extends(ՐՏ_57, ListComprehension), (function(){
         var properties = {
             value_statement: "[Node] statement to perform on each value before returning it"
         };
-        Object.defineProperties(ՐՏ_21.prototype, {
+        Object.defineProperties(ՐՏ_57.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1352,14 +1181,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_21);
-    var With = (ՐՏ_22 = function With() {
+        })    })(), ՐՏ_57);
+    var With = (ՐՏ_58 = function With() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_22, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_58, StatementWithBody), (function(){
         var properties = {
             expression: "[Node] the `with` expression"
         };
-        Object.defineProperties(ՐՏ_22.prototype, {
+        Object.defineProperties(ՐՏ_58.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1377,10 +1206,10 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_22);
-    var Scope = (ՐՏ_23 = function Scope() {
+        })    })(), ՐՏ_58);
+    var Scope = (ՐՏ_59 = function Scope() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_23, Block), (function(){
+    }, ՐՏ_extends(ՐՏ_59, Block), (function(){
         var properties = {
             docstring: "[string?] docstring for this scope, if any",
             directives: "[string*/S] an array of directives declared in this scope",
@@ -1390,17 +1219,18 @@ var ՐՏ_modules = {};
             parent_scope: "[Scope?/S] link to the parent scope",
             enclosed: "[SymbolDef*/S] a list of all symbol definitions that are accessed from this scope or any subscopes"
         };
-        Object.defineProperties(ՐՏ_23.prototype, {
+        Object.defineProperties(ՐՏ_59.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_23);
-    var TopLevel = (ՐՏ_24 = function TopLevel() {
+        })    })(), ՐՏ_59);
+    var TopLevel = (ՐՏ_60 = function TopLevel() {
         Scope.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_24, Scope), (function(){
+    }, ՐՏ_extends(ՐՏ_60, Scope), (function(){
         var properties = {
+            async: "[boolean] if True this is async (external) module should be set at runtime",
             globals: "[Object/S] a map of name -> SymbolDef for all undeclared names",
             baselib: "[Object/s] a collection of used parts of baselib",
             imports: "[Object/S] a map of module_id->TopLevel for all imported modules",
@@ -1415,39 +1245,39 @@ var ՐՏ_modules = {};
             filename: "[string] The absolute path to the file from which this module was read",
             srchash: "[string] SHA1 hash of source code, used for caching"
         };
-        Object.defineProperties(ՐՏ_24.prototype, {
+        Object.defineProperties(ՐՏ_60.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_24);
-    var Splat = (ՐՏ_25 = function Splat() {
+        })    })(), ՐՏ_60);
+    var Splat = (ՐՏ_61 = function Splat() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_25, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_61, Statement), (function(){
         var properties = {
             module: "[SymbolVar] name of the module we're splatting",
             key: "[string] The key by which this module is stored in the global modules mapping",
             body: "[TopLevel] parsed contents of the imported file"
         };
-        Object.defineProperties(ՐՏ_25.prototype, {
+        Object.defineProperties(ՐՏ_61.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_25);
-    var Import = (ՐՏ_26 = function Import() {
+        })    })(), ՐՏ_61);
+    var Import = (ՐՏ_62 = function Import() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_26, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_62, Statement), (function(){
         var properties = {
             module: "[SymbolVar] name of the module we're importing",
             key: "[string] The key by which this module is stored in the global modules mapping",
             alias: "[SymbolAlias] The name this module is imported as, can be None. For import x as y statements.",
             argnames: "[ImportedVar*] names of objects to be imported",
-            body: "[TopLevel] parsed contents of the imported file"
+            body: "[Function -> TopLevel] returns parsed contents of the imported file"
         };
-        Object.defineProperties(ՐՏ_26.prototype, {
+        Object.defineProperties(ՐՏ_62.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1470,14 +1300,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_26);
-    var Imports = (ՐՏ_27 = function Imports() {
+        })    })(), ՐՏ_62);
+    var Imports = (ՐՏ_63 = function Imports() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_27, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_63, Statement), (function(){
         var properties = {
             "imports": "[Import+] array of imports"
         };
-        Object.defineProperties(ՐՏ_27.prototype, {
+        Object.defineProperties(ՐՏ_63.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1500,14 +1330,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_27);
-    var Decorator = (ՐՏ_28 = function Decorator() {
+        })    })(), ՐՏ_63);
+    var Decorator = (ՐՏ_64 = function Decorator() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_28, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_64, Node), (function(){
         var properties = {
             expression: "[Node] decorator expression"
         };
-        Object.defineProperties(ՐՏ_28.prototype, {
+        Object.defineProperties(ՐՏ_64.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1524,14 +1354,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_28);
-    var Annotation = (ՐՏ_29 = function Annotation() {
+        })    })(), ՐՏ_64);
+    var Annotation = (ՐՏ_65 = function Annotation() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_29, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_65, Node), (function(){
         var properties = {
             expression: "[Node] decorator expression"
         };
-        Object.defineProperties(ՐՏ_29.prototype, {
+        Object.defineProperties(ՐՏ_65.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1554,16 +1384,16 @@ var ՐՏ_modules = {};
                 value: memoized(function resolveType(heap){
                     var self = this;
                     function parse(obj) {
-                        var ՐՏ_30;
+                        var ՐՏ_66, ՐՏ_67, ՐՏ_68, ՐՏ_69, ՐՏ_70;
                         if (obj instanceof Array) {
                             if (obj.elements.length === 1) {
-                                return "[" + parse(obj.elements[0]) + "]";
+                                return "[" + parse((ՐՏ_66 = obj.elements)[0]) + "]";
                             }
                             return "[?]";
                         }
                         if (obj instanceof ObjectLiteral) {
                             if (obj.properties.length === 1) {
-                                return "{String:" + parse(obj.properties[0].value) + "}";
+                                return "{String:" + parse((ՐՏ_67 = obj.properties)[0].value) + "}";
                             }
                             return "{String:?}";
                         }
@@ -1572,11 +1402,11 @@ var ՐՏ_modules = {};
                         }
                         if (obj instanceof Call) {
                             if (obj.expression instanceof SymbolRef && obj.expression.name === "Array" && obj.args.length === 1) {
-                                return "[" + parse(obj.args[0]) + "]";
+                                return "[" + parse((ՐՏ_68 = obj.args)[0]) + "]";
                             }
                             if (obj.expression instanceof SymbolRef && ՐՏ_in(obj.expression.name, [ "Object", "Dictionary" ])) {
-                                if (1 <= (ՐՏ_30 = obj.args.length) && ՐՏ_30 <= 2) {
-                                    return "{String:" + parse(obj.args[obj.args.length-1]) + "}";
+                                if (1 <= (ՐՏ_69 = obj.args.length) && ՐՏ_69 <= 2) {
+                                    return "{String:" + parse((ՐՏ_70 = obj.args)[ՐՏ_70.length-1]) + "}";
                                 }
                                 return "{String:?}";
                             }
@@ -1587,10 +1417,10 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_29);
-    var Lambda = (ՐՏ_31 = function Lambda() {
+        })    })(), ՐՏ_65);
+    var Lambda = (ՐՏ_71 = function Lambda() {
         Scope.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_31, Scope), (function(){
+    }, ՐՏ_extends(ՐՏ_71, Scope), (function(){
         var properties = {
             name: "[SymbolDeclaration?] the name of this function/class/method",
             argnames: "[SymbolFunarg*] array of arguments",
@@ -1600,7 +1430,7 @@ var ՐՏ_modules = {};
             generator: "[boolean] true if this is a generator function (false by default)",
             return_annotation: "[Annotation?] the return type annotation provided (if any)"
         };
-        Object.defineProperties(ՐՏ_31.prototype, {
+        Object.defineProperties(ՐՏ_71.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1640,13 +1470,13 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_31);
-    var Accessor = (ՐՏ_32 = function Accessor() {
+        })    })(), ՐՏ_71);
+    var Accessor = (ՐՏ_72 = function Accessor() {
         Lambda.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_32, Lambda), ՐՏ_32);
-    var Function = (ՐՏ_33 = function Function() {
+    }, ՐՏ_extends(ՐՏ_72, Lambda), ՐՏ_72);
+    var Function = (ՐՏ_73 = function Function() {
         Lambda.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_33, Lambda), Object.defineProperties(ՐՏ_33.prototype, {
+    }, ՐՏ_extends(ՐՏ_73, Lambda), Object.defineProperties(ՐՏ_73.prototype, {
         resolveType: {
             enumerable: true, 
             writable: true, 
@@ -1692,10 +1522,10 @@ var ՐՏ_modules = {};
             })
 
         }
-    }), ՐՏ_33);
-    var Class = (ՐՏ_34 = function Class() {
+    }), ՐՏ_73);
+    var Class = (ՐՏ_74 = function Class() {
         Scope.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_34, Scope), (function(){
+    }, ՐՏ_extends(ՐՏ_74, Scope), (function(){
         var properties = {
             name: "[SymbolDeclaration?] the name of this class",
             init: "[Function] constructor for the class",
@@ -1707,7 +1537,7 @@ var ՐՏ_modules = {};
             module_id: "[string] The id of the module this class is defined in",
             statements: "[Node*] list of statements in the class scope (excluding method definitions)"
         };
-        Object.defineProperties(ՐՏ_34.prototype, {
+        Object.defineProperties(ՐՏ_74.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1737,59 +1567,59 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_34);
-    var Module = (ՐՏ_35 = function Module() {
+        })    })(), ՐՏ_74);
+    var Module = (ՐՏ_75 = function Module() {
         Scope.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_35, Scope), (function(){
+    }, ՐՏ_extends(ՐՏ_75, Scope), (function(){
         var properties = {
             name: "[SymbolDeclaration?] the name of this class",
             external: "[boolean] true if module is declared elsewhere, but will be within current scope at runtime",
             decorators: "[Decorator*] module decorators, if any"
         };
-        Object.defineProperties(ՐՏ_35.prototype, {
+        Object.defineProperties(ՐՏ_75.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_35);
-    var Method = (ՐՏ_36 = function Method() {
+        })    })(), ՐՏ_75);
+    var Method = (ՐՏ_76 = function Method() {
         Lambda.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_36, Lambda), (function(){
+    }, ՐՏ_extends(ՐՏ_76, Lambda), (function(){
         var properties = {
             static: "[boolean] true if method is static"
         };
-        Object.defineProperties(ՐՏ_36.prototype, {
+        Object.defineProperties(ՐՏ_76.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_36);
-    var Constructor = (ՐՏ_37 = function Constructor() {
+        })    })(), ՐՏ_76);
+    var Constructor = (ՐՏ_77 = function Constructor() {
         Method.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_37, Method), (function(){
+    }, ՐՏ_extends(ՐՏ_77, Method), (function(){
         var properties = {
             callsSuper: "[boolean] true if user manually called super or Parent.__init__",
             parent: "[string?] parent class this class inherits from"
         };
-        Object.defineProperties(ՐՏ_37.prototype, {
+        Object.defineProperties(ՐՏ_77.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_37);
-    var Jump = (ՐՏ_38 = function Jump() {
+        })    })(), ՐՏ_77);
+    var Jump = (ՐՏ_78 = function Jump() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_38, Statement), ՐՏ_38);
-    var Exit = (ՐՏ_39 = function Exit() {
+    }, ՐՏ_extends(ՐՏ_78, Statement), ՐՏ_78);
+    var Exit = (ՐՏ_79 = function Exit() {
         Jump.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_39, Jump), (function(){
+    }, ՐՏ_extends(ՐՏ_79, Jump), (function(){
         var properties = {
             value: "[Node?] the value returned or thrown by this statement; could be null for Return"
         };
-        Object.defineProperties(ՐՏ_39.prototype, {
+        Object.defineProperties(ՐՏ_79.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1817,34 +1647,34 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_39);
-    var Return = (ՐՏ_40 = function Return() {
+        })    })(), ՐՏ_79);
+    var Return = (ՐՏ_80 = function Return() {
         Exit.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_40, Exit), ՐՏ_40);
-    var Yield = (ՐՏ_41 = function Yield() {
+    }, ՐՏ_extends(ՐՏ_80, Exit), ՐՏ_80);
+    var Yield = (ՐՏ_81 = function Yield() {
         Exit.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_41, Exit), (function(){
+    }, ՐՏ_extends(ՐՏ_81, Exit), (function(){
         var properties = {
             yield_from: "[boolean] true if it is `yield from` i.e. JS `yield*` ",
             yield_request: "[boolean] true if some value is requested from `yield`: `a = yield` or `f(yield, ...) ` and so on"
         };
-        Object.defineProperties(ՐՏ_41.prototype, {
+        Object.defineProperties(ՐՏ_81.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_41);
-    var Throw = (ՐՏ_42 = function Throw() {
+        })    })(), ՐՏ_81);
+    var Throw = (ՐՏ_82 = function Throw() {
         Exit.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_42, Exit), ՐՏ_42);
-    var LoopControl = (ՐՏ_43 = function LoopControl() {
+    }, ՐՏ_extends(ՐՏ_82, Exit), ՐՏ_82);
+    var LoopControl = (ՐՏ_83 = function LoopControl() {
         Jump.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_43, Jump), (function(){
+    }, ՐՏ_extends(ՐՏ_83, Jump), (function(){
         var properties = {
             label: "[LabelRef?] the label, or null if none"
         };
-        Object.defineProperties(ՐՏ_43.prototype, {
+        Object.defineProperties(ՐՏ_83.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1863,21 +1693,21 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_43);
-    var Break = (ՐՏ_44 = function Break() {
+        })    })(), ՐՏ_83);
+    var Break = (ՐՏ_84 = function Break() {
         LoopControl.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_44, LoopControl), ՐՏ_44);
-    var Continue = (ՐՏ_45 = function Continue() {
+    }, ՐՏ_extends(ՐՏ_84, LoopControl), ՐՏ_84);
+    var Continue = (ՐՏ_85 = function Continue() {
         LoopControl.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_45, LoopControl), ՐՏ_45);
-    var If = (ՐՏ_46 = function If() {
+    }, ՐՏ_extends(ՐՏ_85, LoopControl), ՐՏ_85);
+    var If = (ՐՏ_86 = function If() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_46, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_86, StatementWithBody), (function(){
         var properties = {
             condition: "[Node] the `if` condition",
             alternative: "[Statement?] the `else` part, or null if not present"
         };
-        Object.defineProperties(ՐՏ_46.prototype, {
+        Object.defineProperties(ՐՏ_86.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1898,14 +1728,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_46);
-    var Switch = (ՐՏ_47 = function Switch() {
+        })    })(), ՐՏ_86);
+    var Switch = (ՐՏ_87 = function Switch() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_47, Block), (function(){
+    }, ՐՏ_extends(ՐՏ_87, Block), (function(){
         var properties = {
             expression: "[Node] the `switch` “discriminant”"
         };
-        Object.defineProperties(ՐՏ_47.prototype, {
+        Object.defineProperties(ՐՏ_87.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1923,20 +1753,20 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_47);
-    var SwitchBranch = (ՐՏ_48 = function SwitchBranch() {
+        })    })(), ՐՏ_87);
+    var SwitchBranch = (ՐՏ_88 = function SwitchBranch() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_48, Block), ՐՏ_48);
-    var Default = (ՐՏ_49 = function Default() {
+    }, ՐՏ_extends(ՐՏ_88, Block), ՐՏ_88);
+    var Default = (ՐՏ_89 = function Default() {
         SwitchBranch.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_49, SwitchBranch), ՐՏ_49);
-    var Case = (ՐՏ_50 = function Case() {
+    }, ՐՏ_extends(ՐՏ_89, SwitchBranch), ՐՏ_89);
+    var Case = (ՐՏ_90 = function Case() {
         SwitchBranch.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_50, SwitchBranch), (function(){
+    }, ՐՏ_extends(ՐՏ_90, SwitchBranch), (function(){
         var properties = {
             expression: "[Node] the `case` expression"
         };
-        Object.defineProperties(ՐՏ_50.prototype, {
+        Object.defineProperties(ՐՏ_90.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1954,15 +1784,15 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_50);
-    var Try = (ՐՏ_51 = function Try() {
+        })    })(), ՐՏ_90);
+    var Try = (ՐՏ_91 = function Try() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_51, Block), (function(){
+    }, ՐՏ_extends(ՐՏ_91, Block), (function(){
         var properties = {
             bcatch: "[Catch?] the catch block, or null if not present",
             bfinally: "[Finally?] the finally block, or null if not present"
         };
-        Object.defineProperties(ՐՏ_51.prototype, {
+        Object.defineProperties(ՐՏ_91.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1985,18 +1815,18 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_51);
-    var Catch = (ՐՏ_52 = function Catch() {
+        })    })(), ՐՏ_91);
+    var Catch = (ՐՏ_92 = function Catch() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_52, Block), ՐՏ_52);
-    var Except = (ՐՏ_53 = function Except() {
+    }, ՐՏ_extends(ՐՏ_92, Block), ՐՏ_92);
+    var Except = (ՐՏ_93 = function Except() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_53, Block), (function(){
+    }, ՐՏ_extends(ՐՏ_93, Block), (function(){
         var properties = {
             argname: "[SymbolCatch] symbol for the exception",
             errors: "[SymbolVar*] error classes to catch in this block"
         };
-        Object.defineProperties(ՐՏ_53.prototype, {
+        Object.defineProperties(ՐՏ_93.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2025,17 +1855,17 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_53);
-    var Finally = (ՐՏ_54 = function Finally() {
+        })    })(), ՐՏ_93);
+    var Finally = (ՐՏ_94 = function Finally() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_54, Block), ՐՏ_54);
-    var Definitions = (ՐՏ_55 = function Definitions() {
+    }, ՐՏ_extends(ՐՏ_94, Block), ՐՏ_94);
+    var Definitions = (ՐՏ_95 = function Definitions() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_55, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_95, Statement), (function(){
         var properties = {
             definitions: "[VarDef*] array of variable definitions"
         };
-        Object.defineProperties(ՐՏ_55.prototype, {
+        Object.defineProperties(ՐՏ_95.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2058,21 +1888,21 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_55);
-    var Var = (ՐՏ_56 = function Var() {
+        })    })(), ՐՏ_95);
+    var Var = (ՐՏ_96 = function Var() {
         Definitions.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_56, Definitions), ՐՏ_56);
-    var Const = (ՐՏ_57 = function Const() {
+    }, ՐՏ_extends(ՐՏ_96, Definitions), ՐՏ_96);
+    var Const = (ՐՏ_97 = function Const() {
         Definitions.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_57, Definitions), ՐՏ_57);
-    var VarDef = (ՐՏ_58 = function VarDef() {
+    }, ՐՏ_extends(ՐՏ_97, Definitions), ՐՏ_97);
+    var VarDef = (ՐՏ_98 = function VarDef() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_58, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_98, Node), (function(){
         var properties = {
             name: "[SymbolVar|SymbolConst] name of the variable",
             value: "[Node?] initializer, or null if there's no initializer"
         };
-        Object.defineProperties(ՐՏ_58.prototype, {
+        Object.defineProperties(ՐՏ_98.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2092,27 +1922,27 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_58);
-    var BaseCall = (ՐՏ_59 = function BaseCall() {
+        })    })(), ՐՏ_98);
+    var BaseCall = (ՐՏ_99 = function BaseCall() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_59, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_99, Node), (function(){
         var properties = {
             args: "[Node*] array of arguments"
         };
-        Object.defineProperties(ՐՏ_59.prototype, {
+        Object.defineProperties(ՐՏ_99.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_59);
-    var Call = (ՐՏ_60 = function Call() {
+        })    })(), ՐՏ_99);
+    var Call = (ՐՏ_100 = function Call() {
         BaseCall.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_60, BaseCall), (function(){
+    }, ՐՏ_extends(ՐՏ_100, BaseCall), (function(){
         var properties = {
             expression: "[Node] expression to invoke as function"
         };
-        Object.defineProperties(ՐՏ_60.prototype, {
+        Object.defineProperties(ՐՏ_100.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2124,7 +1954,7 @@ var ՐՏ_modules = {};
                 value: function _walk(visitor){
                     var self = this;
                     return visitor._visit(self, function() {
-                        var ՐՏitr19, ՐՏidx19, ՐՏitr20, ՐՏidx20, ՐՏitr21, ՐՏidx21;
+                        var ՐՏitr19, ՐՏidx19, ՐՏitr20, ՐՏidx20, ՐՏ_101, ՐՏ_102, ՐՏitr21, ՐՏidx21;
                         var arg;
                         self.expression._walk(visitor);
                         ՐՏitr19 = ՐՏ_Iterable(self.args);
@@ -2136,8 +1966,8 @@ var ՐՏ_modules = {};
                             ՐՏitr20 = ՐՏ_Iterable(self.args.kwargs);
                             for (ՐՏidx20 = 0; ՐՏidx20 < ՐՏitr20.length; ՐՏidx20++) {
                                 arg = ՐՏitr20[ՐՏidx20];
-                                arg[0]._walk(visitor);
-                                arg[1]._walk(visitor);
+                                (ՐՏ_101 = arg)[0]._walk(visitor);
+                                (ՐՏ_102 = arg)[1]._walk(visitor);
                             }
                         }
                         if (self.args.kwarg_items) {
@@ -2155,7 +1985,7 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: memoized(function resolveType(heap){
-                    var ՐՏitr22, ՐՏidx22;
+                    var ՐՏitr22, ՐՏidx22, ՐՏ_103, ՐՏ_104, ՐՏ_105, ՐՏ_106, ՐՏ_107, ՐՏ_108, ՐՏ_109, ՐՏ_110, ՐՏ_111, ՐՏ_112, ՐՏ_113;
                     var self = this;
                     var scope, exp_name, parse, result;
                     if (self.expression instanceof SymbolRef) {
@@ -2163,13 +1993,13 @@ var ՐՏ_modules = {};
                         for (ՐՏidx22 = 0; ՐՏidx22 < ՐՏitr22.length; ՐՏidx22++) {
                             scope = ՐՏitr22[ՐՏidx22];
                             exp_name = self.expression.name;
-                            if (ՐՏ_in(exp_name, scope.vars) && scope.vars[exp_name][scope.vars[exp_name].length-1] && ՐՏ_in("->", scope.vars[exp_name][scope.vars[exp_name].length-1])) {
-                                return scope.vars[exp_name][scope.vars[exp_name].length-1].split("->")[1].trim();
-                            } else if (ՐՏ_in(exp_name, scope.functions) && scope.functions[exp_name] && ՐՏ_in("->", scope.functions[exp_name])) {
-                                return scope.functions[exp_name].split("->")[1].trim();
+                            if (ՐՏ_in(exp_name, scope.vars) && (ՐՏ_103 = (ՐՏ_104 = scope.vars)[exp_name])[ՐՏ_103.length-1] && ՐՏ_in("->", (ՐՏ_105 = (ՐՏ_106 = scope.vars)[exp_name])[ՐՏ_105.length-1])) {
+                                return (ՐՏ_107 = (ՐՏ_108 = (ՐՏ_109 = scope.vars)[exp_name])[ՐՏ_108.length-1].split("->"))[1].trim();
+                            } else if (ՐՏ_in(exp_name, scope.functions) && (ՐՏ_110 = scope.functions)[exp_name] && ՐՏ_in("->", (ՐՏ_111 = scope.functions)[exp_name])) {
+                                return (ՐՏ_112 = (ՐՏ_113 = scope.functions)[exp_name].split("->"))[1].trim();
                             } else if (scope.type === "function" && exp_name === scope.name && scope.return) {
                                 parse = function(variable) {
-                                    var ՐՏ_61;
+                                    var ՐՏ_114, ՐՏ_115, ՐՏ_116, ՐՏ_117, ՐՏ_118, ՐՏ_119, ՐՏ_120;
                                     var wrap, wrapper, element, result;
                                     wrap = {
                                         "array": function(value) {
@@ -2188,22 +2018,22 @@ var ՐՏ_modules = {};
                                             return;
                                         }
                                         wrapper = "array";
-                                        element = variable.elements[0];
+                                        element = (ՐՏ_114 = variable.elements)[0];
                                     } else if (variable instanceof Call && variable.expression instanceof SymbolRef && variable.expression.name === "Array") {
                                         if (variable.args.length !== 1) {
                                             return;
                                         }
                                         wrapper = "array";
-                                        element = variable.args[0];
+                                        element = (ՐՏ_115 = variable.args)[0];
                                     } else if (variable instanceof ObjectLiteral) {
                                         if (variable.properties.length !== 1) {
                                             return;
                                         }
                                         wrapper = "dict";
-                                        element = variable.properties[0].value;
+                                        element = (ՐՏ_116 = variable.properties)[0].value;
                                     } else if (variable instanceof Call && variable.expression instanceof SymbolRef && ՐՏ_in(variable.expression.name, [ "Object", "Dictionary" ])) {
-                                        if (1 <= (ՐՏ_61 = variable.args.length) && ՐՏ_61 <= 2) {
-                                            element = variable.args[variable.args.length-1];
+                                        if (1 <= (ՐՏ_117 = variable.args.length) && ՐՏ_117 <= 2) {
+                                            element = (ՐՏ_118 = variable.args)[ՐՏ_118.length-1];
                                             wrapper = "dict";
                                         } else {
                                             return;
@@ -2212,11 +2042,11 @@ var ՐՏ_modules = {};
                                         element = variable;
                                     }
                                     if (element instanceof SymbolRef && ՐՏ_in(element.name, NATIVE_CLASSES)) {
-                                        return wrap[wrapper](element.name);
+                                        return (ՐՏ_119 = wrap)[wrapper](element.name);
                                     } else if (element instanceof Array || element instanceof ObjectLiteral || element instanceof Call) {
                                         result = parse(element);
                                         if (result) {
-                                            return wrap[wrapper](result);
+                                            return (ՐՏ_120 = wrap)[wrapper](result);
                                         }
                                     }
                                 };
@@ -2231,17 +2061,17 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_60);
-    var ClassCall = (ՐՏ_62 = function ClassCall() {
+        })    })(), ՐՏ_100);
+    var ClassCall = (ՐՏ_121 = function ClassCall() {
         BaseCall.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_62, BaseCall), (function(){
+    }, ՐՏ_extends(ՐՏ_121, BaseCall), (function(){
         var properties = {
             class: "[string] name of the class method belongs to",
             super: "[boolean] this call can be replaced with a super() call",
             method: "[string] class method being called",
             static: "[boolean] defines whether the method is static"
         };
-        Object.defineProperties(ՐՏ_62.prototype, {
+        Object.defineProperties(ՐՏ_121.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2253,7 +2083,7 @@ var ՐՏ_modules = {};
                 value: function _walk(visitor){
                     var self = this;
                     return visitor._visit(self, function() {
-                        var ՐՏitr23, ՐՏidx23, ՐՏitr24, ՐՏidx24, ՐՏitr25, ՐՏidx25;
+                        var ՐՏitr23, ՐՏidx23, ՐՏitr24, ՐՏidx24, ՐՏ_122, ՐՏ_123, ՐՏitr25, ՐՏidx25;
                         var arg;
                         if (self.expression) {
                             self.expression._walk(visitor);
@@ -2266,8 +2096,8 @@ var ՐՏ_modules = {};
                         ՐՏitr24 = ՐՏ_Iterable(self.args.kwargs);
                         for (ՐՏidx24 = 0; ՐՏidx24 < ՐՏitr24.length; ՐՏidx24++) {
                             arg = ՐՏitr24[ՐՏidx24];
-                            arg[0]._walk(visitor);
-                            arg[1]._walk(visitor);
+                            (ՐՏ_122 = arg)[0]._walk(visitor);
+                            (ՐՏ_123 = arg)[1]._walk(visitor);
                         }
                         ՐՏitr25 = ՐՏ_Iterable(self.args.kwarg_items);
                         for (ՐՏidx25 = 0; ՐՏidx25 < ՐՏitr25.length; ՐՏidx25++) {
@@ -2278,18 +2108,18 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_62);
-    var New = (ՐՏ_63 = function New() {
+        })    })(), ՐՏ_121);
+    var New = (ՐՏ_124 = function New() {
         Call.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_63, Call), ՐՏ_63);
-    var Seq = (ՐՏ_64 = function Seq() {
+    }, ՐՏ_extends(ՐՏ_124, Call), ՐՏ_124);
+    var Seq = (ՐՏ_125 = function Seq() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_64, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_125, Node), (function(){
         var properties = {
             car: "[Node] first element in sequence",
             cdr: "[Node] second element in sequence"
         };
-        Object.defineProperties(ՐՏ_64.prototype, {
+        Object.defineProperties(ՐՏ_125.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2312,20 +2142,20 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: function from_array(array){
-                    var ՐՏitr26, ՐՏidx26;
+                    var ՐՏ_126, ՐՏitr26, ՐՏidx26, ՐՏ_127;
                     var self = this;
                     var list, i, p;
                     if (array.length === 0) {
                         return null;
                     }
                     if (array.length === 1) {
-                        return array[0].clone();
+                        return (ՐՏ_126 = array)[0].clone();
                     }
                     list = null;
                     ՐՏitr26 = ՐՏ_Iterable(range(array.length - 1, -1, -1));
                     for (ՐՏidx26 = 0; ՐՏidx26 < ՐՏitr26.length; ՐՏidx26++) {
                         i = ՐՏitr26[ՐՏidx26];
-                        list = Seq.prototype.cons.call(array[i], list);
+                        list = Seq.prototype.cons.call((ՐՏ_127 = array)[i], list);
                     }
                     p = list;
                     while (p) {
@@ -2390,24 +2220,24 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_64);
-    var PropAccess = (ՐՏ_65 = function PropAccess() {
+        })    })(), ՐՏ_125);
+    var PropAccess = (ՐՏ_128 = function PropAccess() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_65, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_128, Node), (function(){
         var properties = {
             expression: "[Node] the “container” expression",
             property: "[Node|string] the property to access. For Dot this is always a plain string, while for Sub it's an arbitrary Node"
         };
-        Object.defineProperties(ՐՏ_65.prototype, {
+        Object.defineProperties(ՐՏ_128.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_65);
-    var Dot = (ՐՏ_66 = function Dot() {
+        })    })(), ՐՏ_128);
+    var Dot = (ՐՏ_129 = function Dot() {
         PropAccess.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_66, PropAccess), Object.defineProperties(ՐՏ_66.prototype, {
+    }, ՐՏ_extends(ՐՏ_129, PropAccess), Object.defineProperties(ՐՏ_129.prototype, {
         _walk: {
             enumerable: true, 
             writable: true, 
@@ -2423,20 +2253,21 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: memoized(function resolveType(heap){
+                var ՐՏ_130, ՐՏ_131;
                 var self = this;
                 var containerType;
                 containerType = self.expression.resolveType(heap);
-                if (containerType && containerType[0] === "{") {
-                    return /\{\w+:(.*)\}/.exec(containerType)[1];
+                if (containerType && (ՐՏ_130 = containerType)[0] === "{") {
+                    return (ՐՏ_131 = /\{\w+:(.*)\}/.exec(containerType))[1];
                 }
                 return "?";
             })
 
         }
-    }), ՐՏ_66);
-    var Sub = (ՐՏ_67 = function Sub() {
+    }), ՐՏ_129);
+    var Sub = (ՐՏ_132 = function Sub() {
         PropAccess.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_67, PropAccess), Object.defineProperties(ՐՏ_67.prototype, {
+    }, ՐՏ_extends(ՐՏ_132, PropAccess), Object.defineProperties(ՐՏ_132.prototype, {
         _walk: {
             enumerable: true, 
             writable: true, 
@@ -2453,30 +2284,31 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: memoized(function resolveType(heap){
+                var ՐՏ_133, ՐՏ_134, ՐՏ_135, ՐՏ_136;
                 var self = this;
                 var containerType;
                 containerType = self.expression.resolveType(heap);
                 if (containerType) {
-                    if (containerType[0] === "[" && self.property instanceof Number) {
-                        return /\[(.*)\]/.exec(containerType)[1];
+                    if ((ՐՏ_133 = containerType)[0] === "[" && self.property instanceof Number) {
+                        return (ՐՏ_134 = /\[(.*)\]/.exec(containerType))[1];
                     }
-                    if (containerType[0] === "{") {
-                        return /\{\w+:(.*)\}/.exec(containerType)[1];
+                    if ((ՐՏ_135 = containerType)[0] === "{") {
+                        return (ՐՏ_136 = /\{\w+:(.*)\}/.exec(containerType))[1];
                     }
                 }
                 return "?";
             })
 
         }
-    }), ՐՏ_67);
-    var Slice = (ՐՏ_68 = function Slice() {
+    }), ՐՏ_132);
+    var Slice = (ՐՏ_137 = function Slice() {
         PropAccess.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_68, PropAccess), (function(){
+    }, ՐՏ_extends(ՐՏ_137, PropAccess), (function(){
         var properties = {
             property2: "[Node] the 2nd property to access - typically ending index for the array.",
             assignment: "[Node] The data being spliced in."
         };
-        Object.defineProperties(ՐՏ_68.prototype, {
+        Object.defineProperties(ՐՏ_137.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2504,15 +2336,15 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_68);
-    var Unary = (ՐՏ_69 = function Unary() {
+        })    })(), ՐՏ_137);
+    var Unary = (ՐՏ_138 = function Unary() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_69, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_138, Node), (function(){
         var properties = {
             operator: "[string] the operator",
             expression: "[Node] expression that this unary operator applies to"
         };
-        Object.defineProperties(ՐՏ_69.prototype, {
+        Object.defineProperties(ՐՏ_138.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2544,22 +2376,22 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_69);
-    var UnaryPrefix = (ՐՏ_70 = function UnaryPrefix() {
+        })    })(), ՐՏ_138);
+    var UnaryPrefix = (ՐՏ_139 = function UnaryPrefix() {
         Unary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_70, Unary), ՐՏ_70);
-    var UnaryPostfix = (ՐՏ_71 = function UnaryPostfix() {
+    }, ՐՏ_extends(ՐՏ_139, Unary), ՐՏ_139);
+    var UnaryPostfix = (ՐՏ_140 = function UnaryPostfix() {
         Unary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_71, Unary), ՐՏ_71);
-    var Binary = (ՐՏ_72 = function Binary() {
+    }, ՐՏ_extends(ՐՏ_140, Unary), ՐՏ_140);
+    var Binary = (ՐՏ_141 = function Binary() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_72, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_141, Node), (function(){
         var properties = {
             left: "[Node] left-hand side expression",
             operator: "[string] the operator",
             right: "[Node] right-hand side expression"
         };
-        Object.defineProperties(ՐՏ_72.prototype, {
+        Object.defineProperties(ՐՏ_141.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2601,10 +2433,10 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_72);
-    var Range = (ՐՏ_73 = function Range() {
+        })    })(), ՐՏ_141);
+    var Range = (ՐՏ_142 = function Range() {
         Binary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_73, Binary), Object.defineProperties(ՐՏ_73.prototype, {
+    }, ՐՏ_extends(ՐՏ_142, Binary), Object.defineProperties(ՐՏ_142.prototype, {
         resolveType: {
             enumerable: true, 
             writable: true, 
@@ -2614,10 +2446,10 @@ var ՐՏ_modules = {};
             })
 
         }
-    }), ՐՏ_73);
-    var DeepEquality = (ՐՏ_74 = function DeepEquality() {
+    }), ՐՏ_142);
+    var DeepEquality = (ՐՏ_143 = function DeepEquality() {
         Binary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_74, Binary), Object.defineProperties(ՐՏ_74.prototype, {
+    }, ՐՏ_extends(ՐՏ_143, Binary), Object.defineProperties(ՐՏ_143.prototype, {
         resolveType: {
             enumerable: true, 
             writable: true, 
@@ -2627,16 +2459,16 @@ var ՐՏ_modules = {};
             })
 
         }
-    }), ՐՏ_74);
-    var Conditional = (ՐՏ_75 = function Conditional() {
+    }), ՐՏ_143);
+    var Conditional = (ՐՏ_144 = function Conditional() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_75, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_144, Node), (function(){
         var properties = {
             condition: "[Node] test to run before deciding the return value",
             consequent: "[Node] return expression in the event on truthy test evaluation",
             alternative: "[Node] return expression in the event of falsy test evaluation"
         };
-        Object.defineProperties(ՐՏ_75.prototype, {
+        Object.defineProperties(ՐՏ_144.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2666,10 +2498,10 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_75);
-    var Assign = (ՐՏ_76 = function Assign() {
+        })    })(), ՐՏ_144);
+    var Assign = (ՐՏ_145 = function Assign() {
         Binary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_76, Binary), Object.defineProperties(ՐՏ_76.prototype, {
+    }, ՐՏ_extends(ՐՏ_145, Binary), Object.defineProperties(ՐՏ_145.prototype, {
         resolveType: {
             enumerable: true, 
             writable: true, 
@@ -2682,14 +2514,14 @@ var ՐՏ_modules = {};
             })
 
         }
-    }), ՐՏ_76);
-    var Array = (ՐՏ_77 = function Array() {
+    }), ՐՏ_145);
+    var Array = (ՐՏ_146 = function Array() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_77, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_146, Node), (function(){
         var properties = {
             elements: "[Node*] array of elements"
         };
-        Object.defineProperties(ՐՏ_77.prototype, {
+        Object.defineProperties(ՐՏ_146.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2716,13 +2548,13 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: memoized(function resolveType(heap){
-                    var ՐՏitr28, ՐՏidx28;
+                    var ՐՏ_147, ՐՏitr28, ՐՏidx28;
                     var self = this;
                     var expected, element, current;
                     if (!self.elements.length) {
                         return "[?]";
                     }
-                    expected = self.elements[0].resolveType(heap);
+                    expected = (ՐՏ_147 = self.elements)[0].resolveType(heap);
                     if (!expected) {
                         return "[?]";
                     }
@@ -2741,15 +2573,15 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_77);
-    var TupleUnpack = (ՐՏ_78 = function TupleUnpack() {
+        })    })(), ՐՏ_146);
+    var TupleUnpack = (ՐՏ_148 = function TupleUnpack() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_78, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_148, Node), (function(){
         var properties = {
             elements: "[Node*] array of elements being assigned to",
             right: "[Node] right-hand side expression"
         };
-        Object.defineProperties(ՐՏ_78.prototype, {
+        Object.defineProperties(ՐՏ_148.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2773,14 +2605,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_78);
-    var ObjectLiteral = (ՐՏ_79 = function ObjectLiteral() {
+        })    })(), ՐՏ_148);
+    var ObjectLiteral = (ՐՏ_149 = function ObjectLiteral() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_79, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_149, Node), (function(){
         var properties = {
             properties: "[ObjectProperty*] array of properties"
         };
-        Object.defineProperties(ՐՏ_79.prototype, {
+        Object.defineProperties(ՐՏ_149.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2807,7 +2639,7 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: memoized(function resolveType(heap){
-                    var ՐՏitr31, ՐՏidx31;
+                    var ՐՏ_150, ՐՏ_151, ՐՏ_152, ՐՏitr31, ՐՏidx31;
                     var self = this;
                     var start, spread, expected, element, current, result;
                     if (!self.properties.length) {
@@ -2815,14 +2647,14 @@ var ՐՏ_modules = {};
                     }
                     start = 0;
                     spread = null;
-                    while (self.properties[start] instanceof UnaryPrefix) {
-                        spread = self.properties[start].expression.resolveType(heap);
+                    while ((ՐՏ_150 = self.properties)[start] instanceof UnaryPrefix) {
+                        spread = (ՐՏ_151 = self.properties)[start].expression.resolveType(heap);
                         if (ՐՏ_in("?", spread)) {
                             return "{String:?}";
                         }
                         ++start;
                     }
-                    expected = self.properties[start].value.resolveType(heap);
+                    expected = (ՐՏ_152 = self.properties)[start].value.resolveType(heap);
                     if (!expected) {
                         return "{String:?}";
                     }
@@ -2863,15 +2695,15 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_79);
-    var ObjectProperty = (ՐՏ_80 = function ObjectProperty() {
+        })    })(), ՐՏ_149);
+    var ObjectProperty = (ՐՏ_153 = function ObjectProperty() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_80, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_153, Node), (function(){
         var properties = {
             key: "[Node] the property name or expression for computed key ",
             value: "[Node] property value. For setters and getters this is an Function."
         };
-        Object.defineProperties(ՐՏ_80.prototype, {
+        Object.defineProperties(ՐՏ_153.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2889,127 +2721,127 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_80);
-    var ObjectKeyVal = (ՐՏ_81 = function ObjectKeyVal() {
+        })    })(), ՐՏ_153);
+    var ObjectKeyVal = (ՐՏ_154 = function ObjectKeyVal() {
         ObjectProperty.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_81, ObjectProperty), ՐՏ_81);
-    var ObjectSetter = (ՐՏ_82 = function ObjectSetter() {
+    }, ՐՏ_extends(ՐՏ_154, ObjectProperty), ՐՏ_154);
+    var ObjectSetter = (ՐՏ_155 = function ObjectSetter() {
         Accessor.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_82, Accessor), ՐՏ_82);
-    var ObjectGetter = (ՐՏ_83 = function ObjectGetter() {
+    }, ՐՏ_extends(ՐՏ_155, Accessor), ՐՏ_155);
+    var ObjectGetter = (ՐՏ_156 = function ObjectGetter() {
         Accessor.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_83, Accessor), ՐՏ_83);
-    var Symbol = (ՐՏ_84 = function Symbol() {
+    }, ՐՏ_extends(ՐՏ_156, Accessor), ՐՏ_156);
+    var Symbol = (ՐՏ_157 = function Symbol() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_84, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_157, Node), (function(){
         var properties = {
             name: "[string] name of this symbol",
             scope: "[Scope/S] the current scope (not necessarily the definition scope)",
             thedef: "[SymbolDef/S] the definition of this symbol"
         };
-        Object.defineProperties(ՐՏ_84.prototype, {
+        Object.defineProperties(ՐՏ_157.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_84);
-    var SymbolAlias = (ՐՏ_85 = function SymbolAlias() {
+        })    })(), ՐՏ_157);
+    var SymbolAlias = (ՐՏ_158 = function SymbolAlias() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_85, Symbol), ՐՏ_85);
-    var SymbolDeclaration = (ՐՏ_86 = function SymbolDeclaration() {
+    }, ՐՏ_extends(ՐՏ_158, Symbol), ՐՏ_158);
+    var SymbolDeclaration = (ՐՏ_159 = function SymbolDeclaration() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_86, Symbol), (function(){
+    }, ՐՏ_extends(ՐՏ_159, Symbol), (function(){
         var properties = {
             init: "[Node*/S] array of initializers for this declaration."
         };
-        Object.defineProperties(ՐՏ_86.prototype, {
+        Object.defineProperties(ՐՏ_159.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_86);
-    var SymbolVar = (ՐՏ_87 = function SymbolVar() {
+        })    })(), ՐՏ_159);
+    var SymbolVar = (ՐՏ_160 = function SymbolVar() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_87, SymbolDeclaration), ՐՏ_87);
-    var SymbolNonlocal = (ՐՏ_88 = function SymbolNonlocal() {
+    }, ՐՏ_extends(ՐՏ_160, SymbolDeclaration), ՐՏ_160);
+    var SymbolNonlocal = (ՐՏ_161 = function SymbolNonlocal() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_88, SymbolDeclaration), ՐՏ_88);
-    var ImportedVar = (ՐՏ_89 = function ImportedVar() {
+    }, ՐՏ_extends(ՐՏ_161, SymbolDeclaration), ՐՏ_161);
+    var ImportedVar = (ՐՏ_162 = function ImportedVar() {
         SymbolVar.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_89, SymbolVar), (function(){
+    }, ՐՏ_extends(ՐՏ_162, SymbolVar), (function(){
         var properties = {
             alias: "SymbolAlias the alias for this imported symbol"
         };
-        Object.defineProperties(ՐՏ_89.prototype, {
+        Object.defineProperties(ՐՏ_162.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_89);
-    var SymbolConst = (ՐՏ_90 = function SymbolConst() {
+        })    })(), ՐՏ_162);
+    var SymbolConst = (ՐՏ_163 = function SymbolConst() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_90, SymbolDeclaration), ՐՏ_90);
-    var SymbolFunarg = (ՐՏ_91 = function SymbolFunarg() {
+    }, ՐՏ_extends(ՐՏ_163, SymbolDeclaration), ՐՏ_163);
+    var SymbolFunarg = (ՐՏ_164 = function SymbolFunarg() {
         SymbolVar.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_91, SymbolVar), (function(){
+    }, ՐՏ_extends(ՐՏ_164, SymbolVar), (function(){
         var properties = {
             annotation: "[Annotation?] annotation provided for this argument, if any"
         };
-        Object.defineProperties(ՐՏ_91.prototype, {
+        Object.defineProperties(ՐՏ_164.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_91);
-    var SymbolClass = (ՐՏ_92 = function SymbolClass() {
+        })    })(), ՐՏ_164);
+    var SymbolClass = (ՐՏ_165 = function SymbolClass() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_92, SymbolDeclaration), ՐՏ_92);
-    var SymbolDefun = (ՐՏ_93 = function SymbolDefun() {
+    }, ՐՏ_extends(ՐՏ_165, SymbolDeclaration), ՐՏ_165);
+    var SymbolDefun = (ՐՏ_166 = function SymbolDefun() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_93, SymbolDeclaration), (function(){
+    }, ՐՏ_extends(ՐՏ_166, SymbolDeclaration), (function(){
         var properties = {
             js_reserved: "[boolean/S] If True, the method name must be omitted and defined as anonymous function (does matter in es5 only)"
         };
-        Object.defineProperties(ՐՏ_93.prototype, {
+        Object.defineProperties(ՐՏ_166.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_93);
-    var SymbolAccessor = (ՐՏ_94 = function SymbolAccessor() {
+        })    })(), ՐՏ_166);
+    var SymbolAccessor = (ՐՏ_167 = function SymbolAccessor() {
         SymbolDefun.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_94, SymbolDefun), ՐՏ_94);
-    var SymbolLambda = (ՐՏ_95 = function SymbolLambda() {
+    }, ՐՏ_extends(ՐՏ_167, SymbolDefun), ՐՏ_167);
+    var SymbolLambda = (ՐՏ_168 = function SymbolLambda() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_95, SymbolDeclaration), ՐՏ_95);
-    var SymbolCatch = (ՐՏ_96 = function SymbolCatch() {
+    }, ՐՏ_extends(ՐՏ_168, SymbolDeclaration), ՐՏ_168);
+    var SymbolCatch = (ՐՏ_169 = function SymbolCatch() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_96, SymbolDeclaration), ՐՏ_96);
-    var Label = (ՐՏ_97 = function Label() {
+    }, ՐՏ_extends(ՐՏ_169, SymbolDeclaration), ՐՏ_169);
+    var Label = (ՐՏ_170 = function Label() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_97, Symbol), (function(){
+    }, ՐՏ_extends(ՐՏ_170, Symbol), (function(){
         var properties = {
             references: "[LabelRef*] a list of nodes referring to this label"
         };
-        Object.defineProperties(ՐՏ_97.prototype, {
+        Object.defineProperties(ՐՏ_170.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_97);
-    var SymbolRef = (ՐՏ_98 = function SymbolRef() {
+        })    })(), ՐՏ_170);
+    var SymbolRef = (ՐՏ_171 = function SymbolRef() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_98, Symbol), (function(){
+    }, ՐՏ_extends(ՐՏ_171, Symbol), (function(){
         var properties = {
             parens: "[boolean/S] if true, this variable is wrapped in parentheses"
         };
-        Object.defineProperties(ՐՏ_98.prototype, {
+        Object.defineProperties(ՐՏ_171.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3019,46 +2851,46 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: memoized(function resolveType(heap){
-                    var ՐՏitr32, ՐՏidx32;
+                    var ՐՏitr32, ՐՏidx32, ՐՏ_172, ՐՏ_173, ՐՏ_174;
                     var self = this;
                     var scope;
                     ՐՏitr32 = ՐՏ_Iterable(reversed(heap));
                     for (ՐՏidx32 = 0; ՐՏidx32 < ՐՏitr32.length; ՐՏidx32++) {
                         scope = ՐՏitr32[ՐՏidx32];
                         if (ՐՏ_in(self.name, scope.vars)) {
-                            return scope.vars[self.name][scope.vars[self.name].length-1];
+                            return (ՐՏ_172 = (ՐՏ_173 = scope.vars)[self.name])[ՐՏ_172.length-1];
                         }
                         if (scope.args && ՐՏ_in(self.name, scope.args)) {
-                            return scope.args[self.name];
+                            return (ՐՏ_174 = scope.args)[self.name];
                         }
                     }
                     return "?";
                 })
 
             }
-        })    })(), ՐՏ_98);
-    var SymbolClassRef = (ՐՏ_99 = function SymbolClassRef() {
+        })    })(), ՐՏ_171);
+    var SymbolClassRef = (ՐՏ_175 = function SymbolClassRef() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_99, Symbol), (function(){
+    }, ՐՏ_extends(ՐՏ_175, Symbol), (function(){
         var properties = {
             class: "[SymbolDeclaration?] the name of this class"
         };
-        Object.defineProperties(ՐՏ_99.prototype, {
+        Object.defineProperties(ՐՏ_175.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_99);
-    var LabelRef = (ՐՏ_100 = function LabelRef() {
+        })    })(), ՐՏ_175);
+    var LabelRef = (ՐՏ_176 = function LabelRef() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_100, Symbol), ՐՏ_100);
-    var This = (ՐՏ_101 = function This() {
+    }, ՐՏ_extends(ՐՏ_176, Symbol), ՐՏ_176);
+    var This = (ՐՏ_177 = function This() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_101, Symbol), ՐՏ_101);
-    var Constant = (ՐՏ_102 = function Constant() {
+    }, ՐՏ_extends(ՐՏ_177, Symbol), ՐՏ_177);
+    var Constant = (ՐՏ_178 = function Constant() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_102, Node), Object.defineProperties(ՐՏ_102.prototype, {
+    }, ՐՏ_extends(ՐՏ_178, Node), Object.defineProperties(ՐՏ_178.prototype, {
         getValue: {
             enumerable: true, 
             writable: true, 
@@ -3068,15 +2900,15 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_102);
-    var String = (ՐՏ_103 = function String() {
+    }), ՐՏ_178);
+    var String = (ՐՏ_179 = function String() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_103, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_179, Constant), (function(){
         var properties = {
             value: "[string] the contents of this string",
             modifier: "[string] string type modifier"
         };
-        Object.defineProperties(ՐՏ_103.prototype, {
+        Object.defineProperties(ՐՏ_179.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3091,14 +2923,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_103);
-    var Verbatim = (ՐՏ_104 = function Verbatim() {
+        })    })(), ՐՏ_179);
+    var Verbatim = (ՐՏ_180 = function Verbatim() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_104, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_180, Constant), (function(){
         var properties = {
             value: "[string] A string of raw JS code"
         };
-        Object.defineProperties(ՐՏ_104.prototype, {
+        Object.defineProperties(ՐՏ_180.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3113,14 +2945,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_104);
-    var Number = (ՐՏ_105 = function Number() {
+        })    })(), ՐՏ_180);
+    var Number = (ՐՏ_181 = function Number() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_105, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_181, Constant), (function(){
         var properties = {
             value: "[number] the numeric value"
         };
-        Object.defineProperties(ՐՏ_105.prototype, {
+        Object.defineProperties(ՐՏ_181.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3135,14 +2967,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_105);
-    var Identifier = (ՐՏ_106 = function Identifier() {
+        })    })(), ՐՏ_181);
+    var Identifier = (ՐՏ_182 = function Identifier() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_106, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_182, Constant), (function(){
         var properties = {
             value: "[string] the name of this key"
         };
-        Object.defineProperties(ՐՏ_106.prototype, {
+        Object.defineProperties(ՐՏ_182.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3157,14 +2989,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_106);
-    var RegExp = (ՐՏ_107 = function RegExp() {
+        })    })(), ՐՏ_182);
+    var RegExp = (ՐՏ_183 = function RegExp() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_107, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_183, Constant), (function(){
         var properties = {
             value: "[RegExp] the actual regexp"
         };
-        Object.defineProperties(ՐՏ_107.prototype, {
+        Object.defineProperties(ՐՏ_183.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3179,15 +3011,15 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_107);
-    var Atom = (ՐՏ_108 = function Atom() {
+        })    })(), ՐՏ_183);
+    var Atom = (ՐՏ_184 = function Atom() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_108, Constant), ՐՏ_108);
-    var Null = (ՐՏ_109 = function Null() {
+    }, ՐՏ_extends(ՐՏ_184, Constant), ՐՏ_184);
+    var Null = (ՐՏ_185 = function Null() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_109, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_185, Atom), (function(){
         var value = null;
-        Object.defineProperties(ՐՏ_109.prototype, {
+        Object.defineProperties(ՐՏ_185.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3202,12 +3034,12 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_109);
-    var NotANumber = (ՐՏ_110 = function NotANumber() {
+        })    })(), ՐՏ_185);
+    var NotANumber = (ՐՏ_186 = function NotANumber() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_110, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_186, Atom), (function(){
         var value = 0 / 0;
-        Object.defineProperties(ՐՏ_110.prototype, {
+        Object.defineProperties(ՐՏ_186.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3222,12 +3054,12 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_110);
-    var Undefined = (ՐՏ_111 = function Undefined() {
+        })    })(), ՐՏ_186);
+    var Undefined = (ՐՏ_187 = function Undefined() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_111, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_187, Atom), (function(){
         var value = void 0;
-        Object.defineProperties(ՐՏ_111.prototype, {
+        Object.defineProperties(ՐՏ_187.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3242,12 +3074,12 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_111);
-    var Hole = (ՐՏ_112 = function Hole() {
+        })    })(), ՐՏ_187);
+    var Hole = (ՐՏ_188 = function Hole() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_112, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_188, Atom), (function(){
         var value = void 0;
-        Object.defineProperties(ՐՏ_112.prototype, {
+        Object.defineProperties(ՐՏ_188.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3262,12 +3094,12 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_112);
-    var Infinity = (ՐՏ_113 = function Infinity() {
+        })    })(), ՐՏ_188);
+    var Infinity = (ՐՏ_189 = function Infinity() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_113, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_189, Atom), (function(){
         var value = 1 / 0;
-        Object.defineProperties(ՐՏ_113.prototype, {
+        Object.defineProperties(ՐՏ_189.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3282,14 +3114,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_113);
-    var Boolean = (ՐՏ_114 = function Boolean() {
+        })    })(), ՐՏ_189);
+    var Boolean = (ՐՏ_190 = function Boolean() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_114, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_190, Atom), (function(){
         var properties = {
             value: "[boolean] value"
         };
-        Object.defineProperties(ՐՏ_114.prototype, {
+        Object.defineProperties(ՐՏ_190.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3304,10 +3136,10 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_114);
-    var TreeWalker = (ՐՏ_115 = function TreeWalker() {
+        })    })(), ՐՏ_190);
+    var TreeWalker = (ՐՏ_191 = function TreeWalker() {
         TreeWalker.prototype.__init__.apply(this, arguments);
-    }, Object.defineProperties(ՐՏ_115.prototype, {
+    }, Object.defineProperties(ՐՏ_191.prototype, {
         __init__: {
             enumerable: true, 
             writable: true, 
@@ -3340,8 +3172,9 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function parent(n){
+                var ՐՏ_192;
                 var self = this;
-                return self.stack[self.stack.length - 2 - (n || 0)];
+                return (ՐՏ_192 = self.stack)[self.stack.length - 2 - (n || 0)];
             }
 
         },
@@ -3367,8 +3200,9 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function self(){
+                var ՐՏ_193;
                 var self = this;
-                return self.stack[self.stack.length - 1];
+                return (ՐՏ_193 = self.stack)[self.stack.length - 1];
             }
 
         },
@@ -3376,14 +3210,14 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function find_parent(type){
-                var ՐՏitr33, ՐՏidx33;
+                var ՐՏitr33, ՐՏidx33, ՐՏ_194;
                 var self = this;
                 var stack, i, x;
                 stack = self.stack;
                 ՐՏitr33 = ՐՏ_Iterable(range(stack.length - 1, -1, -1));
                 for (ՐՏidx33 = 0; ՐՏidx33 < ՐՏitr33.length; ՐՏidx33++) {
                     i = ՐՏitr33[ՐՏidx33];
-                    x = stack[i];
+                    x = (ՐՏ_194 = stack)[i];
                     if (x instanceof type) {
                         return x;
                     }
@@ -3395,13 +3229,14 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function in_boolean_context(){
+                var ՐՏ_195, ՐՏ_196;
                 var self = this;
                 var stack, i, p;
                 stack = self.stack;
                 i = stack.length;
-                self = stack[--i];
+                self = (ՐՏ_195 = stack)[--i];
                 while (i > 0) {
-                    p = stack[--i];
+                    p = (ՐՏ_196 = stack)[--i];
                     if (p instanceof If && p.condition === self || p instanceof Conditional && p.condition === self || p instanceof DWLoop && p.condition === self || p instanceof UnaryPrefix && p.operator === "!" && p.expression === self) {
                         return true;
                     }
@@ -3417,7 +3252,7 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function loopcontrol_target(label){
-                var ՐՏitr34, ՐՏidx34, ՐՏitr35, ՐՏidx35;
+                var ՐՏitr34, ՐՏidx34, ՐՏ_197, ՐՏitr35, ՐՏidx35, ՐՏ_198;
                 var self = this;
                 var stack, i, x;
                 stack = self.stack;
@@ -3425,7 +3260,7 @@ var ՐՏ_modules = {};
                     ՐՏitr34 = ՐՏ_Iterable(range(stack.length - 1, -1, -1));
                     for (ՐՏidx34 = 0; ՐՏidx34 < ՐՏitr34.length; ՐՏidx34++) {
                         i = ՐՏitr34[ՐՏidx34];
-                        x = stack[i];
+                        x = (ՐՏ_197 = stack)[i];
                         if (x instanceof LabeledStatement && x.label.name === label.name) {
                             return x.body;
                         }
@@ -3434,7 +3269,7 @@ var ՐՏ_modules = {};
                     ՐՏitr35 = ՐՏ_Iterable(range(stack.length - 1, -1, -1));
                     for (ՐՏidx35 = 0; ՐՏidx35 < ՐՏitr35.length; ՐՏidx35++) {
                         i = ՐՏitr35[ՐՏidx35];
-                        x = stack[i];
+                        x = (ՐՏ_198 = stack)[i];
                         if (x instanceof Switch || x instanceof ForIn || x instanceof DWLoop) {
                             return x;
                         }
@@ -3443,131 +3278,131 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_115);
-    ՐՏ_modules["ast"]["memoized"] = memoized;
-    ՐՏ_modules["ast"]["AST"] = AST;
-    ՐՏ_modules["ast"]["Token"] = Token;
-    ՐՏ_modules["ast"]["Node"] = Node;
-    ՐՏ_modules["ast"]["Statement"] = Statement;
-    ՐՏ_modules["ast"]["Debugger"] = Debugger;
-    ՐՏ_modules["ast"]["Directive"] = Directive;
-    ՐՏ_modules["ast"]["SimpleStatement"] = SimpleStatement;
-    ՐՏ_modules["ast"]["walk_body"] = walk_body;
-    ՐՏ_modules["ast"]["Block"] = Block;
-    ՐՏ_modules["ast"]["BlockStatement"] = BlockStatement;
-    ՐՏ_modules["ast"]["EmptyStatement"] = EmptyStatement;
-    ՐՏ_modules["ast"]["StatementWithBody"] = StatementWithBody;
-    ՐՏ_modules["ast"]["LabeledStatement"] = LabeledStatement;
-    ՐՏ_modules["ast"]["DWLoop"] = DWLoop;
-    ՐՏ_modules["ast"]["Do"] = Do;
-    ՐՏ_modules["ast"]["While"] = While;
-    ՐՏ_modules["ast"]["ForIn"] = ForIn;
-    ՐՏ_modules["ast"]["ForJS"] = ForJS;
-    ՐՏ_modules["ast"]["ListComprehension"] = ListComprehension;
-    ՐՏ_modules["ast"]["DictComprehension"] = DictComprehension;
-    ՐՏ_modules["ast"]["With"] = With;
-    ՐՏ_modules["ast"]["Scope"] = Scope;
-    ՐՏ_modules["ast"]["TopLevel"] = TopLevel;
-    ՐՏ_modules["ast"]["Splat"] = Splat;
-    ՐՏ_modules["ast"]["Import"] = Import;
-    ՐՏ_modules["ast"]["Imports"] = Imports;
-    ՐՏ_modules["ast"]["Decorator"] = Decorator;
-    ՐՏ_modules["ast"]["Annotation"] = Annotation;
-    ՐՏ_modules["ast"]["Lambda"] = Lambda;
-    ՐՏ_modules["ast"]["Accessor"] = Accessor;
-    ՐՏ_modules["ast"]["Function"] = Function;
-    ՐՏ_modules["ast"]["Class"] = Class;
-    ՐՏ_modules["ast"]["Module"] = Module;
-    ՐՏ_modules["ast"]["Method"] = Method;
-    ՐՏ_modules["ast"]["Constructor"] = Constructor;
-    ՐՏ_modules["ast"]["Jump"] = Jump;
-    ՐՏ_modules["ast"]["Exit"] = Exit;
-    ՐՏ_modules["ast"]["Return"] = Return;
-    ՐՏ_modules["ast"]["Yield"] = Yield;
-    ՐՏ_modules["ast"]["Throw"] = Throw;
-    ՐՏ_modules["ast"]["LoopControl"] = LoopControl;
-    ՐՏ_modules["ast"]["Break"] = Break;
-    ՐՏ_modules["ast"]["Continue"] = Continue;
-    ՐՏ_modules["ast"]["If"] = If;
-    ՐՏ_modules["ast"]["Switch"] = Switch;
-    ՐՏ_modules["ast"]["SwitchBranch"] = SwitchBranch;
-    ՐՏ_modules["ast"]["Default"] = Default;
-    ՐՏ_modules["ast"]["Case"] = Case;
-    ՐՏ_modules["ast"]["Try"] = Try;
-    ՐՏ_modules["ast"]["Catch"] = Catch;
-    ՐՏ_modules["ast"]["Except"] = Except;
-    ՐՏ_modules["ast"]["Finally"] = Finally;
-    ՐՏ_modules["ast"]["Definitions"] = Definitions;
-    ՐՏ_modules["ast"]["Var"] = Var;
-    ՐՏ_modules["ast"]["Const"] = Const;
-    ՐՏ_modules["ast"]["VarDef"] = VarDef;
-    ՐՏ_modules["ast"]["BaseCall"] = BaseCall;
-    ՐՏ_modules["ast"]["Call"] = Call;
-    ՐՏ_modules["ast"]["ClassCall"] = ClassCall;
-    ՐՏ_modules["ast"]["New"] = New;
-    ՐՏ_modules["ast"]["Seq"] = Seq;
-    ՐՏ_modules["ast"]["PropAccess"] = PropAccess;
-    ՐՏ_modules["ast"]["Dot"] = Dot;
-    ՐՏ_modules["ast"]["Sub"] = Sub;
-    ՐՏ_modules["ast"]["Slice"] = Slice;
-    ՐՏ_modules["ast"]["Unary"] = Unary;
-    ՐՏ_modules["ast"]["UnaryPrefix"] = UnaryPrefix;
-    ՐՏ_modules["ast"]["UnaryPostfix"] = UnaryPostfix;
-    ՐՏ_modules["ast"]["Binary"] = Binary;
-    ՐՏ_modules["ast"]["Range"] = Range;
-    ՐՏ_modules["ast"]["DeepEquality"] = DeepEquality;
-    ՐՏ_modules["ast"]["Conditional"] = Conditional;
-    ՐՏ_modules["ast"]["Assign"] = Assign;
-    ՐՏ_modules["ast"]["Array"] = Array;
-    ՐՏ_modules["ast"]["TupleUnpack"] = TupleUnpack;
-    ՐՏ_modules["ast"]["ObjectLiteral"] = ObjectLiteral;
-    ՐՏ_modules["ast"]["ObjectProperty"] = ObjectProperty;
-    ՐՏ_modules["ast"]["ObjectKeyVal"] = ObjectKeyVal;
-    ՐՏ_modules["ast"]["ObjectSetter"] = ObjectSetter;
-    ՐՏ_modules["ast"]["ObjectGetter"] = ObjectGetter;
-    ՐՏ_modules["ast"]["Symbol"] = Symbol;
-    ՐՏ_modules["ast"]["SymbolAlias"] = SymbolAlias;
-    ՐՏ_modules["ast"]["SymbolDeclaration"] = SymbolDeclaration;
-    ՐՏ_modules["ast"]["SymbolVar"] = SymbolVar;
-    ՐՏ_modules["ast"]["SymbolNonlocal"] = SymbolNonlocal;
-    ՐՏ_modules["ast"]["ImportedVar"] = ImportedVar;
-    ՐՏ_modules["ast"]["SymbolConst"] = SymbolConst;
-    ՐՏ_modules["ast"]["SymbolFunarg"] = SymbolFunarg;
-    ՐՏ_modules["ast"]["SymbolClass"] = SymbolClass;
-    ՐՏ_modules["ast"]["SymbolDefun"] = SymbolDefun;
-    ՐՏ_modules["ast"]["SymbolAccessor"] = SymbolAccessor;
-    ՐՏ_modules["ast"]["SymbolLambda"] = SymbolLambda;
-    ՐՏ_modules["ast"]["SymbolCatch"] = SymbolCatch;
-    ՐՏ_modules["ast"]["Label"] = Label;
-    ՐՏ_modules["ast"]["SymbolRef"] = SymbolRef;
-    ՐՏ_modules["ast"]["SymbolClassRef"] = SymbolClassRef;
-    ՐՏ_modules["ast"]["LabelRef"] = LabelRef;
-    ՐՏ_modules["ast"]["This"] = This;
-    ՐՏ_modules["ast"]["Constant"] = Constant;
-    ՐՏ_modules["ast"]["String"] = String;
-    ՐՏ_modules["ast"]["Verbatim"] = Verbatim;
-    ՐՏ_modules["ast"]["Number"] = Number;
-    ՐՏ_modules["ast"]["Identifier"] = Identifier;
-    ՐՏ_modules["ast"]["RegExp"] = RegExp;
-    ՐՏ_modules["ast"]["Atom"] = Atom;
-    ՐՏ_modules["ast"]["Null"] = Null;
-    ՐՏ_modules["ast"]["NotANumber"] = NotANumber;
-    ՐՏ_modules["ast"]["Undefined"] = Undefined;
-    ՐՏ_modules["ast"]["Hole"] = Hole;
-    ՐՏ_modules["ast"]["Infinity"] = Infinity;
-    ՐՏ_modules["ast"]["Boolean"] = Boolean;
-    ՐՏ_modules["ast"]["TreeWalker"] = TreeWalker;
-})();
+    }), ՐՏ_191);
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:ast"];
+    ՐՏ_mod.export("memoized", function(){return memoized;}, function(ՐՏ_v){if (typeof memoized !== "undefined") {memoized = ՐՏ_v;};});
+    ՐՏ_mod.export("AST", function(){return AST;}, function(ՐՏ_v){if (typeof AST !== "undefined") {AST = ՐՏ_v;};});
+    ՐՏ_mod.export("Token", function(){return Token;}, function(ՐՏ_v){if (typeof Token !== "undefined") {Token = ՐՏ_v;};});
+    ՐՏ_mod.export("Node", function(){return Node;}, function(ՐՏ_v){if (typeof Node !== "undefined") {Node = ՐՏ_v;};});
+    ՐՏ_mod.export("Statement", function(){return Statement;}, function(ՐՏ_v){if (typeof Statement !== "undefined") {Statement = ՐՏ_v;};});
+    ՐՏ_mod.export("Debugger", function(){return Debugger;}, function(ՐՏ_v){if (typeof Debugger !== "undefined") {Debugger = ՐՏ_v;};});
+    ՐՏ_mod.export("Directive", function(){return Directive;}, function(ՐՏ_v){if (typeof Directive !== "undefined") {Directive = ՐՏ_v;};});
+    ՐՏ_mod.export("SimpleStatement", function(){return SimpleStatement;}, function(ՐՏ_v){if (typeof SimpleStatement !== "undefined") {SimpleStatement = ՐՏ_v;};});
+    ՐՏ_mod.export("walk_body", function(){return walk_body;}, function(ՐՏ_v){if (typeof walk_body !== "undefined") {walk_body = ՐՏ_v;};});
+    ՐՏ_mod.export("Block", function(){return Block;}, function(ՐՏ_v){if (typeof Block !== "undefined") {Block = ՐՏ_v;};});
+    ՐՏ_mod.export("BlockStatement", function(){return BlockStatement;}, function(ՐՏ_v){if (typeof BlockStatement !== "undefined") {BlockStatement = ՐՏ_v;};});
+    ՐՏ_mod.export("EmptyStatement", function(){return EmptyStatement;}, function(ՐՏ_v){if (typeof EmptyStatement !== "undefined") {EmptyStatement = ՐՏ_v;};});
+    ՐՏ_mod.export("StatementWithBody", function(){return StatementWithBody;}, function(ՐՏ_v){if (typeof StatementWithBody !== "undefined") {StatementWithBody = ՐՏ_v;};});
+    ՐՏ_mod.export("LabeledStatement", function(){return LabeledStatement;}, function(ՐՏ_v){if (typeof LabeledStatement !== "undefined") {LabeledStatement = ՐՏ_v;};});
+    ՐՏ_mod.export("DWLoop", function(){return DWLoop;}, function(ՐՏ_v){if (typeof DWLoop !== "undefined") {DWLoop = ՐՏ_v;};});
+    ՐՏ_mod.export("Do", function(){return Do;}, function(ՐՏ_v){if (typeof Do !== "undefined") {Do = ՐՏ_v;};});
+    ՐՏ_mod.export("While", function(){return While;}, function(ՐՏ_v){if (typeof While !== "undefined") {While = ՐՏ_v;};});
+    ՐՏ_mod.export("ForIn", function(){return ForIn;}, function(ՐՏ_v){if (typeof ForIn !== "undefined") {ForIn = ՐՏ_v;};});
+    ՐՏ_mod.export("ForJS", function(){return ForJS;}, function(ՐՏ_v){if (typeof ForJS !== "undefined") {ForJS = ՐՏ_v;};});
+    ՐՏ_mod.export("ListComprehension", function(){return ListComprehension;}, function(ՐՏ_v){if (typeof ListComprehension !== "undefined") {ListComprehension = ՐՏ_v;};});
+    ՐՏ_mod.export("DictComprehension", function(){return DictComprehension;}, function(ՐՏ_v){if (typeof DictComprehension !== "undefined") {DictComprehension = ՐՏ_v;};});
+    ՐՏ_mod.export("With", function(){return With;}, function(ՐՏ_v){if (typeof With !== "undefined") {With = ՐՏ_v;};});
+    ՐՏ_mod.export("Scope", function(){return Scope;}, function(ՐՏ_v){if (typeof Scope !== "undefined") {Scope = ՐՏ_v;};});
+    ՐՏ_mod.export("TopLevel", function(){return TopLevel;}, function(ՐՏ_v){if (typeof TopLevel !== "undefined") {TopLevel = ՐՏ_v;};});
+    ՐՏ_mod.export("Splat", function(){return Splat;}, function(ՐՏ_v){if (typeof Splat !== "undefined") {Splat = ՐՏ_v;};});
+    ՐՏ_mod.export("Import", function(){return Import;}, function(ՐՏ_v){if (typeof Import !== "undefined") {Import = ՐՏ_v;};});
+    ՐՏ_mod.export("Imports", function(){return Imports;}, function(ՐՏ_v){if (typeof Imports !== "undefined") {Imports = ՐՏ_v;};});
+    ՐՏ_mod.export("Decorator", function(){return Decorator;}, function(ՐՏ_v){if (typeof Decorator !== "undefined") {Decorator = ՐՏ_v;};});
+    ՐՏ_mod.export("Annotation", function(){return Annotation;}, function(ՐՏ_v){if (typeof Annotation !== "undefined") {Annotation = ՐՏ_v;};});
+    ՐՏ_mod.export("Lambda", function(){return Lambda;}, function(ՐՏ_v){if (typeof Lambda !== "undefined") {Lambda = ՐՏ_v;};});
+    ՐՏ_mod.export("Accessor", function(){return Accessor;}, function(ՐՏ_v){if (typeof Accessor !== "undefined") {Accessor = ՐՏ_v;};});
+    ՐՏ_mod.export("Function", function(){return Function;}, function(ՐՏ_v){if (typeof Function !== "undefined") {Function = ՐՏ_v;};});
+    ՐՏ_mod.export("Class", function(){return Class;}, function(ՐՏ_v){if (typeof Class !== "undefined") {Class = ՐՏ_v;};});
+    ՐՏ_mod.export("Module", function(){return Module;}, function(ՐՏ_v){if (typeof Module !== "undefined") {Module = ՐՏ_v;};});
+    ՐՏ_mod.export("Method", function(){return Method;}, function(ՐՏ_v){if (typeof Method !== "undefined") {Method = ՐՏ_v;};});
+    ՐՏ_mod.export("Constructor", function(){return Constructor;}, function(ՐՏ_v){if (typeof Constructor !== "undefined") {Constructor = ՐՏ_v;};});
+    ՐՏ_mod.export("Jump", function(){return Jump;}, function(ՐՏ_v){if (typeof Jump !== "undefined") {Jump = ՐՏ_v;};});
+    ՐՏ_mod.export("Exit", function(){return Exit;}, function(ՐՏ_v){if (typeof Exit !== "undefined") {Exit = ՐՏ_v;};});
+    ՐՏ_mod.export("Return", function(){return Return;}, function(ՐՏ_v){if (typeof Return !== "undefined") {Return = ՐՏ_v;};});
+    ՐՏ_mod.export("Yield", function(){return Yield;}, function(ՐՏ_v){if (typeof Yield !== "undefined") {Yield = ՐՏ_v;};});
+    ՐՏ_mod.export("Throw", function(){return Throw;}, function(ՐՏ_v){if (typeof Throw !== "undefined") {Throw = ՐՏ_v;};});
+    ՐՏ_mod.export("LoopControl", function(){return LoopControl;}, function(ՐՏ_v){if (typeof LoopControl !== "undefined") {LoopControl = ՐՏ_v;};});
+    ՐՏ_mod.export("Break", function(){return Break;}, function(ՐՏ_v){if (typeof Break !== "undefined") {Break = ՐՏ_v;};});
+    ՐՏ_mod.export("Continue", function(){return Continue;}, function(ՐՏ_v){if (typeof Continue !== "undefined") {Continue = ՐՏ_v;};});
+    ՐՏ_mod.export("If", function(){return If;}, function(ՐՏ_v){if (typeof If !== "undefined") {If = ՐՏ_v;};});
+    ՐՏ_mod.export("Switch", function(){return Switch;}, function(ՐՏ_v){if (typeof Switch !== "undefined") {Switch = ՐՏ_v;};});
+    ՐՏ_mod.export("SwitchBranch", function(){return SwitchBranch;}, function(ՐՏ_v){if (typeof SwitchBranch !== "undefined") {SwitchBranch = ՐՏ_v;};});
+    ՐՏ_mod.export("Default", function(){return Default;}, function(ՐՏ_v){if (typeof Default !== "undefined") {Default = ՐՏ_v;};});
+    ՐՏ_mod.export("Case", function(){return Case;}, function(ՐՏ_v){if (typeof Case !== "undefined") {Case = ՐՏ_v;};});
+    ՐՏ_mod.export("Try", function(){return Try;}, function(ՐՏ_v){if (typeof Try !== "undefined") {Try = ՐՏ_v;};});
+    ՐՏ_mod.export("Catch", function(){return Catch;}, function(ՐՏ_v){if (typeof Catch !== "undefined") {Catch = ՐՏ_v;};});
+    ՐՏ_mod.export("Except", function(){return Except;}, function(ՐՏ_v){if (typeof Except !== "undefined") {Except = ՐՏ_v;};});
+    ՐՏ_mod.export("Finally", function(){return Finally;}, function(ՐՏ_v){if (typeof Finally !== "undefined") {Finally = ՐՏ_v;};});
+    ՐՏ_mod.export("Definitions", function(){return Definitions;}, function(ՐՏ_v){if (typeof Definitions !== "undefined") {Definitions = ՐՏ_v;};});
+    ՐՏ_mod.export("Var", function(){return Var;}, function(ՐՏ_v){if (typeof Var !== "undefined") {Var = ՐՏ_v;};});
+    ՐՏ_mod.export("Const", function(){return Const;}, function(ՐՏ_v){if (typeof Const !== "undefined") {Const = ՐՏ_v;};});
+    ՐՏ_mod.export("VarDef", function(){return VarDef;}, function(ՐՏ_v){if (typeof VarDef !== "undefined") {VarDef = ՐՏ_v;};});
+    ՐՏ_mod.export("BaseCall", function(){return BaseCall;}, function(ՐՏ_v){if (typeof BaseCall !== "undefined") {BaseCall = ՐՏ_v;};});
+    ՐՏ_mod.export("Call", function(){return Call;}, function(ՐՏ_v){if (typeof Call !== "undefined") {Call = ՐՏ_v;};});
+    ՐՏ_mod.export("ClassCall", function(){return ClassCall;}, function(ՐՏ_v){if (typeof ClassCall !== "undefined") {ClassCall = ՐՏ_v;};});
+    ՐՏ_mod.export("New", function(){return New;}, function(ՐՏ_v){if (typeof New !== "undefined") {New = ՐՏ_v;};});
+    ՐՏ_mod.export("Seq", function(){return Seq;}, function(ՐՏ_v){if (typeof Seq !== "undefined") {Seq = ՐՏ_v;};});
+    ՐՏ_mod.export("PropAccess", function(){return PropAccess;}, function(ՐՏ_v){if (typeof PropAccess !== "undefined") {PropAccess = ՐՏ_v;};});
+    ՐՏ_mod.export("Dot", function(){return Dot;}, function(ՐՏ_v){if (typeof Dot !== "undefined") {Dot = ՐՏ_v;};});
+    ՐՏ_mod.export("Sub", function(){return Sub;}, function(ՐՏ_v){if (typeof Sub !== "undefined") {Sub = ՐՏ_v;};});
+    ՐՏ_mod.export("Slice", function(){return Slice;}, function(ՐՏ_v){if (typeof Slice !== "undefined") {Slice = ՐՏ_v;};});
+    ՐՏ_mod.export("Unary", function(){return Unary;}, function(ՐՏ_v){if (typeof Unary !== "undefined") {Unary = ՐՏ_v;};});
+    ՐՏ_mod.export("UnaryPrefix", function(){return UnaryPrefix;}, function(ՐՏ_v){if (typeof UnaryPrefix !== "undefined") {UnaryPrefix = ՐՏ_v;};});
+    ՐՏ_mod.export("UnaryPostfix", function(){return UnaryPostfix;}, function(ՐՏ_v){if (typeof UnaryPostfix !== "undefined") {UnaryPostfix = ՐՏ_v;};});
+    ՐՏ_mod.export("Binary", function(){return Binary;}, function(ՐՏ_v){if (typeof Binary !== "undefined") {Binary = ՐՏ_v;};});
+    ՐՏ_mod.export("Range", function(){return Range;}, function(ՐՏ_v){if (typeof Range !== "undefined") {Range = ՐՏ_v;};});
+    ՐՏ_mod.export("DeepEquality", function(){return DeepEquality;}, function(ՐՏ_v){if (typeof DeepEquality !== "undefined") {DeepEquality = ՐՏ_v;};});
+    ՐՏ_mod.export("Conditional", function(){return Conditional;}, function(ՐՏ_v){if (typeof Conditional !== "undefined") {Conditional = ՐՏ_v;};});
+    ՐՏ_mod.export("Assign", function(){return Assign;}, function(ՐՏ_v){if (typeof Assign !== "undefined") {Assign = ՐՏ_v;};});
+    ՐՏ_mod.export("Array", function(){return Array;}, function(ՐՏ_v){if (typeof Array !== "undefined") {Array = ՐՏ_v;};});
+    ՐՏ_mod.export("TupleUnpack", function(){return TupleUnpack;}, function(ՐՏ_v){if (typeof TupleUnpack !== "undefined") {TupleUnpack = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectLiteral", function(){return ObjectLiteral;}, function(ՐՏ_v){if (typeof ObjectLiteral !== "undefined") {ObjectLiteral = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectProperty", function(){return ObjectProperty;}, function(ՐՏ_v){if (typeof ObjectProperty !== "undefined") {ObjectProperty = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectKeyVal", function(){return ObjectKeyVal;}, function(ՐՏ_v){if (typeof ObjectKeyVal !== "undefined") {ObjectKeyVal = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectSetter", function(){return ObjectSetter;}, function(ՐՏ_v){if (typeof ObjectSetter !== "undefined") {ObjectSetter = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectGetter", function(){return ObjectGetter;}, function(ՐՏ_v){if (typeof ObjectGetter !== "undefined") {ObjectGetter = ՐՏ_v;};});
+    ՐՏ_mod.export("Symbol", function(){return Symbol;}, function(ՐՏ_v){if (typeof Symbol !== "undefined") {Symbol = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolAlias", function(){return SymbolAlias;}, function(ՐՏ_v){if (typeof SymbolAlias !== "undefined") {SymbolAlias = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolDeclaration", function(){return SymbolDeclaration;}, function(ՐՏ_v){if (typeof SymbolDeclaration !== "undefined") {SymbolDeclaration = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolVar", function(){return SymbolVar;}, function(ՐՏ_v){if (typeof SymbolVar !== "undefined") {SymbolVar = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolNonlocal", function(){return SymbolNonlocal;}, function(ՐՏ_v){if (typeof SymbolNonlocal !== "undefined") {SymbolNonlocal = ՐՏ_v;};});
+    ՐՏ_mod.export("ImportedVar", function(){return ImportedVar;}, function(ՐՏ_v){if (typeof ImportedVar !== "undefined") {ImportedVar = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolConst", function(){return SymbolConst;}, function(ՐՏ_v){if (typeof SymbolConst !== "undefined") {SymbolConst = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolFunarg", function(){return SymbolFunarg;}, function(ՐՏ_v){if (typeof SymbolFunarg !== "undefined") {SymbolFunarg = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolClass", function(){return SymbolClass;}, function(ՐՏ_v){if (typeof SymbolClass !== "undefined") {SymbolClass = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolDefun", function(){return SymbolDefun;}, function(ՐՏ_v){if (typeof SymbolDefun !== "undefined") {SymbolDefun = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolAccessor", function(){return SymbolAccessor;}, function(ՐՏ_v){if (typeof SymbolAccessor !== "undefined") {SymbolAccessor = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolLambda", function(){return SymbolLambda;}, function(ՐՏ_v){if (typeof SymbolLambda !== "undefined") {SymbolLambda = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolCatch", function(){return SymbolCatch;}, function(ՐՏ_v){if (typeof SymbolCatch !== "undefined") {SymbolCatch = ՐՏ_v;};});
+    ՐՏ_mod.export("Label", function(){return Label;}, function(ՐՏ_v){if (typeof Label !== "undefined") {Label = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolRef", function(){return SymbolRef;}, function(ՐՏ_v){if (typeof SymbolRef !== "undefined") {SymbolRef = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolClassRef", function(){return SymbolClassRef;}, function(ՐՏ_v){if (typeof SymbolClassRef !== "undefined") {SymbolClassRef = ՐՏ_v;};});
+    ՐՏ_mod.export("LabelRef", function(){return LabelRef;}, function(ՐՏ_v){if (typeof LabelRef !== "undefined") {LabelRef = ՐՏ_v;};});
+    ՐՏ_mod.export("This", function(){return This;}, function(ՐՏ_v){if (typeof This !== "undefined") {This = ՐՏ_v;};});
+    ՐՏ_mod.export("Constant", function(){return Constant;}, function(ՐՏ_v){if (typeof Constant !== "undefined") {Constant = ՐՏ_v;};});
+    ՐՏ_mod.export("String", function(){return String;}, function(ՐՏ_v){if (typeof String !== "undefined") {String = ՐՏ_v;};});
+    ՐՏ_mod.export("Verbatim", function(){return Verbatim;}, function(ՐՏ_v){if (typeof Verbatim !== "undefined") {Verbatim = ՐՏ_v;};});
+    ՐՏ_mod.export("Number", function(){return Number;}, function(ՐՏ_v){if (typeof Number !== "undefined") {Number = ՐՏ_v;};});
+    ՐՏ_mod.export("Identifier", function(){return Identifier;}, function(ՐՏ_v){if (typeof Identifier !== "undefined") {Identifier = ՐՏ_v;};});
+    ՐՏ_mod.export("RegExp", function(){return RegExp;}, function(ՐՏ_v){if (typeof RegExp !== "undefined") {RegExp = ՐՏ_v;};});
+    ՐՏ_mod.export("Atom", function(){return Atom;}, function(ՐՏ_v){if (typeof Atom !== "undefined") {Atom = ՐՏ_v;};});
+    ՐՏ_mod.export("Null", function(){return Null;}, function(ՐՏ_v){if (typeof Null !== "undefined") {Null = ՐՏ_v;};});
+    ՐՏ_mod.export("NotANumber", function(){return NotANumber;}, function(ՐՏ_v){if (typeof NotANumber !== "undefined") {NotANumber = ՐՏ_v;};});
+    ՐՏ_mod.export("Undefined", function(){return Undefined;}, function(ՐՏ_v){if (typeof Undefined !== "undefined") {Undefined = ՐՏ_v;};});
+    ՐՏ_mod.export("Hole", function(){return Hole;}, function(ՐՏ_v){if (typeof Hole !== "undefined") {Hole = ՐՏ_v;};});
+    ՐՏ_mod.export("Infinity", function(){return Infinity;}, function(ՐՏ_v){if (typeof Infinity !== "undefined") {Infinity = ՐՏ_v;};});
+    ՐՏ_mod.export("Boolean", function(){return Boolean;}, function(ՐՏ_v){if (typeof Boolean !== "undefined") {Boolean = ՐՏ_v;};});
+    ՐՏ_mod.export("TreeWalker", function(){return TreeWalker;}, function(ՐՏ_v){if (typeof TreeWalker !== "undefined") {TreeWalker = ՐՏ_v;};});
+    ՐՏ_mod.export("colored", function(){return colored;}, function(ՐՏ_v){if (typeof colored !== "undefined") {colored = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:tokenizer"].body = function(){
     var __name__ = "tokenizer";
 
     var ES6_KEYWORDS, COMMON_KEYWORDS, JS_KEYWORDS, JS_KEYWORDS_AUTOFIX, RS_KEYWORDS, KEYWORDS, KEYWORDS_ATOM, RESERVED_WORDS, KEYWORDS_BEFORE_EXPRESSION, ALL_KEYWORDS, ALL_JS_KEYWORDS, IS_ANY_KEYWORD, OPERATOR_CHARS, RE_HEX_NUMBER, RE_OCT_NUMBER, RE_DEC_NUMBER, OPERATORS, OP_MAP, WHITESPACE_CHARS, PUNC_BEFORE_EXPRESSION, PUNC_CHARS, REGEXP_MODIFIERS, UNICODE, IDENTIFIER_PAT, STRING_MODIFIERS, UNARY_POSTFIX, PRECEDENCE, EX_EOF;
-    var makePredicate = ՐՏ_modules["utils"].makePredicate;
-    var ParseError = ՐՏ_modules["utils"].ParseError;
-    
+    var makePredicate = ՐՏ_modules["utils"].makePredicate;var ParseError = ՐՏ_modules["utils"].ParseError;
     var ast = ՐՏ_modules["ast"];
-    
     function characters(str_) {
         return str_.split("");
     }
@@ -3617,11 +3452,12 @@ var ՐՏ_modules = {};
     STRING_MODIFIERS = "urfvURFV";
     UNARY_POSTFIX = makePredicate([ "--", "++" ]);
     PRECEDENCE = function(a, ret) {
+        var ՐՏ_199, ՐՏ_200, ՐՏ_201;
         var i, b, j;
         for (i = 0; i < a.length; i++) {
-            b = a[i];
+            b = (ՐՏ_199 = a)[i];
             for (j = 0; j < b.length; j++) {
-                ret[b[j]] = i + 1;
+                (ՐՏ_200 = ret)[(ՐՏ_201 = b)[j]] = i + 1;
             }
         }
         return ret;
@@ -3674,10 +3510,11 @@ var ՐՏ_modules = {};
         }
     }
     function is_token(token, type, val) {
+        var ՐՏ_202, ՐՏ_203;
         var type_subtype, subtype;
         type_subtype = type.split(":");
-        type = type_subtype[0];
-        subtype = type_subtype[1];
+        type = (ՐՏ_202 = type_subtype)[0];
+        subtype = (ՐՏ_203 = type_subtype)[1];
         return token.type === type && (subtype ? token.subtype === subtype : true) && (val === null || val === void 0 || Array.isArray(val) && val.indexOf(token.value) >= 0 || token.value === val);
     }
     function js_error(message, filename, line, col, pos, is_eof) {
@@ -3691,7 +3528,7 @@ var ՐՏ_modules = {};
     }
     EX_EOF = {};
     function tokenizer($TEXT, filename) {
-        var ՐՏ_116, ՐՏ_117, ՐՏ_118;
+        var ՐՏ_218, ՐՏ_222, ՐՏ_225;
         var S;
         S = {
             text: $TEXT.replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/\uFEFF/g, ""),
@@ -3750,19 +3587,20 @@ var ՐՏ_modules = {};
             S.tokpos = S.pos;
         }
         function token(full_type, value, is_comment, keep_newline) {
+            var ՐՏ_204, ՐՏ_205, ՐՏ_206, ՐՏ_207, ՐՏ_208, ՐՏ_209, ՐՏ_210, ՐՏ_211, ՐՏ_212, ՐՏ_213, ՐՏ_214, ՐՏ_215;
             var _full_type, type, subtype, _value, ret, block_expect, i, top_scope;
             _full_type = full_type.split(":");
-            type = _full_type[0];
-            subtype = _full_type[1];
+            type = (ՐՏ_204 = _full_type)[0];
+            subtype = (ՐՏ_205 = _full_type)[1];
             _value = null;
-            S.regex_allowed = type === "operator" && !UNARY_POSTFIX[value] || type === "keyword" && KEYWORDS_BEFORE_EXPRESSION(value) || type === "punc" && PUNC_BEFORE_EXPRESSION(value);
+            S.regex_allowed = type === "operator" && !(ՐՏ_206 = UNARY_POSTFIX)[value] || type === "keyword" && KEYWORDS_BEFORE_EXPRESSION(value) || type === "punc" && PUNC_BEFORE_EXPRESSION(value);
             if (type === "operator" && value === "is" && S.text.substr(S.pos).trimLeft().substr(0, 4).trimRight() === "not") {
                 next_token();
                 value = "!==";
             }
-            if (type === "operator" && OP_MAP[value]) {
+            if (type === "operator" && (ՐՏ_207 = OP_MAP)[value]) {
                 _value = value;
-                value = OP_MAP[value];
+                value = (ՐՏ_208 = OP_MAP)[value];
             }
             ret = {
                 type: type,
@@ -3779,7 +3617,7 @@ var ՐՏ_modules = {};
             };
             S.comma_expect = false;
             if (!S.block_expect) {
-                S.block_expect = S.in_scope[S.in_scope.length-1] === "{}" && (S.prev.type === "keyword" && S.prev.value === "def" && (value === "(" || ՐՏ_in(type, [ "name", "string", "num" ]) || full_type === "operator:keyword") || S.prev.type === "name" && ՐՏ_in(S.prev.value, [ "get", "set" ]) && (ՐՏ_in(type, [ "name", "string", "num" ]) || full_type === "operator:keyword")) || S.in_scope[S.in_scope.length-1] === "()" && S.prev.type === "keyword" && S.prev.value === "def" && (value === "(" || type === "name");
+                S.block_expect = (ՐՏ_209 = S.in_scope)[ՐՏ_209.length-1] === "{}" && (S.prev.type === "keyword" && S.prev.value === "def" && (value === "(" || ՐՏ_in(type, [ "name", "string", "num" ]) || full_type === "operator:keyword") || S.prev.type === "name" && ՐՏ_in(S.prev.value, [ "get", "set" ]) && (ՐՏ_in(type, [ "name", "string", "num" ]) || full_type === "operator:keyword")) || (ՐՏ_210 = S.in_scope)[ՐՏ_210.length-1] === "()" && S.prev.type === "keyword" && S.prev.value === "def" && (value === "(" || type === "name");
             } else {
                 block_expect = true;
                 S.block_expect = false;
@@ -3788,13 +3626,13 @@ var ՐՏ_modules = {};
                 ret.comments_before = S.comments_before;
                 S.comments_before = [];
                 for (i = 0; i < len(ret.comments_before); i++) {
-                    ret.newline_before = ret.newline_before || ret.comments_before[i].newline_before;
+                    ret.newline_before = ret.newline_before || (ՐՏ_211 = ret.comments_before)[i].newline_before;
                 }
             }
             if (!keep_newline) {
                 S.newline_before = false;
             }
-            top_scope = S.in_scope[S.in_scope.length-1];
+            top_scope = (ՐՏ_212 = S.in_scope)[ՐՏ_212.length-1];
             if (type === "punc") {
                 if (value === ":") {
                     if (ՐՏ_in(top_scope, [ "block", "def", "[]" ])) {
@@ -3821,20 +3659,20 @@ var ՐՏ_modules = {};
                 } else if (value === "{") {
                     S.in_scope.push("{}");
                 } else if (ՐՏ_in(value, [ "]", ")", "}" ])) {
-                    if (top_scope[top_scope.length-1] === value) {
+                    if ((ՐՏ_213 = top_scope)[ՐՏ_213.length-1] === value) {
                         S.in_scope.pop();
                     } else {
                         console.log("mismatch: " + value);
                     }
                 } else if (value === "endblock") {
                     ret.value = "}";
-                    if (ret.comments_before.length && ret.comments_before[ret.comments_before.length-1].col <= S.col) {
+                    if (ret.comments_before.length && (ՐՏ_214 = ret.comments_before)[ՐՏ_214.length-1].col <= S.col) {
                         S.comments_before = ret.comments_before;
                         ret.comments_before = [];
                     }
                     if (top_scope === "block") {
                         S.in_scope.pop();
-                        if (ՐՏ_in(S.in_scope[S.in_scope.length-1], [ "[]", "{}", "()" ])) {
+                        if (ՐՏ_in((ՐՏ_215 = S.in_scope)[ՐՏ_215.length-1], [ "[]", "{}", "()" ])) {
                             S.comma_expect = true;
                         }
                     } else {
@@ -3870,10 +3708,11 @@ var ՐՏ_modules = {};
             }
         }
         function test_indent_token(leading_whitespace) {
+            var ՐՏ_216, ՐՏ_217;
             var most_recent;
-            most_recent = S.whitespace_before[S.whitespace_before.length-1] || "";
+            most_recent = (ՐՏ_216 = S.whitespace_before)[ՐՏ_216.length-1] || "";
             S.endblock = false;
-            if (S.in_scope[S.in_scope.length-1] === "block" && leading_whitespace !== most_recent) {
+            if ((ՐՏ_217 = S.in_scope)[ՐՏ_217.length-1] === "block" && leading_whitespace !== most_recent) {
                 if (S.newblock && leading_whitespace && leading_whitespace.indexOf(most_recent) === 0) {
                     S.newblock = false;
                     S.whitespace_before.push(leading_whitespace);
@@ -3980,7 +3819,8 @@ var ՐՏ_modules = {};
             return num;
         }
         
-        var read_string = (ՐՏ_116 = function read_string(modifier) {
+        var read_string = (ՐՏ_218 = function read_string(modifier) {
+            var ՐՏ_219, ՐՏ_221;
             var token_type, quote, ret, i, tmp, find_newlines, ch;
             token_type = "string";
             if (modifier) {
@@ -3997,16 +3837,17 @@ var ՐՏ_modules = {};
                         tmp = S.text.substring(S.pos, i);
                         S.pos = i + 3;
                         while (tmp.length) {
-                            if (tmp[0] === "\\") {
+                            if ((ՐՏ_219 = tmp)[0] === "\\") {
                                 tmp = tmp.slice(1);
                                 ret += read_escaped_char(true, function() {
+                                    var ՐՏ_220;
                                     var ch;
-                                    ch = tmp[0];
+                                    ch = (ՐՏ_220 = tmp)[0];
                                     tmp = tmp.slice(1);
                                     return ch;
                                 });
                             } else {
-                                ret += tmp[0];
+                                ret += (ՐՏ_221 = tmp)[0];
                                 tmp = tmp.slice(1);
                             }
                         }
@@ -4038,7 +3879,7 @@ var ՐՏ_modules = {};
                 ret += ch;
             }
             return token(token_type, ret);
-        }, ՐՏ_116 = with_eof_error("Unterminated string constant")(ՐՏ_116), ՐՏ_116);
+        }, ՐՏ_218 = with_eof_error("Unterminated string constant")(ՐՏ_218), ՐՏ_218);
         function read_line_comment(shebang) {
             shebang = shebang === void 0 ? false : shebang;
             var i, ret;
@@ -4056,7 +3897,8 @@ var ՐՏ_modules = {};
             return token(shebang ? "shebang" : "comment:line", ret, true);
         }
         
-        var read_multiline_comment = (ՐՏ_117 = function read_multiline_comment() {
+        var read_multiline_comment = (ՐՏ_222 = function read_multiline_comment() {
+            var ՐՏ_223, ՐՏ_224;
             var i, text, a, n;
             next();
             i = find("*/", true);
@@ -4066,14 +3908,14 @@ var ՐՏ_modules = {};
             S.pos = i + 2;
             S.line += n - 1;
             if (n > 1) {
-                S.col = a[n - 1].length;
+                S.col = (ՐՏ_223 = a)[n - 1].length;
             } else {
-                S.col += a[n - 1].length;
+                S.col += (ՐՏ_224 = a)[n - 1].length;
             }
             S.col += 2;
             S.newline_before = S.newline_before || ՐՏ_in("\n", text);
             return token("comment:multiline", text, true);
-        }, ՐՏ_117 = with_eof_error("Unterminated multiline comment")(ՐՏ_117), ՐՏ_117);
+        }, ՐՏ_222 = with_eof_error("Unterminated multiline comment")(ՐՏ_222), ՐՏ_222);
         function read_name() {
             var backslash, name, escaped, ch, hex;
             backslash = false;
@@ -4113,7 +3955,7 @@ var ՐՏ_modules = {};
             return name;
         }
         
-        var read_regexp = (ՐՏ_118 = function read_regexp(regexp) {
+        var read_regexp = (ՐՏ_225 = function read_regexp(regexp) {
             var prev_backslash, in_class, verbose_regexp, in_comment, mods, ch;
             prev_backslash = false;
             in_class = false;
@@ -4170,7 +4012,7 @@ var ՐՏ_modules = {};
             }
             mods = read_name();
             return token("regexp", new RegExp(regexp, mods));
-        }, ՐՏ_118 = with_eof_error("Unterminated regular expression")(ՐՏ_118), ՐՏ_118);
+        }, ՐՏ_225 = with_eof_error("Unterminated regular expression")(ՐՏ_225), ՐՏ_225);
         function read_operator(prefix) {
             var op;
             function grow(op) {
@@ -4291,75 +4133,72 @@ var ՐՏ_modules = {};
         };
         return next_token;
     }
-    ՐՏ_modules["tokenizer"]["ES6_KEYWORDS"] = ES6_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["COMMON_KEYWORDS"] = COMMON_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["JS_KEYWORDS"] = JS_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["JS_KEYWORDS_AUTOFIX"] = JS_KEYWORDS_AUTOFIX;
-    ՐՏ_modules["tokenizer"]["RS_KEYWORDS"] = RS_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["KEYWORDS"] = KEYWORDS;
-    ՐՏ_modules["tokenizer"]["KEYWORDS_ATOM"] = KEYWORDS_ATOM;
-    ՐՏ_modules["tokenizer"]["RESERVED_WORDS"] = RESERVED_WORDS;
-    ՐՏ_modules["tokenizer"]["KEYWORDS_BEFORE_EXPRESSION"] = KEYWORDS_BEFORE_EXPRESSION;
-    ՐՏ_modules["tokenizer"]["ALL_KEYWORDS"] = ALL_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["ALL_JS_KEYWORDS"] = ALL_JS_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["IS_ANY_KEYWORD"] = IS_ANY_KEYWORD;
-    ՐՏ_modules["tokenizer"]["OPERATOR_CHARS"] = OPERATOR_CHARS;
-    ՐՏ_modules["tokenizer"]["RE_HEX_NUMBER"] = RE_HEX_NUMBER;
-    ՐՏ_modules["tokenizer"]["RE_OCT_NUMBER"] = RE_OCT_NUMBER;
-    ՐՏ_modules["tokenizer"]["RE_DEC_NUMBER"] = RE_DEC_NUMBER;
-    ՐՏ_modules["tokenizer"]["OPERATORS"] = OPERATORS;
-    ՐՏ_modules["tokenizer"]["OP_MAP"] = OP_MAP;
-    ՐՏ_modules["tokenizer"]["WHITESPACE_CHARS"] = WHITESPACE_CHARS;
-    ՐՏ_modules["tokenizer"]["PUNC_BEFORE_EXPRESSION"] = PUNC_BEFORE_EXPRESSION;
-    ՐՏ_modules["tokenizer"]["PUNC_CHARS"] = PUNC_CHARS;
-    ՐՏ_modules["tokenizer"]["REGEXP_MODIFIERS"] = REGEXP_MODIFIERS;
-    ՐՏ_modules["tokenizer"]["UNICODE"] = UNICODE;
-    ՐՏ_modules["tokenizer"]["IDENTIFIER_PAT"] = IDENTIFIER_PAT;
-    ՐՏ_modules["tokenizer"]["STRING_MODIFIERS"] = STRING_MODIFIERS;
-    ՐՏ_modules["tokenizer"]["UNARY_POSTFIX"] = UNARY_POSTFIX;
-    ՐՏ_modules["tokenizer"]["PRECEDENCE"] = PRECEDENCE;
-    ՐՏ_modules["tokenizer"]["EX_EOF"] = EX_EOF;
-    ՐՏ_modules["tokenizer"]["characters"] = characters;
-    ՐՏ_modules["tokenizer"]["is_letter"] = is_letter;
-    ՐՏ_modules["tokenizer"]["is_digit"] = is_digit;
-    ՐՏ_modules["tokenizer"]["is_alphanumeric_char"] = is_alphanumeric_char;
-    ՐՏ_modules["tokenizer"]["is_unicode_combining_mark"] = is_unicode_combining_mark;
-    ՐՏ_modules["tokenizer"]["is_unicode_connector_punctuation"] = is_unicode_connector_punctuation;
-    ՐՏ_modules["tokenizer"]["is_string_modifier"] = is_string_modifier;
-    ՐՏ_modules["tokenizer"]["is_identifier"] = is_identifier;
-    ՐՏ_modules["tokenizer"]["is_identifier_start"] = is_identifier_start;
-    ՐՏ_modules["tokenizer"]["is_identifier_char"] = is_identifier_char;
-    ՐՏ_modules["tokenizer"]["parse_js_number"] = parse_js_number;
-    ՐՏ_modules["tokenizer"]["is_token"] = is_token;
-    ՐՏ_modules["tokenizer"]["js_error"] = js_error;
-    ՐՏ_modules["tokenizer"]["tokenizer"] = tokenizer;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:tokenizer"];
+    ՐՏ_mod.export("ES6_KEYWORDS", function(){return ES6_KEYWORDS;}, function(ՐՏ_v){if (typeof ES6_KEYWORDS !== "undefined") {ES6_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("COMMON_KEYWORDS", function(){return COMMON_KEYWORDS;}, function(ՐՏ_v){if (typeof COMMON_KEYWORDS !== "undefined") {COMMON_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("JS_KEYWORDS", function(){return JS_KEYWORDS;}, function(ՐՏ_v){if (typeof JS_KEYWORDS !== "undefined") {JS_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("JS_KEYWORDS_AUTOFIX", function(){return JS_KEYWORDS_AUTOFIX;}, function(ՐՏ_v){if (typeof JS_KEYWORDS_AUTOFIX !== "undefined") {JS_KEYWORDS_AUTOFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("RS_KEYWORDS", function(){return RS_KEYWORDS;}, function(ՐՏ_v){if (typeof RS_KEYWORDS !== "undefined") {RS_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("KEYWORDS", function(){return KEYWORDS;}, function(ՐՏ_v){if (typeof KEYWORDS !== "undefined") {KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("KEYWORDS_ATOM", function(){return KEYWORDS_ATOM;}, function(ՐՏ_v){if (typeof KEYWORDS_ATOM !== "undefined") {KEYWORDS_ATOM = ՐՏ_v;};});
+    ՐՏ_mod.export("RESERVED_WORDS", function(){return RESERVED_WORDS;}, function(ՐՏ_v){if (typeof RESERVED_WORDS !== "undefined") {RESERVED_WORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("KEYWORDS_BEFORE_EXPRESSION", function(){return KEYWORDS_BEFORE_EXPRESSION;}, function(ՐՏ_v){if (typeof KEYWORDS_BEFORE_EXPRESSION !== "undefined") {KEYWORDS_BEFORE_EXPRESSION = ՐՏ_v;};});
+    ՐՏ_mod.export("ALL_KEYWORDS", function(){return ALL_KEYWORDS;}, function(ՐՏ_v){if (typeof ALL_KEYWORDS !== "undefined") {ALL_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("ALL_JS_KEYWORDS", function(){return ALL_JS_KEYWORDS;}, function(ՐՏ_v){if (typeof ALL_JS_KEYWORDS !== "undefined") {ALL_JS_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("IS_ANY_KEYWORD", function(){return IS_ANY_KEYWORD;}, function(ՐՏ_v){if (typeof IS_ANY_KEYWORD !== "undefined") {IS_ANY_KEYWORD = ՐՏ_v;};});
+    ՐՏ_mod.export("OPERATOR_CHARS", function(){return OPERATOR_CHARS;}, function(ՐՏ_v){if (typeof OPERATOR_CHARS !== "undefined") {OPERATOR_CHARS = ՐՏ_v;};});
+    ՐՏ_mod.export("RE_HEX_NUMBER", function(){return RE_HEX_NUMBER;}, function(ՐՏ_v){if (typeof RE_HEX_NUMBER !== "undefined") {RE_HEX_NUMBER = ՐՏ_v;};});
+    ՐՏ_mod.export("RE_OCT_NUMBER", function(){return RE_OCT_NUMBER;}, function(ՐՏ_v){if (typeof RE_OCT_NUMBER !== "undefined") {RE_OCT_NUMBER = ՐՏ_v;};});
+    ՐՏ_mod.export("RE_DEC_NUMBER", function(){return RE_DEC_NUMBER;}, function(ՐՏ_v){if (typeof RE_DEC_NUMBER !== "undefined") {RE_DEC_NUMBER = ՐՏ_v;};});
+    ՐՏ_mod.export("OPERATORS", function(){return OPERATORS;}, function(ՐՏ_v){if (typeof OPERATORS !== "undefined") {OPERATORS = ՐՏ_v;};});
+    ՐՏ_mod.export("OP_MAP", function(){return OP_MAP;}, function(ՐՏ_v){if (typeof OP_MAP !== "undefined") {OP_MAP = ՐՏ_v;};});
+    ՐՏ_mod.export("WHITESPACE_CHARS", function(){return WHITESPACE_CHARS;}, function(ՐՏ_v){if (typeof WHITESPACE_CHARS !== "undefined") {WHITESPACE_CHARS = ՐՏ_v;};});
+    ՐՏ_mod.export("PUNC_BEFORE_EXPRESSION", function(){return PUNC_BEFORE_EXPRESSION;}, function(ՐՏ_v){if (typeof PUNC_BEFORE_EXPRESSION !== "undefined") {PUNC_BEFORE_EXPRESSION = ՐՏ_v;};});
+    ՐՏ_mod.export("PUNC_CHARS", function(){return PUNC_CHARS;}, function(ՐՏ_v){if (typeof PUNC_CHARS !== "undefined") {PUNC_CHARS = ՐՏ_v;};});
+    ՐՏ_mod.export("REGEXP_MODIFIERS", function(){return REGEXP_MODIFIERS;}, function(ՐՏ_v){if (typeof REGEXP_MODIFIERS !== "undefined") {REGEXP_MODIFIERS = ՐՏ_v;};});
+    ՐՏ_mod.export("UNICODE", function(){return UNICODE;}, function(ՐՏ_v){if (typeof UNICODE !== "undefined") {UNICODE = ՐՏ_v;};});
+    ՐՏ_mod.export("IDENTIFIER_PAT", function(){return IDENTIFIER_PAT;}, function(ՐՏ_v){if (typeof IDENTIFIER_PAT !== "undefined") {IDENTIFIER_PAT = ՐՏ_v;};});
+    ՐՏ_mod.export("STRING_MODIFIERS", function(){return STRING_MODIFIERS;}, function(ՐՏ_v){if (typeof STRING_MODIFIERS !== "undefined") {STRING_MODIFIERS = ՐՏ_v;};});
+    ՐՏ_mod.export("UNARY_POSTFIX", function(){return UNARY_POSTFIX;}, function(ՐՏ_v){if (typeof UNARY_POSTFIX !== "undefined") {UNARY_POSTFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("PRECEDENCE", function(){return PRECEDENCE;}, function(ՐՏ_v){if (typeof PRECEDENCE !== "undefined") {PRECEDENCE = ՐՏ_v;};});
+    ՐՏ_mod.export("EX_EOF", function(){return EX_EOF;}, function(ՐՏ_v){if (typeof EX_EOF !== "undefined") {EX_EOF = ՐՏ_v;};});
+    ՐՏ_mod.export("characters", function(){return characters;}, function(ՐՏ_v){if (typeof characters !== "undefined") {characters = ՐՏ_v;};});
+    ՐՏ_mod.export("is_letter", function(){return is_letter;}, function(ՐՏ_v){if (typeof is_letter !== "undefined") {is_letter = ՐՏ_v;};});
+    ՐՏ_mod.export("is_digit", function(){return is_digit;}, function(ՐՏ_v){if (typeof is_digit !== "undefined") {is_digit = ՐՏ_v;};});
+    ՐՏ_mod.export("is_alphanumeric_char", function(){return is_alphanumeric_char;}, function(ՐՏ_v){if (typeof is_alphanumeric_char !== "undefined") {is_alphanumeric_char = ՐՏ_v;};});
+    ՐՏ_mod.export("is_unicode_combining_mark", function(){return is_unicode_combining_mark;}, function(ՐՏ_v){if (typeof is_unicode_combining_mark !== "undefined") {is_unicode_combining_mark = ՐՏ_v;};});
+    ՐՏ_mod.export("is_unicode_connector_punctuation", function(){return is_unicode_connector_punctuation;}, function(ՐՏ_v){if (typeof is_unicode_connector_punctuation !== "undefined") {is_unicode_connector_punctuation = ՐՏ_v;};});
+    ՐՏ_mod.export("is_string_modifier", function(){return is_string_modifier;}, function(ՐՏ_v){if (typeof is_string_modifier !== "undefined") {is_string_modifier = ՐՏ_v;};});
+    ՐՏ_mod.export("is_identifier", function(){return is_identifier;}, function(ՐՏ_v){if (typeof is_identifier !== "undefined") {is_identifier = ՐՏ_v;};});
+    ՐՏ_mod.export("is_identifier_start", function(){return is_identifier_start;}, function(ՐՏ_v){if (typeof is_identifier_start !== "undefined") {is_identifier_start = ՐՏ_v;};});
+    ՐՏ_mod.export("is_identifier_char", function(){return is_identifier_char;}, function(ՐՏ_v){if (typeof is_identifier_char !== "undefined") {is_identifier_char = ՐՏ_v;};});
+    ՐՏ_mod.export("parse_js_number", function(){return parse_js_number;}, function(ՐՏ_v){if (typeof parse_js_number !== "undefined") {parse_js_number = ՐՏ_v;};});
+    ՐՏ_mod.export("is_token", function(){return is_token;}, function(ՐՏ_v){if (typeof is_token !== "undefined") {is_token = ՐՏ_v;};});
+    ՐՏ_mod.export("js_error", function(){return js_error;}, function(ՐՏ_v){if (typeof js_error !== "undefined") {js_error = ՐՏ_v;};});
+    ՐՏ_mod.export("tokenizer", function(){return tokenizer;}, function(ՐՏ_v){if (typeof tokenizer !== "undefined") {tokenizer = ՐՏ_v;};});
+    ՐՏ_mod.export("ParseError", function(){return ParseError;}, function(ՐՏ_v){if (typeof ParseError !== "undefined") {ParseError = ՐՏ_v;};});
+    ՐՏ_mod.export("ast", function(){return ast;}, function(ՐՏ_v){if (typeof ast !== "undefined") {ast = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:parser"].body = function(){
     var __name__ = "parser";
 
     var NATIVE_CLASSES, COMMON_STATIC, CLASS_MAP, BASELIB, STDLIB, UNARY_PREFIX, ASSIGNMENT, STATEMENTS_WITH_LABELS, ATOMIC_START_TOKEN;
-    var makePredicate = ՐՏ_modules["utils"].makePredicate;
-    var defaults = ՐՏ_modules["utils"].defaults;
-    var ImportError = ՐՏ_modules["utils"].ImportError;
-    var js_error = ՐՏ_modules["utils"].js_error;
-    var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
-    var find_if = ՐՏ_modules["utils"].find_if;
-    
+    var makePredicate = ՐՏ_modules["utils"].makePredicate;var defaults = ՐՏ_modules["utils"].defaults;var ImportError = ՐՏ_modules["utils"].ImportError;var js_error = ՐՏ_modules["utils"].js_error;var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;var find_if = ՐՏ_modules["utils"].find_if;
     var ast = ՐՏ_modules["ast"];
-    
     var tokenizer = ՐՏ_modules["tokenizer"];
-    
     NATIVE_CLASSES = null;
     COMMON_STATIC = null;
     CLASS_MAP = null;
     BASELIB = null;
     STDLIB = null;
     function array_to_hash(a) {
+        var ՐՏ_226, ՐՏ_227;
         var ret, i;
         ret = {};
         for (i = 0; i < len(a); i++) {
-            ret[a[i]] = true;
+            (ՐՏ_226 = ret)[(ՐՏ_227 = a)[i]] = true;
         }
         return ret;
     }
@@ -4415,7 +4254,7 @@ var ՐՏ_modules = {};
         COMMON_STATIC = [ "call", "apply", "bind", "toString" ];
         CLASS_MAP = {};
         BASELIB = (function() {
-            var ՐՏidx37, ՐՏitr37 = ՐՏ_Iterable([ "abs", "all", "any", "bin", "bind", "rebind_all", "with__name__", "cmp", "chr", "dir", "enumerate", "eslice", "extends", "filter", "hex", "in", "iterable", "len", "map", "max", "min", "merge", "mixin", "print", "range", "reduce", "reversed", "sorted", "sum", "type", "zip", "getattr", "setattr", "hasattr", "eq", "kwargs", "AssertionError", "IndexError", "KeyError", "TypeError", "ValueError" ]), ՐՏres = {}, key;
+            var ՐՏidx37, ՐՏitr37 = ՐՏ_Iterable([ "abs", "all", "any", "bin", "bind", "rebind_all", "with__name__", "def_modules", "cmp", "chr", "dir", "enumerate", "eslice", "extends", "filter", "hex", "in", "iterable", "len", "map", "max", "min", "merge", "mixin", "print", "range", "reduce", "reversed", "sorted", "sum", "type", "zip", "getattr", "setattr", "hasattr", "eq", "kwargs", "AssertionError", "IndexError", "KeyError", "TypeError", "ValueError" ]), ՐՏres = {}, key;
             for (ՐՏidx37 = 0; ՐՏidx37 < ՐՏitr37.length; ՐՏidx37++) {
                 key = ՐՏitr37[ՐՏidx37];
                 ՐՏres[key] = 0;
@@ -4425,10 +4264,11 @@ var ՐՏ_modules = {};
         STDLIB = [ "abs", "bin", "cmp", "chr", "dir", "hex", "max", "min", "merge", "mixin", "print", "range", "reduce", "getattr", "setattr", "hasattr", "eq", "bind", "rebind_all", "type", "all", "any", "enumerate", "filter", "len", "map", "reversed", "sum", "zip", "AssertionError", "IndexError", "KeyError", "TypeError", "ValueError" ];
     }
     function has_simple_decorator(decorators, name) {
+        var ՐՏ_228, ՐՏ_229;
         var remove, s;
         remove = [];
         for (var i = 0; i < decorators.length; i++) {
-            s = decorators[i];
+            s = (ՐՏ_228 = decorators)[i];
             if (s instanceof ast.SymbolRef && !s.parens && s.name === name) {
                 remove.push(i);
             }
@@ -4436,7 +4276,7 @@ var ՐՏ_modules = {};
         if (remove.length) {
             remove.reverse();
             for (var i = 0; i < remove.length; i++) {
-                decorators.splice(remove[i], 1);
+                decorators.splice((ՐՏ_229 = remove)[i], 1);
             }
             return true;
         }
@@ -4447,7 +4287,7 @@ var ՐՏ_modules = {};
     STATEMENTS_WITH_LABELS = array_to_hash([ "for", "do", "while", "switch" ]);
     ATOMIC_START_TOKEN = array_to_hash([ "atom", "num", "string", "regexp", "name" ]);
     function parse($TEXT, options) {
-        var ՐՏitr38, ՐՏidx38, ՐՏ_119, ՐՏ_120, ՐՏ_121;
+        var ՐՏ_230, ՐՏitr38, ՐՏidx38, ՐՏ_231, ՐՏ_232, ՐՏ_233, ՐՏ_239, ՐՏ_331, ՐՏ_339;
         var class_map, module_id, import_dirs, depends_on, PRE_IMPORTED, IMPORTED, IMPORTING, S, cname, obj;
         if (!STDLIB) {
             init_mod();
@@ -4480,7 +4320,7 @@ var ՐՏ_modules = {};
         PRE_IMPORTED = options.PRE_IMPORTED || {};
         IMPORTED = options.IMPORTED || {};
         IMPORTING = options.IMPORTING || {};
-        IMPORTING[module_id] = true;
+        (ՐՏ_230 = IMPORTING)[module_id] = true;
         S = {
             input: typeof $TEXT === "string" ? tokenizer.tokenizer($TEXT, options.filename) : $TEXT,
             token: null,
@@ -4504,8 +4344,8 @@ var ՐՏ_modules = {};
             ՐՏitr38 = ՐՏ_Iterable(options.classes);
             for (ՐՏidx38 = 0; ՐՏidx38 < ՐՏitr38.length; ՐՏidx38++) {
                 cname = ՐՏitr38[ՐՏidx38];
-                obj = options.classes[cname];
-                S.in_scope[0].classes[cname] = {
+                obj = (ՐՏ_231 = options.classes)[cname];
+                (ՐՏ_232 = (ՐՏ_233 = S.in_scope)[0].classes)[cname] = {
                     "static": obj.static,
                     "bound": obj.bound
                 };
@@ -4620,13 +4460,58 @@ var ՐՏ_modules = {};
                 return false;
             }
         }
+        function scan_for_top_level_imports(body) {
+            var ՐՏ_234, ՐՏitr39, ՐՏidx39, ՐՏitr40, ՐՏidx40, ՐՏ_235, ՐՏitr41, ՐՏidx41, ՐՏ_236;
+            var self_fun, ans, name, obj, imp, argname, imp_sym, x, opt;
+            self_fun = scan_for_top_level_imports;
+            ans = [];
+            if (Array.isArray(body)) {
+                for (name in body) {
+                    obj = (ՐՏ_234 = body)[name];
+                    if (obj instanceof ast.Imports) {
+                        ՐՏitr39 = ՐՏ_Iterable(obj.imports);
+                        for (ՐՏidx39 = 0; ՐՏidx39 < ՐՏitr39.length; ՐՏidx39++) {
+                            imp = ՐՏitr39[ՐՏidx39];
+                            if (imp.argnames) {
+                                ՐՏitr40 = ՐՏ_Iterable(imp.argnames);
+                                for (ՐՏidx40 = 0; ՐՏidx40 < ՐՏitr40.length; ՐՏidx40++) {
+                                    argname = ՐՏitr40[ՐՏidx40];
+                                    imp_sym = argname.alias || argname;
+                                }
+                            } else {
+                                imp_sym = imp.alias || new_symbol(ast.SymbolVar, (ՐՏ_235 = imp.key.split(".", 1))[0]);
+                            }
+                            ans.push(imp_sym);
+                        }
+                    } else {
+                        if (obj instanceof ast.Scope) {
+                            continue;
+                        }
+                        ՐՏitr41 = ՐՏ_Iterable([ "body", "alternative" ]);
+                        for (ՐՏidx41 = 0; ՐՏidx41 < ՐՏitr41.length; ՐՏidx41++) {
+                            x = ՐՏitr41[ՐՏidx41];
+                            opt = (ՐՏ_236 = obj)[x];
+                            if (opt) {
+                                ans = ans.concat(self_fun(opt));
+                            }
+                        }
+                    }
+                }
+            } else if (body.body) {
+                ans = ans.concat(self_fun(body.body));
+                if (body.alternative) {
+                    ans = ans.concat(self_fun(body.alternative));
+                }
+            }
+            return ans;
+        }
         function scan_for_top_level_callables(body) {
-            var ՐՏitr39, ՐՏidx39;
+            var ՐՏ_237, ՐՏitr42, ՐՏidx42, ՐՏ_238;
             var ans, name, obj, x, opt;
             ans = [];
             if (Array.isArray(body)) {
                 for (name in body) {
-                    obj = body[name];
+                    obj = (ՐՏ_237 = body)[name];
                     if (obj instanceof ast.Function || obj instanceof ast.Class) {
                         if (obj.name) {
                             ans.push(obj.name);
@@ -4637,10 +4522,10 @@ var ՐՏ_modules = {};
                         if (obj instanceof ast.Scope) {
                             continue;
                         }
-                        ՐՏitr39 = ՐՏ_Iterable([ "body", "alternative" ]);
-                        for (ՐՏidx39 = 0; ՐՏidx39 < ՐՏitr39.length; ՐՏidx39++) {
-                            x = ՐՏitr39[ՐՏidx39];
-                            opt = obj[x];
+                        ՐՏitr42 = ՐՏ_Iterable([ "body", "alternative" ]);
+                        for (ՐՏidx42 = 0; ՐՏidx42 < ՐՏitr42.length; ՐՏidx42++) {
+                            x = ՐՏitr42[ՐՏidx42];
+                            opt = (ՐՏ_238 = obj)[x];
                             if (opt) {
                                 ans = ans.concat(scan_for_top_level_callables(opt));
                             }
@@ -4662,8 +4547,9 @@ var ՐՏ_modules = {};
             return statement(true);
         }
         
-        var statement = (ՐՏ_119 = function statement(expect_block) {
-            var tmp_, dir, stat, type, start, func, chain, result, ctor, expectedType, actualType, tmp;
+        var statement = (ՐՏ_239 = function statement(expect_block) {
+            var ՐՏ_240, ՐՏ_241, ՐՏ_242, ՐՏ_243, ՐՏ_244, ՐՏ_245, ՐՏ_246, ՐՏ_247, ՐՏ_248, ՐՏ_249;
+            var tmp_, dir, stat, type, start, func, chain, is_from, result, ctor, expectedType, actualType, tmp;
             if (is_("operator", "/") || is_("operator", "/=")) {
                 S.peeked = null;
                 S.token = S.input(S.token.value.slice(1));
@@ -4715,10 +4601,10 @@ var ՐՏ_modules = {};
                     type = S.token.value;
                     start = S.token.start;
                     next();
-                    if (!(S.in_scope[S.in_scope.length-1].type === "class")) {
+                    if (!((ՐՏ_240 = S.in_scope)[ՐՏ_240.length-1].type === "class")) {
                         croak("Getter/setter outside of class");
                     }
-                    return accessor_(type, start, S.in_scope[S.in_scope.length-1].name || true);
+                    return accessor_(type, start, (ՐՏ_241 = S.in_scope)[ՐՏ_241.length-1].name || true);
                 }
                 return tokenizer.is_token(peek(), "punc", ":") ? labeled_statement() : simple_statement();
             } else if (tmp_ === "keyword") {
@@ -4761,17 +4647,17 @@ var ՐՏ_modules = {};
                 } else if (tmp_ === "import") {
                     return import_(false);
                 } else if (tmp_ === "class") {
-                    ++BASELIB["extends"];
+                    ++(ՐՏ_242 = BASELIB)["extends"];
                     if (options.auto_bind) {
-                        ++BASELIB["rebind_all"];
+                        ++(ՐՏ_243 = BASELIB)["rebind_all"];
                     }
                     if (!options.es6) {
-                        ++BASELIB["with__name__"];
+                        ++(ՐՏ_244 = BASELIB)["with__name__"];
                     }
                     return class_();
                 } else if (tmp_ === "def") {
                     start = prev();
-                    func = function_(S.in_scope[S.in_scope.length-1].type === "class" ? S.in_scope[S.in_scope.length-1].name : false);
+                    func = function_((ՐՏ_245 = S.in_scope)[ՐՏ_245.length-1].type === "class" ? (ՐՏ_246 = S.in_scope)[ՐՏ_246.length-1].name : false);
                     func.start = start;
                     func.end = prev();
                     chain = subscripts(func, true);
@@ -4789,8 +4675,15 @@ var ՐՏ_modules = {};
                 } else if (tmp_ === "pass") {
                     semicolon();
                     return new ast.EmptyStatement();
+                } else if (tmp_ === "async") {
+                    is_from = false;
+                    if (S.token.type === "keyword" && (S.token.value === "import" || (is_from = S.token.value === "from"))) {
+                        next();
+                        return import_(is_from, true);
+                    }
+                    unexpected();
                 } else if (tmp_ === "return" || tmp_ === "yield") {
-                    if (S.in_scope[S.in_scope.length-1].type !== "function") {
+                    if ((ՐՏ_247 = S.in_scope)[ՐՏ_247.length-1].type !== "function") {
                         croak("'return' outside of function");
                     }
                     if (tmp_ === "yield") {
@@ -4809,8 +4702,8 @@ var ՐՏ_modules = {};
                             }()
                         });
                     }
-                    if (S.in_scope[S.in_scope.length-1].return_annotation) {
-                        expectedType = S.in_scope[S.in_scope.length-1].return_annotation.resolveType(S.in_scope);
+                    if ((ՐՏ_248 = S.in_scope)[ՐՏ_248.length-1].return_annotation) {
+                        expectedType = (ՐՏ_249 = S.in_scope)[ՐՏ_249.length-1].return_annotation.resolveType(S.in_scope);
                         actualType = result.resolveType(S.in_scope);
                         if (!(ՐՏ_in(actualType, [ expectedType, "?" ]))) {
                             croak("Type annotation states that function returns " + expectedType + ", actual returned type is " + actualType + "");
@@ -4854,7 +4747,7 @@ var ՐՏ_modules = {};
                     unexpected();
                 }
             }
-        }, ՐՏ_119 = embed_tokens(ՐՏ_119), ՐՏ_119);
+        }, ՐՏ_239 = embed_tokens(ՐՏ_239), ՐՏ_239);
         function labeled_statement() {
             var label, stat;
             label = as_symbol(ast.Label);
@@ -4925,14 +4818,14 @@ var ՐՏ_modules = {};
             unexpected();
         }
         function for_in(init, list_comp) {
-            var ՐՏitr40, ՐՏidx40, ՐՏupk1;
+            var ՐՏ_250, ՐՏitr43, ՐՏidx43, ՐՏupk1, ՐՏ_251;
             var lhs, obj, i, element, value;
-            lhs = init instanceof ast.Var ? init.definitions[0].name : null;
+            lhs = init instanceof ast.Var ? (ՐՏ_250 = init.definitions)[0].name : null;
             obj = expression(true);
             if (init instanceof ast.Array) {
-                ՐՏitr40 = ՐՏ_Iterable(enumerate(init.elements));
-                for (ՐՏidx40 = 0; ՐՏidx40 < ՐՏitr40.length; ՐՏidx40++) {
-                    ՐՏupk1 = ՐՏitr40[ՐՏidx40];
+                ՐՏitr43 = ՐՏ_Iterable(enumerate(init.elements));
+                for (ՐՏidx43 = 0; ՐՏidx43 < ՐՏitr43.length; ՐՏidx43++) {
+                    ՐՏupk1 = ՐՏitr43[ՐՏidx43];
                     i = ՐՏupk1[0];
                     element = ՐՏupk1[1];
                     value = null;
@@ -4950,7 +4843,7 @@ var ՐՏ_modules = {};
                 }
                 mark_local_assignment(init, value);
             }
-            ++BASELIB["iterable"];
+            ++(ՐՏ_251 = BASELIB)["iterable"];
             if (list_comp) {
                 return {
                     init: init,
@@ -4974,17 +4867,17 @@ var ՐՏ_modules = {};
             });
         }
         function get_class_in_scope(expr) {
-            var ՐՏitr41, ՐՏidx41, ՐՏitr42, ՐՏidx42;
+            var ՐՏ_252, ՐՏitr44, ՐՏidx44, ՐՏ_253, ՐՏ_254, ՐՏ_255, ՐՏitr45, ՐՏidx45, ՐՏ_256, ՐՏ_257, ՐՏ_258;
             var s, referenced_path, class_name;
             if (expr instanceof ast.SymbolRef) {
                 if (ՐՏ_in(expr.name, NATIVE_CLASSES)) {
-                    return NATIVE_CLASSES[expr.name];
+                    return (ՐՏ_252 = NATIVE_CLASSES)[expr.name];
                 }
-                ՐՏitr41 = ՐՏ_Iterable(range(S.in_scope.length - 1, -1, -1));
-                for (ՐՏidx41 = 0; ՐՏidx41 < ՐՏitr41.length; ՐՏidx41++) {
-                    s = ՐՏitr41[ՐՏidx41];
-                    if (ՐՏ_in(expr.name, S.in_scope[s].classes)) {
-                        return S.in_scope[s].classes[expr.name];
+                ՐՏitr44 = ՐՏ_Iterable(range(S.in_scope.length - 1, -1, -1));
+                for (ՐՏidx44 = 0; ՐՏidx44 < ՐՏitr44.length; ՐՏidx44++) {
+                    s = ՐՏitr44[ՐՏidx44];
+                    if (ՐՏ_in(expr.name, (ՐՏ_253 = S.in_scope)[s].classes)) {
+                        return (ՐՏ_254 = (ՐՏ_255 = S.in_scope)[s].classes)[expr.name];
                     }
                 }
             } else if (expr instanceof ast.Dot) {
@@ -4997,11 +4890,11 @@ var ՐՏ_modules = {};
                     referenced_path.unshift(expr.name);
                     if (len(referenced_path) > 1) {
                         class_name = referenced_path.join(".");
-                        ՐՏitr42 = ՐՏ_Iterable(range(S.in_scope.length - 1, -1, -1));
-                        for (ՐՏidx42 = 0; ՐՏidx42 < ՐՏitr42.length; ՐՏidx42++) {
-                            s = ՐՏitr42[ՐՏidx42];
-                            if (ՐՏ_in(class_name, S.in_scope[s].classes)) {
-                                return S.in_scope[s].classes[class_name];
+                        ՐՏitr45 = ՐՏ_Iterable(range(S.in_scope.length - 1, -1, -1));
+                        for (ՐՏidx45 = 0; ՐՏidx45 < ՐՏitr45.length; ՐՏidx45++) {
+                            s = ՐՏitr45[ՐՏidx45];
+                            if (ՐՏ_in(class_name, (ՐՏ_256 = S.in_scope)[s].classes)) {
+                                return (ՐՏ_257 = (ՐՏ_258 = S.in_scope)[s].classes)[class_name];
                             }
                         }
                     }
@@ -5010,27 +4903,27 @@ var ՐՏ_modules = {};
             return false;
         }
         function do_import(key) {
-            var ՐՏitr44, ՐՏidx44, ՐՏupk3;
+            var ՐՏ_259, ՐՏ_260, ՐՏitr47, ՐՏidx47, ՐՏupk3, ՐՏ_261, ՐՏ_262, ՐՏ_263;
             var package_module_id, filename, src_code, modpath, location, data, msg, contents, subs;
             if (ՐՏ_in(key, IMPORTED)) {
                 return;
             }
-            if (IMPORTING[key]) {
+            if ((ՐՏ_259 = IMPORTING)[key]) {
                 throw new ImportError("Detected a recursive import of: " + key + " while importing: " + module_id, options.filename);
             }
             package_module_id = key.split(".").slice(0, -1).join(".");
-            if (len(package_module_id) > 0 && !IMPORTING[package_module_id]) {
+            if (len(package_module_id) > 0 && !(ՐՏ_260 = IMPORTING)[package_module_id]) {
                 do_import(package_module_id);
                 if (ՐՏ_in(key, IMPORTED)) {
                     return;
                 }
             }
             function safe_read(base_path) {
-                var ՐՏitr43, ՐՏidx43, ՐՏupk2;
+                var ՐՏitr46, ՐՏidx46, ՐՏupk2;
                 var i, path;
-                ՐՏitr43 = ՐՏ_Iterable(enumerate([ base_path + ".pyj", base_path + "/__init__.pyj" ]));
-                for (ՐՏidx43 = 0; ՐՏidx43 < ՐՏitr43.length; ՐՏidx43++) {
-                    ՐՏupk2 = ՐՏitr43[ՐՏidx43];
+                ՐՏitr46 = ՐՏ_Iterable(enumerate([ base_path + ".pyj", base_path + "/__init__.pyj" ]));
+                for (ՐՏidx46 = 0; ՐՏidx46 < ՐՏitr46.length; ՐՏidx46++) {
+                    ՐՏupk2 = ՐՏitr46[ՐՏidx46];
                     i = ՐՏupk2[0];
                     path = ՐՏupk2[1];
                     try {
@@ -5049,9 +4942,9 @@ var ՐՏ_modules = {};
             }
             src_code = filename = null;
             modpath = key.replace(/\./g, "/");
-            ՐՏitr44 = ՐՏ_Iterable(import_dirs);
-            for (ՐՏidx44 = 0; ՐՏidx44 < ՐՏitr44.length; ՐՏidx44++) {
-                location = ՐՏitr44[ՐՏidx44];
+            ՐՏitr47 = ՐՏ_Iterable(import_dirs);
+            for (ՐՏidx47 = 0; ՐՏidx47 < ՐՏitr47.length; ՐՏidx47++) {
+                location = ՐՏitr47[ՐՏidx47];
                 if (location) {
                     try {
                         ՐՏupk3 = safe_read(location + "/" + modpath);
@@ -5092,36 +4985,39 @@ var ՐՏ_modules = {};
                 dropDocstrings: options.dropDocstrings
             });
             if (len(package_module_id) > 0) {
-                subs = !IMPORTING[package_module_id] ? IMPORTED[package_module_id].submodules : PRE_IMPORTED[package_module_id].submodules;
+                subs = !(ՐՏ_261 = IMPORTING)[package_module_id] ? (ՐՏ_262 = IMPORTED)[package_module_id].submodules : (ՐՏ_263 = PRE_IMPORTED)[package_module_id].submodules;
                 if (!(ՐՏ_in(key, subs))) {
                     subs.push(key);
                 }
             }
         }
-        function import_(from_import) {
-            var ՐՏitr45, ՐՏidx45, ՐՏitr46, ՐՏidx46, ՐՏitr47, ՐՏidx47;
+        function import_(from_import, async_import) {
+            var ՐՏ_264, ՐՏ_265, ՐՏ_266, ՐՏitr48, ՐՏ_268, ՐՏidx48, ՐՏ_269, ՐՏ_270, ՐՏ_271, ՐՏ_272, ՐՏ_273, ՐՏitr49, ՐՏidx49, ՐՏ_275, ՐՏ_276, ՐՏ_277, ՐՏitr50, ՐՏidx50, ՐՏ_278, ՐՏ_279, ՐՏ_280;
             var ans, imp_with, package_pref, name, tmp, key, alias, imp, from_pack_imp, cur_imported, argnames, from_pack_module_names, aname, classes, argvar, obj, mod_name;
             ans = new ast.Imports({
-                "imports": []
+                "imports": [],
+                "async": async_import
             });
             imp_with = null;
             while (true) {
                 package_pref = "";
-                if ((options.filename || "").endsWith("/__init__.pyj")) {
-                    package_pref = options.module_id + ".";
-                    if (!PRE_IMPORTED[options.module_id]) {
-                        PRE_IMPORTED[options.module_id] = {
-                            submodules: []
-                        };
+                if (!async_import) {
+                    if (!async_import && (options.filename || "").endsWith("/__init__.pyj")) {
+                        package_pref = options.module_id + ".";
+                        if (!(ՐՏ_264 = PRE_IMPORTED)[options.module_id]) {
+                            (ՐՏ_265 = PRE_IMPORTED)[options.module_id] = {
+                                submodules: []
+                            };
+                        }
                     }
-                }
-                if (is_("punc", ".")) {
-                    if (!package_pref) {
-                        package_pref = (/^(.+?\.)[^\.]+$/.exec(options.module_id || "") || [ "", "" ])[1];
+                    if (is_("punc", ".")) {
+                        if (!package_pref) {
+                            package_pref = (ՐՏ_266 = (/^(.+?\.)[^\.]+$/.exec(options.module_id || "") || [ "", "" ]))[1];
+                        }
+                        next();
+                    } else {
+                        package_pref = "";
                     }
-                    next();
-                } else {
-                    package_pref = "";
                 }
                 tmp = name = expression(false);
                 key = "";
@@ -5161,9 +5057,12 @@ var ՐՏ_modules = {};
                     "key": key,
                     "alias": alias,
                     "argnames": null,
-                    "body": function() {
-                        return IMPORTED[key];
-                    }
+                    "body": function(_) {
+                        return function() {
+                            var ՐՏ_267;
+                            return (ՐՏ_267 = IMPORTED)[_];
+                        };
+                    }(key)
                 });
                 ans.imports.push(imp);
                 if (from_import) {
@@ -5176,12 +5075,27 @@ var ՐՏ_modules = {};
                 }
             }
             from_pack_imp = [];
-            ՐՏitr45 = ՐՏ_Iterable(ans["imports"]);
-            for (ՐՏidx45 = 0; ՐՏidx45 < ՐՏitr45.length; ՐՏidx45++) {
-                imp = ՐՏitr45[ՐՏidx45];
-                do_import(imp.key);
-                depends_on[imp.key] = true;
-                cur_imported = IMPORTED[imp.key];
+            ՐՏitr48 = ՐՏ_Iterable((ՐՏ_268 = ans)["imports"]);
+            for (ՐՏidx48 = 0; ՐՏidx48 < ՐՏitr48.length; ՐՏidx48++) {
+                imp = ՐՏitr48[ՐՏidx48];
+                if (!async_import) {
+                    do_import(imp.key);
+                } else {
+                    (ՐՏ_269 = IMPORTED)[imp.key] = new ast.TopLevel({
+                        imports: {},
+                        nonlocalvars: [],
+                        module_id: imp.key,
+                        exports: [],
+                        submodules: [],
+                        classes: [],
+                        filename: null,
+                        async: true
+                    });
+                    (ՐՏ_270 = IMPORTED)[imp.key].localvars = [];
+                    (ՐՏ_271 = IMPORTED)[imp.key].body = [];
+                }
+                (ՐՏ_272 = depends_on)[imp.key] = true;
+                cur_imported = async_import ? null : (ՐՏ_273 = IMPORTED)[imp.key];
                 argnames = [];
                 if (from_import) {
                     expect_token("keyword", "import");
@@ -5192,7 +5106,7 @@ var ՐՏ_modules = {};
                             unexpected();
                         }
                         name = S.token.value;
-                        if (cur_imported.is_package && !cur_imported.exports.find(function(it) {
+                        if (cur_imported && cur_imported.is_package && !cur_imported.exports.find(function(it) {
                             return it.name === name;
                         })) {
                             key = imp.key + "." + name;
@@ -5202,7 +5116,8 @@ var ՐՏ_modules = {};
                                 "alias": new_symbol(ast.SymbolAlias, name),
                                 "argnames": null,
                                 "body": function() {
-                                    return IMPORTED[key];
+                                    var ՐՏ_274;
+                                    return (ՐՏ_274 = IMPORTED)[key];
                                 }
                             });
                             from_pack_imp.push(aname);
@@ -5222,34 +5137,38 @@ var ՐՏ_modules = {};
                             break;
                         }
                     }
-                    classes = cur_imported.classes;
-                    ՐՏitr46 = ՐՏ_Iterable(argnames);
-                    for (ՐՏidx46 = 0; ՐՏidx46 < ՐՏitr46.length; ՐՏidx46++) {
-                        argvar = ՐՏitr46[ՐՏidx46];
-                        obj = classes[argvar.name];
-                        if (obj) {
-                            key = argvar.alias ? argvar.alias.name : argvar.name;
-                            S.in_scope[S.in_scope.length-1].classes[key] = {
-                                "static": obj.static,
-                                "bound": obj.bound
-                            };
+                    if (cur_imported) {
+                        classes = cur_imported.classes;
+                        ՐՏitr49 = ՐՏ_Iterable(argnames);
+                        for (ՐՏidx49 = 0; ՐՏidx49 < ՐՏitr49.length; ՐՏidx49++) {
+                            argvar = ՐՏitr49[ՐՏidx49];
+                            obj = (ՐՏ_275 = classes)[argvar.name];
+                            if (obj) {
+                                key = argvar.alias ? argvar.alias.name : argvar.name;
+                                (ՐՏ_276 = (ՐՏ_277 = S.in_scope)[ՐՏ_277.length-1].classes)[key] = {
+                                    "static": obj.static,
+                                    "bound": obj.bound
+                                };
+                            }
                         }
                     }
-                    ՐՏitr47 = ՐՏ_Iterable(from_pack_module_names);
-                    for (ՐՏidx47 = 0; ՐՏidx47 < ՐՏitr47.length; ՐՏidx47++) {
-                        mod_name = ՐՏitr47[ՐՏidx47];
-                        Object.assign(S.in_scope[S.in_scope.length - 1].classes, IMPORTED[mod_name.key].top_classes(mod_name.alias.name));
+                    ՐՏitr50 = ՐՏ_Iterable(from_pack_module_names);
+                    for (ՐՏidx50 = 0; ՐՏidx50 < ՐՏitr50.length; ՐՏidx50++) {
+                        mod_name = ՐՏitr50[ՐՏidx50];
+                        Object.assign((ՐՏ_278 = S.in_scope)[S.in_scope.length - 1].classes, (ՐՏ_279 = IMPORTED)[mod_name.key].top_classes(mod_name.alias.name));
                     }
                 } else {
                     key = imp.alias ? imp.alias.name : imp.key;
-                    Object.assign(S.in_scope[S.in_scope.length - 1].classes, cur_imported.top_classes(key));
+                    if (cur_imported) {
+                        Object.assign((ՐՏ_280 = S.in_scope)[S.in_scope.length - 1].classes, cur_imported.top_classes(key));
+                    }
                 }
             }
             [].push.apply(ans.imports, from_pack_imp);
             return ans;
         }
         function class_() {
-            var ՐՏitr50, ՐՏidx50;
+            var ՐՏ_287, ՐՏitr53, ՐՏidx53, ՐՏ_294, ՐՏ_295;
             var start, name, externaldecorator, class_details, parent, docstring, definition, i, stmt, class_vars_names, visitor;
             start = prev();
             name = as_symbol(ast.SymbolClass);
@@ -5288,6 +5207,7 @@ var ՐՏ_modules = {};
                 name: name,
                 module_id: module_id,
                 parent: function() {
+                    var ՐՏ_281, ՐՏ_282;
                     var atom, parent_details;
                     if (is_("punc", "(")) {
                         next();
@@ -5299,7 +5219,7 @@ var ՐՏ_modules = {};
                         atom = expr_atom(false);
                         expect(")");
                         parent = stringifyName(atom);
-                        if (parent && (parent_details = S.in_scope[S.in_scope.length-1].classes[parent])) {
+                        if (parent && (parent_details = (ՐՏ_281 = (ՐՏ_282 = S.in_scope)[ՐՏ_282.length-1].classes)[parent])) {
                             [].push.apply(class_details.static, parent_details.static);
                         }
                         return atom;
@@ -5313,14 +5233,14 @@ var ՐՏ_modules = {};
                 bound: class_details.bound,
                 statements: [],
                 decorators: function() {
-                    var ՐՏitr48, ՐՏidx48;
+                    var ՐՏitr51, ՐՏidx51, ՐՏ_283;
                     var d, decorator;
                     d = [];
-                    ՐՏitr48 = ՐՏ_Iterable(S.decorators);
-                    for (ՐՏidx48 = 0; ՐՏidx48 < ՐՏitr48.length; ՐՏidx48++) {
-                        decorator = ՐՏitr48[ՐՏidx48];
+                    ՐՏitr51 = ՐՏ_Iterable(S.decorators);
+                    for (ՐՏidx51 = 0; ՐՏidx51 < ՐՏitr51.length; ՐՏidx51++) {
+                        decorator = ՐՏitr51[ՐՏidx51];
                         if (decorator === "kwargs") {
-                            ++BASELIB["kwargs"];
+                            ++(ՐՏ_283 = BASELIB)["kwargs"];
                         }
                         d.push(new ast.Decorator({
                             expression: decorator
@@ -5330,8 +5250,9 @@ var ՐՏ_modules = {};
                     return d;
                 }(),
                 body: function(loop, labels) {
+                    var ՐՏ_284, ՐՏ_285, ՐՏ_286;
                     var a;
-                    S.in_scope[S.in_scope.length-1].classes[name.name] = class_details;
+                    (ՐՏ_284 = (ՐՏ_285 = S.in_scope)[ՐՏ_285.length-1].classes)[name.name] = class_details;
                     S.in_scope.push({
                         type: "class",
                         name: name.name,
@@ -5345,7 +5266,7 @@ var ՐՏ_modules = {};
                     S.in_loop = 0;
                     S.labels = [];
                     a = block_();
-                    docstring = S.in_scope[S.in_scope.length-1].docstring;
+                    docstring = (ՐՏ_286 = S.in_scope)[ՐՏ_286.length-1].docstring;
                     S.in_scope.pop();
                     S.in_loop = loop;
                     S.labels = labels;
@@ -5355,7 +5276,7 @@ var ՐՏ_modules = {};
                 end: prev()
             });
             for (i in definition.body) {
-                stmt = definition.body[i];
+                stmt = (ՐՏ_287 = definition.body)[i];
                 if (stmt instanceof ast.Method && stmt.name.name === "__init__") {
                     definition.init = stmt;
                     break;
@@ -5364,21 +5285,21 @@ var ՐՏ_modules = {};
             class_vars_names = {};
             function walker() {
                 this._visit = function(node, descend) {
-                    var ՐՏitr49, ՐՏidx49;
+                    var ՐՏ_288, ՐՏ_289, ՐՏitr52, ՐՏidx52, ՐՏ_290, ՐՏ_291, ՐՏ_292, ՐՏ_293;
                     var child;
                     if (node instanceof ast.Method) {
-                        class_vars_names[node.name.name] = true;
+                        (ՐՏ_288 = class_vars_names)[node.name.name] = true;
                         return;
                     } else if (node instanceof ast.Assign && node.left instanceof ast.SymbolRef) {
-                        class_vars_names[node.left.name] = true;
+                        (ՐՏ_289 = class_vars_names)[node.left.name] = true;
                     }
-                    ՐՏitr49 = ՐՏ_Iterable(node);
-                    for (ՐՏidx49 = 0; ՐՏidx49 < ՐՏitr49.length; ՐՏidx49++) {
-                        child = ՐՏitr49[ՐՏidx49];
-                        if (node[child] instanceof ast.SymbolRef && Object.prototype.hasOwnProperty.call(class_vars_names, node[child].name)) {
-                            node[child] = new ast.SymbolClassRef({
+                    ՐՏitr52 = ՐՏ_Iterable(node);
+                    for (ՐՏidx52 = 0; ՐՏidx52 < ՐՏitr52.length; ՐՏidx52++) {
+                        child = ՐՏitr52[ՐՏidx52];
+                        if ((ՐՏ_290 = node)[child] instanceof ast.SymbolRef && Object.prototype.hasOwnProperty.call(class_vars_names, (ՐՏ_291 = node)[child].name)) {
+                            (ՐՏ_292 = node)[child] = new ast.SymbolClassRef({
                                 "class": name,
-                                "name": node[child].name
+                                "name": (ՐՏ_293 = node)[child].name
                             });
                         }
                     }
@@ -5388,21 +5309,22 @@ var ՐՏ_modules = {};
                 };
             }
             visitor = new walker();
-            ՐՏitr50 = ՐՏ_Iterable(definition.body);
-            for (ՐՏidx50 = 0; ՐՏidx50 < ՐՏitr50.length; ՐՏidx50++) {
-                stmt = ՐՏitr50[ՐՏidx50];
+            ՐՏitr53 = ՐՏ_Iterable(definition.body);
+            for (ՐՏidx53 = 0; ՐՏidx53 < ՐՏitr53.length; ՐՏidx53++) {
+                stmt = ՐՏitr53[ՐՏidx53];
                 if (!(stmt instanceof ast.Class) && !(stmt instanceof ast.Method)) {
                     stmt.walk(visitor);
                     definition.statements.push(stmt);
                 }
             }
             if (S.in_scope.length === 1) {
-                class_map[definition.name.name] = definition;
-                CLASS_MAP[definition.name.name] = definition;
+                (ՐՏ_294 = class_map)[definition.name.name] = definition;
+                (ՐՏ_295 = CLASS_MAP)[definition.name.name] = definition;
             }
             return definition;
         }
         function function_(in_class_or_xobject, ctor) {
+            var ՐՏ_296, ՐՏ_297, ՐՏ_298, ՐՏ_299, ՐՏ_300, ՐՏ_301, ՐՏ_311, ՐՏ_312, ՐՏ_313, ՐՏ_314;
             var in_xobject, in_class, start, is_accessor, name, generator, localvars, staticmethod, function_args, return_annotation, has_special_decorator, cls_details, docstring, callsSuper, superCall_expr, definition, arg, args;
             in_class = in_xobject = false;
             if (in_class_or_xobject) {
@@ -5428,7 +5350,7 @@ var ՐՏ_modules = {};
                     return has_simple_decorator(S.decorators, name);
                 };
                 if (in_class) {
-                    cls_details = S.in_scope[S.in_scope.length-2].classes[in_class];
+                    cls_details = (ՐՏ_296 = (ՐՏ_297 = S.in_scope)[ՐՏ_297.length-2].classes)[in_class];
                     if (has_special_decorator("staticmethod")) {
                         staticmethod = true;
                         if (!(ՐՏ_in(name.name, cls_details.static))) {
@@ -5438,8 +5360,8 @@ var ՐՏ_modules = {};
                         cls_details.pop_static(name.name);
                     }
                     if (has_special_decorator("bind") || name.name !== "__init__" && options.auto_bind) {
-                        ++BASELIB["bind"];
-                        S.in_scope[S.in_scope.length-2].classes[in_class].bound[name.name] = true;
+                        ++(ՐՏ_298 = BASELIB)["bind"];
+                        (ՐՏ_299 = (ՐՏ_300 = (ՐՏ_301 = S.in_scope)[ՐՏ_301.length-2].classes)[in_class].bound)[name.name] = true;
                     }
                 }
             }
@@ -5458,11 +5380,13 @@ var ՐՏ_modules = {};
                 start: start,
                 name: name,
                 argnames: function(a) {
+                    var ՐՏ_304;
                     var defaults, first, seen_names, val, expr;
                     defaults = {};
                     first = true;
                     seen_names = {};
                     function get_arg() {
+                        var ՐՏ_302, ՐՏ_303;
                         var name_token, name, ntok, annotation, sym;
                         if (Object.prototype.hasOwnProperty.call(seen_names, S.token.value)) {
                             token_error(prev(), "Can't repeat parameter names");
@@ -5475,7 +5399,7 @@ var ՐՏ_modules = {};
                             return null;
                         }
                         name_token = S.token;
-                        seen_names[name_token.value] = true;
+                        (ՐՏ_302 = seen_names)[name_token.value] = true;
                         name = maybe_keyword(name_token.value);
                         ntok = peek();
                         if (ntok.type === "punc" && ntok.value === ":") {
@@ -5501,7 +5425,7 @@ var ՐՏ_modules = {};
                             });
                             next();
                         }
-                        function_args[sym.name] = sym.annotation ? sym.annotation.resolveType(S.in_scope) : "?";
+                        (ՐՏ_303 = function_args)[sym.name] = sym.annotation ? sym.annotation.resolveType(S.in_scope) : "?";
                         return sym;
                     }
                     while (!is_("punc", ")")) {
@@ -5537,7 +5461,7 @@ var ՐՏ_modules = {};
                                 }
                                 val = prev().value;
                                 next();
-                                defaults[val] = expression(false);
+                                (ՐՏ_304 = defaults)[val] = expression(false);
                                 a.has_defaults = true;
                             } else {
                                 if (a.has_defaults) {
@@ -5560,12 +5484,12 @@ var ՐՏ_modules = {};
                     return a;
                 }([]),
                 decorators: S.in_decorator ? [] : function() {
-                    var ՐՏitr51, ՐՏidx51;
+                    var ՐՏitr54, ՐՏidx54;
                     var d, decorator;
                     d = [];
-                    ՐՏitr51 = ՐՏ_Iterable(S.decorators);
-                    for (ՐՏidx51 = 0; ՐՏidx51 < ՐՏitr51.length; ՐՏidx51++) {
-                        decorator = ՐՏitr51[ՐՏidx51];
+                    ՐՏitr54 = ՐՏ_Iterable(S.decorators);
+                    for (ՐՏidx54 = 0; ՐՏidx54 < ՐՏitr54.length; ՐՏidx54++) {
+                        decorator = ՐՏitr54[ՐՏidx54];
                         d.push(new ast.Decorator({
                             expression: decorator
                         }));
@@ -5575,6 +5499,7 @@ var ՐՏ_modules = {};
                 }(),
                 return_annotation: return_annotation,
                 body: function(loop, labels) {
+                    var ՐՏ_305, ՐՏ_306, ՐՏ_307, ՐՏ_308, ՐՏ_309, ՐՏ_310;
                     var a, variable;
                     S.in_scope.push({
                         type: "function",
@@ -5590,15 +5515,15 @@ var ՐՏ_modules = {};
                     S.in_loop = 0;
                     S.labels = [];
                     a = block_();
-                    generator = S.in_scope[S.in_scope.length-1].generator;
-                    docstring = S.in_scope[S.in_scope.length-1].docstring;
-                    callsSuper = S.in_scope[S.in_scope.length-1].callsSuper;
-                    superCall_expr = S.in_scope[S.in_scope.length-1].superCall_expr;
+                    generator = (ՐՏ_305 = S.in_scope)[ՐՏ_305.length-1].generator;
+                    docstring = (ՐՏ_306 = S.in_scope)[ՐՏ_306.length-1].docstring;
+                    callsSuper = (ՐՏ_307 = S.in_scope)[ՐՏ_307.length-1].callsSuper;
+                    superCall_expr = (ՐՏ_308 = S.in_scope)[ՐՏ_308.length-1].superCall_expr;
                     localvars = (function() {
-                        var ՐՏidx52, ՐՏitr52 = ՐՏ_Iterable(Object.keys(S.in_scope[S.in_scope.length-1].vars)), ՐՏres = [], variable;
-                        for (ՐՏidx52 = 0; ՐՏidx52 < ՐՏitr52.length; ՐՏidx52++) {
-                            variable = ՐՏitr52[ՐՏidx52];
-                            if (!(ՐՏ_in(variable, S.in_scope[S.in_scope.length-1].nonlocal))) {
+                        var ՐՏidx55, ՐՏitr55 = ՐՏ_Iterable(Object.keys((ՐՏ_309 = S.in_scope)[ՐՏ_309.length-1].vars)), ՐՏres = [], variable;
+                        for (ՐՏidx55 = 0; ՐՏidx55 < ՐՏitr55.length; ՐՏidx55++) {
+                            variable = ՐՏitr55[ՐՏidx55];
+                            if (!(ՐՏ_in(variable, (ՐՏ_310 = S.in_scope)[ՐՏ_310.length-1].nonlocal))) {
                                 ՐՏres.push(new_symbol(ast.SymbolVar, variable));
                             }
                         }
@@ -5616,12 +5541,12 @@ var ՐՏ_modules = {};
                 static: in_class && staticmethod
             });
             if (name) {
-                S.in_scope[S.in_scope.length-1].functions[name.name] = definition.resolveType(S.in_scope);
+                (ՐՏ_311 = (ՐՏ_312 = S.in_scope)[ՐՏ_312.length-1].functions)[name.name] = definition.resolveType(S.in_scope);
             }
             args = (function() {
-                var ՐՏidx53, ՐՏitr53 = ՐՏ_Iterable(definition.argnames), ՐՏres = [], arg;
-                for (ՐՏidx53 = 0; ՐՏidx53 < ՐՏitr53.length; ՐՏidx53++) {
-                    arg = ՐՏitr53[ՐՏidx53];
+                var ՐՏidx56, ՐՏitr56 = ՐՏ_Iterable(definition.argnames), ՐՏres = [], arg;
+                for (ՐՏidx56 = 0; ՐՏidx56 < ՐՏitr56.length; ՐՏidx56++) {
+                    arg = ՐՏitr56[ՐՏidx56];
                     ՐՏres.push(arg.name);
                 }
                 return ՐՏres;
@@ -5632,10 +5557,10 @@ var ՐՏ_modules = {};
             if (in_class_or_xobject && !staticmethod) {
                 if (in_class) {
                     if (ctor === ast.Constructor) {
-                        definition.parent = S.in_scope[S.in_scope.length-1].parent;
+                        definition.parent = (ՐՏ_313 = S.in_scope)[ՐՏ_313.length-1].parent;
                         definition.callsSuper = callsSuper;
                         if (superCall_expr) {
-                            superCall_expr.selfArg = definition.argnames[0];
+                            superCall_expr.selfArg = (ՐՏ_314 = definition.argnames)[0];
                         }
                     }
                 }
@@ -5684,41 +5609,43 @@ var ՐՏ_modules = {};
             });
         }
         function is_docstring(stmt) {
-            if (stmt instanceof ast.Directive && !S.in_scope[S.in_scope.length-1].docstring) {
+            var ՐՏ_315;
+            if (stmt instanceof ast.Directive && !(ՐՏ_315 = S.in_scope)[ՐՏ_315.length-1].docstring) {
                 return true;
             }
             return false;
         }
         function format_docstring(string) {
-            var ՐՏitr54, ՐՏidx54, ՐՏitr55, ՐՏidx55;
+            var ՐՏitr57, ՐՏidx57, ՐՏ_316, ՐՏ_317, ՐՏitr58, ՐՏidx58, ՐՏ_318, ՐՏ_319;
             var lines, indent, line, pad, trimmed;
             lines = string.split(/\n/g);
             indent = 1e6;
-            ՐՏitr54 = ՐՏ_Iterable(lines.slice(1));
-            for (ՐՏidx54 = 0; ՐՏidx54 < ՐՏitr54.length; ՐՏidx54++) {
-                line = ՐՏitr54[ՐՏidx54];
+            ՐՏitr57 = ՐՏ_Iterable(lines.slice(1));
+            for (ՐՏidx57 = 0; ՐՏidx57 < ՐՏitr57.length; ՐՏidx57++) {
+                line = ՐՏitr57[ՐՏidx57];
                 if (line.trim().length) {
-                    pad = line.match(/^\s*/)[0];
+                    pad = (ՐՏ_316 = line.match(/^\s*/))[0];
                     indent = Math.min(indent, pad.length);
                 }
             }
-            trimmed = [ lines[0].trim() ];
+            trimmed = [ (ՐՏ_317 = lines)[0].trim() ];
             if (indent < 1e6) {
-                ՐՏitr55 = ՐՏ_Iterable(lines.slice(1));
-                for (ՐՏidx55 = 0; ՐՏidx55 < ՐՏitr55.length; ՐՏidx55++) {
-                    line = ՐՏitr55[ՐՏidx55];
+                ՐՏitr58 = ՐՏ_Iterable(lines.slice(1));
+                for (ՐՏidx58 = 0; ՐՏidx58 < ՐՏitr58.length; ՐՏidx58++) {
+                    line = ՐՏitr58[ՐՏidx58];
                     trimmed.push(line.slice(indent).replace(/\s+$/));
                 }
             }
-            while (trimmed && !trimmed[trimmed.length-1]) {
+            while (trimmed && !(ՐՏ_318 = trimmed)[ՐՏ_318.length-1]) {
                 trimmed.pop();
             }
-            while (trimmed && !trimmed[0]) {
+            while (trimmed && !(ՐՏ_319 = trimmed)[0]) {
                 trimmed.shift();
             }
             return trimmed.join("\n");
         }
         function block_() {
+            var ՐՏ_320, ՐՏ_321;
             var a, stmt;
             expect(":");
             a = [];
@@ -5730,7 +5657,7 @@ var ՐՏ_modules = {};
                     stmt = statement();
                     if (!a.length && is_docstring(stmt)) {
                         if (!options.dropDocstrings) {
-                            S.in_scope[S.in_scope.length-1].docstring = format_docstring(stmt.value);
+                            (ՐՏ_320 = S.in_scope)[ՐՏ_320.length-1].docstring = format_docstring(stmt.value);
                         }
                     } else {
                         a.push(stmt);
@@ -5744,7 +5671,7 @@ var ՐՏ_modules = {};
                     stmt = statement();
                     if (!a.length && is_docstring(stmt)) {
                         if (!options.dropDocstrings) {
-                            S.in_scope[S.in_scope.length-1].docstring = format_docstring(stmt.value);
+                            (ՐՏ_321 = S.in_scope)[ՐՏ_321.length-1].docstring = format_docstring(stmt.value);
                         }
                     } else {
                         a.push(stmt);
@@ -5860,6 +5787,7 @@ var ՐՏ_modules = {};
             });
         }
         function vardefs(no_in, type) {
+            var ՐՏ_322, ՐՏ_323;
             var a, symbol;
             a = [];
             while (true) {
@@ -5869,7 +5797,7 @@ var ՐՏ_modules = {};
                     end: prev()
                 });
                 if (type === "nonlocal") {
-                    S.in_scope[S.in_scope.length-1].nonlocal[symbol.name.name] = true;
+                    (ՐՏ_322 = (ՐՏ_323 = S.in_scope)[ՐՏ_323.length-1].nonlocal)[symbol.name.name] = true;
                 }
                 a.push(symbol);
                 if (!is_("punc", ",")) {
@@ -5894,11 +5822,12 @@ var ՐՏ_modules = {};
             });
         }
         function yield_() {
+            var ՐՏ_324, ՐՏ_325;
             var value, yield_from, ret;
-            if (S.in_scope[S.in_scope.length-1].type !== "function") {
+            if ((ՐՏ_324 = S.in_scope)[ՐՏ_324.length-1].type !== "function") {
                 croak("'yield' outside of function");
             }
-            S.in_scope[S.in_scope.length-1].generator = true;
+            (ՐՏ_325 = S.in_scope)[ՐՏ_325.length-1].generator = true;
             value = null;
             yield_from = false;
             if (is_("punc", ";")) {
@@ -6015,6 +5944,7 @@ var ՐՏ_modules = {};
             return ret;
         }
         function expr_atom(allow_calls) {
+            var ՐՏ_326;
             var start, tmp_, ex, cls, func;
             if (is_("operator", "new")) {
                 return new_();
@@ -6056,13 +5986,13 @@ var ՐՏ_modules = {};
             if (is_("keyword", "yield")) {
                 return yield_request();
             }
-            if (ATOMIC_START_TOKEN[S.token.type]) {
+            if ((ՐՏ_326 = ATOMIC_START_TOKEN)[S.token.type]) {
                 return subscripts(as_atom_node(), allow_calls);
             }
             unexpected();
         }
         function expr_list(closing, allow_trailing_comma, allow_empty, func_call) {
-            var ՐՏitr56, ՐՏidx56, ՐՏupk4;
+            var ՐՏitr59, ՐՏidx59, ՐՏupk4, ՐՏ_327;
             var first, a, saw_starargs, tmp, i, arg;
             first = true;
             a = [];
@@ -6095,13 +6025,13 @@ var ՐՏ_modules = {};
             if (func_call) {
                 tmp = [];
                 tmp.kwargs = [];
-                ՐՏitr56 = ՐՏ_Iterable(enumerate(a));
-                for (ՐՏidx56 = 0; ՐՏidx56 < ՐՏitr56.length; ՐՏidx56++) {
-                    ՐՏupk4 = ՐՏitr56[ՐՏidx56];
+                ՐՏitr59 = ՐՏ_Iterable(enumerate(a));
+                for (ՐՏidx59 = 0; ՐՏidx59 < ՐՏitr59.length; ՐՏidx59++) {
+                    ՐՏupk4 = ՐՏitr59[ՐՏidx59];
                     i = ՐՏupk4[0];
                     arg = ՐՏupk4[1];
                     if (arg instanceof ast.Assign) {
-                        ++BASELIB["kwargs"];
+                        ++(ՐՏ_327 = BASELIB)["kwargs"];
                         tmp.kwargs.push([ arg.left, arg.right ]);
                     } else {
                         tmp.push(arg);
@@ -6116,6 +6046,7 @@ var ՐՏ_modules = {};
             return a;
         }
         function func_call_list() {
+            var ՐՏ_328, ՐՏ_329;
             var a, first, kwargs, arg;
             a = [];
             first = true;
@@ -6135,13 +6066,13 @@ var ՐՏ_modules = {};
                     a.push(arg);
                     a.starargs = true;
                 } else if (is_("operator", "**")) {
-                    ++BASELIB["kwargs"];
+                    ++(ՐՏ_328 = BASELIB)["kwargs"];
                     next();
                     kwargs.push(as_symbol(ast.SymbolVar, false));
                 } else {
                     arg = expression(false);
                     if (arg instanceof ast.Assign) {
-                        ++BASELIB["kwargs"];
+                        ++(ՐՏ_329 = BASELIB)["kwargs"];
                         a.kwargs.push([ arg.left, arg.right ]);
                     } else {
                         a.push(arg);
@@ -6152,11 +6083,12 @@ var ՐՏ_modules = {};
             return a;
         }
         function read_comprehension(object) {
+            var ՐՏ_330;
             var terminator, forloop;
             terminator = object instanceof ast.DictComprehension ? "}" : "]";
             expect_token("keyword", "for");
             forloop = for_(true);
-            ++BASELIB["iterable"];
+            ++(ՐՏ_330 = BASELIB)["iterable"];
             object.init = forloop.init;
             object.name = forloop.name;
             object.object = forloop.object;
@@ -6166,7 +6098,8 @@ var ՐՏ_modules = {};
             return object;
         }
         
-        var array_ = (ՐՏ_120 = function array_() {
+        var array_ = (ՐՏ_331 = function array_() {
+            var ՐՏ_332, ՐՏ_333, ՐՏ_334, ՐՏ_335, ՐՏ_336, ՐՏ_337, ՐՏ_338;
             var expr, ret;
             expect("[");
             expr = [];
@@ -6174,31 +6107,31 @@ var ՐՏ_modules = {};
                 expr.push(expression(false));
                 if (is_("keyword", "for")) {
                     return read_comprehension(new ast.ListComprehension({
-                        statement: expr[0]
+                        statement: (ՐՏ_332 = expr)[0]
                     }));
                 }
                 if (is_("operator", "til")) {
-                    ++BASELIB["range"];
+                    ++(ՐՏ_333 = BASELIB)["range"];
                     next();
                     expr.push(expression(false));
                     ret = new ast.Range({
                         start: S.token,
-                        left: expr[0],
+                        left: (ՐՏ_334 = expr)[0],
                         operator: "til",
-                        right: expr[1],
+                        right: (ՐՏ_335 = expr)[1],
                         end: prev()
                     });
                     expect("]");
                     return ret;
                 } else if (is_("operator", "to")) {
-                    ++BASELIB["range"];
+                    ++(ՐՏ_336 = BASELIB)["range"];
                     next();
                     expr.push(expression(false));
                     ret = new ast.Range({
                         start: S.token,
-                        left: expr[0],
+                        left: (ՐՏ_337 = expr)[0],
                         operator: "to",
-                        right: expr[1],
+                        right: (ՐՏ_338 = expr)[1],
                         end: prev()
                     });
                     expect("]");
@@ -6210,9 +6143,10 @@ var ՐՏ_modules = {};
             return new ast.Array({
                 elements: expr.concat(expr_list("]", !options.strict, true))
             });
-        }, ՐՏ_120 = embed_tokens(ՐՏ_120), ՐՏ_120);
+        }, ՐՏ_331 = embed_tokens(ՐՏ_331), ՐՏ_331);
         
-        var object_ = (ՐՏ_121 = function object_() {
+        var object_ = (ՐՏ_339 = function object_() {
+            var ՐՏ_340, ՐՏ_341;
             var maybe_dict_comprehension, must_be_comprehension, first, a, start, type, fun_type, value, key, name, key_;
             maybe_dict_comprehension = false;
             must_be_comprehension = false;
@@ -6321,8 +6255,8 @@ var ՐՏ_modules = {};
                 }));
                 if (first && is_("keyword", "for")) {
                     return read_comprehension(new ast.DictComprehension({
-                        statement: maybe_dict_comprehension ? key : as_atom_node(a[0].start),
-                        value_statement: a[0].value
+                        statement: maybe_dict_comprehension ? key : as_atom_node((ՐՏ_340 = a)[0].start),
+                        value_statement: (ՐՏ_341 = a)[0].value
                     }));
                 } else if (must_be_comprehension) {
                     unexpected();
@@ -6333,7 +6267,7 @@ var ՐՏ_modules = {};
             return new ast.ObjectLiteral({
                 properties: a
             });
-        }, ՐՏ_121 = embed_tokens(ՐՏ_121), ՐՏ_121);
+        }, ՐՏ_339 = embed_tokens(ՐՏ_339), ՐՏ_339);
         function as_property_name() {
             var tmp, tmp_;
             tmp = S.token;
@@ -6413,6 +6347,7 @@ var ՐՏ_modules = {};
             }
         }
         function mark_local_assignment(element, value) {
+            var ՐՏ_342, ՐՏ_343, ՐՏ_344, ՐՏ_345, ՐՏ_346;
             var computedType, name;
             if (value) {
                 computedType = typeof value === "string" ? value : value.resolveType(S.in_scope);
@@ -6421,14 +6356,15 @@ var ՐՏ_modules = {};
             }
             name = typeof element === "string" ? element : element.name;
             if (name) {
-                if (ՐՏ_in(name, S.in_scope[S.in_scope.length-1].vars)) {
-                    S.in_scope[S.in_scope.length-1].vars[name].push(computedType);
+                if (ՐՏ_in(name, (ՐՏ_342 = S.in_scope)[ՐՏ_342.length-1].vars)) {
+                    (ՐՏ_343 = (ՐՏ_344 = S.in_scope)[ՐՏ_344.length-1].vars)[name].push(computedType);
                 } else {
-                    S.in_scope[S.in_scope.length-1].vars[name] = [ computedType ];
+                    (ՐՏ_345 = (ՐՏ_346 = S.in_scope)[ՐՏ_346.length-1].vars)[name] = [ computedType ];
                 }
             }
         }
         function subscripts(expr, allow_calls) {
+            var ՐՏ_347, ՐՏ_348, ՐՏ_349, ՐՏ_350, ՐՏ_351, ՐՏ_352, ՐՏ_353, ՐՏ_354, ՐՏ_355, ՐՏ_356, ՐՏ_357, ՐՏ_358, ՐՏ_359, ՐՏ_360, ՐՏ_361, ՐՏ_362, ՐՏ_363, ՐՏ_364, ՐՏ_365;
             var start, slice_bounds, is_slice, i, str_, ret, className, funcname, is_super, ast_ClassCall, tmp_, args;
             start = expr.start;
             if (is_("punc", ".")) {
@@ -6459,7 +6395,7 @@ var ՐՏ_modules = {};
                     }
                 }
                 if (is_("punc", ":")) {
-                    ++BASELIB["eslice"];
+                    ++(ՐՏ_347 = BASELIB)["eslice"];
                     next();
                     if (is_("punc", "]")) {
                         unexpected();
@@ -6474,22 +6410,22 @@ var ՐՏ_modules = {};
                         return subscripts(new ast.Slice({
                             start: start,
                             expression: expr,
-                            property: slice_bounds[0] || new ast.Number({
+                            property: (ՐՏ_348 = slice_bounds)[0] || new ast.Number({
                                 value: 0
                             }),
-                            property2: slice_bounds[1],
+                            property2: (ՐՏ_349 = slice_bounds)[1],
                             assignment: expression(true),
                             end: prev()
                         }), allow_calls);
                     } else if (slice_bounds.length === 3) {
                         slice_bounds.unshift(slice_bounds.pop());
-                        if (!slice_bounds[slice_bounds.length-1]) {
+                        if (!(ՐՏ_350 = slice_bounds)[ՐՏ_350.length-1]) {
                             slice_bounds.pop();
-                            if (!slice_bounds[slice_bounds.length-1]) {
+                            if (!(ՐՏ_351 = slice_bounds)[ՐՏ_351.length-1]) {
                                 slice_bounds.pop();
                             }
-                        } else if (!slice_bounds[slice_bounds.length-2]) {
-                            slice_bounds[slice_bounds.length-2] = new ast.Undefined();
+                        } else if (!(ՐՏ_352 = slice_bounds)[ՐՏ_352.length-2]) {
+                            (ՐՏ_353 = slice_bounds)[ՐՏ_353.length-2] = new ast.Undefined();
                         }
                         return subscripts(new ast.Call({
                             start: start,
@@ -6501,9 +6437,9 @@ var ՐՏ_modules = {};
                         }), allow_calls);
                     } else {
                         slice_bounds = (function() {
-                            var ՐՏidx57, ՐՏitr57 = ՐՏ_Iterable(slice_bounds), ՐՏres = [], i;
-                            for (ՐՏidx57 = 0; ՐՏidx57 < ՐՏitr57.length; ՐՏidx57++) {
-                                i = ՐՏitr57[ՐՏidx57];
+                            var ՐՏidx60, ՐՏitr60 = ՐՏ_Iterable(slice_bounds), ՐՏres = [], i;
+                            for (ՐՏidx60 = 0; ՐՏidx60 < ՐՏitr60.length; ՐՏidx60++) {
+                                i = ՐՏitr60[ՐՏidx60];
                                 ՐՏres.push(i === null ? new ast.Number({
                                     value: 0
                                 }) : i);
@@ -6526,7 +6462,7 @@ var ՐՏ_modules = {};
                     return subscripts(new ast.Sub({
                         start: start,
                         expression: expr,
-                        property: slice_bounds[0] || new ast.Number({
+                        property: (ՐՏ_354 = slice_bounds)[0] || new ast.Number({
                             value: 0
                         }),
                         end: prev()
@@ -6549,9 +6485,9 @@ var ՐՏ_modules = {};
                     return subscripts(ret, true);
                 } else if (!expr.parens && get_class_in_scope(expr)) {
                     if (ՐՏ_in(expr.name, STDLIB)) {
-                        ++BASELIB[expr.name];
+                        ++(ՐՏ_355 = BASELIB)[expr.name];
                         if (/Error$/.test(expr.name)) {
-                            ++BASELIB["extends"];
+                            ++(ՐՏ_356 = BASELIB)["extends"];
                         }
                     }
                     return subscripts(new ast.New({
@@ -6569,8 +6505,8 @@ var ՐՏ_modules = {};
                         if (funcname.property === "__init__") {
                             funcname.property = "constructor";
                         }
-                        is_super = S.in_scope.length > 1 && S.in_scope[S.in_scope.length-2].type === "class" && stringifyName(expr.expression) === S.in_scope[S.in_scope.length-2].parent;
-                        S.in_scope[S.in_scope.length-1].callsSuper = S.in_scope[S.in_scope.length-1].callsSuper || is_super;
+                        is_super = S.in_scope.length > 1 && (ՐՏ_357 = S.in_scope)[ՐՏ_357.length-2].type === "class" && stringifyName(expr.expression) === (ՐՏ_358 = S.in_scope)[ՐՏ_358.length-2].parent;
+                        (ՐՏ_359 = S.in_scope)[ՐՏ_359.length-1].callsSuper = (ՐՏ_360 = S.in_scope)[ՐՏ_360.length-1].callsSuper || is_super;
                         ast_ClassCall = new ast.ClassCall({
                             start: start,
                             class: expr.expression,
@@ -6591,7 +6527,7 @@ var ՐՏ_modules = {};
                     } else if (expr instanceof ast.SymbolRef) {
                         tmp_ = expr.name;
                         if (ՐՏ_in(tmp_, STDLIB)) {
-                            ++BASELIB[tmp_];
+                            ++(ՐՏ_361 = BASELIB)[tmp_];
                         } else if (tmp_ === "isinstance") {
                             args = func_call_list();
                             if (args.length !== 2) {
@@ -6600,13 +6536,13 @@ var ՐՏ_modules = {};
                             return new ast.Binary({
                                 start: start,
                                 operator: "instanceof",
-                                left: args[0],
-                                right: args[1],
+                                left: (ՐՏ_362 = args)[0],
+                                right: (ՐՏ_363 = args)[1],
                                 end: prev()
                             });
                         } else if (tmp_ === "super") {
-                            S.in_scope[S.in_scope.length-1].callsSuper = true;
-                            S.in_scope[S.in_scope.length-1].superCall_expr = expr;
+                            (ՐՏ_364 = S.in_scope)[ՐՏ_364.length-1].callsSuper = true;
+                            (ՐՏ_365 = S.in_scope)[ՐՏ_365.length-1].superCall_expr = expr;
                         } else {
                             expr.name = maybe_keyword(expr.name);
                         }
@@ -6700,22 +6636,23 @@ var ՐՏ_modules = {};
             }));
         }
         function validateBinary(astElement) {
+            var ՐՏ_366, ՐՏ_367, ՐՏ_368, ՐՏ_369;
             var left, right, op;
             left = astElement.left.resolveType(S.in_scope);
             right = astElement.right.resolveType(S.in_scope);
             op = astElement.operator;
             if (!(ՐՏ_in(op, [ "in", "instanceof", "==", "!=", "===", "!==", "||", "&&", "=" ])) && (!(ՐՏ_in(left, [ "Number", "String", "Boolean", "?" ])) || !(ՐՏ_in(right, [ "Number", "String", "Boolean", "?" ])) || (left === "String" || right === "String") && (left === right ? !(ՐՏ_in(op, [ "+", "+=", "<", "<=", ">", ">=" ])) : !(ՐՏ_in(op, [ "+", "+=" ]))))) {
                 if (left) {
-                    if (left[0] === "[") {
+                    if ((ՐՏ_366 = left)[0] === "[") {
                         left = "Array";
-                    } else if (left[0] === "{") {
+                    } else if ((ՐՏ_367 = left)[0] === "{") {
                         left = "Object";
                     }
                 }
                 if (right) {
-                    if (right[0] === "[") {
+                    if ((ՐՏ_368 = right)[0] === "[") {
                         right = "Array";
-                    } else if (right[0] === "{") {
+                    } else if ((ՐՏ_369 = right)[0] === "{") {
                         right = "Object";
                     }
                 }
@@ -6724,6 +6661,7 @@ var ՐՏ_modules = {};
             return astElement;
         }
         function validateUnary(astElement) {
+            var ՐՏ_370, ՐՏ_371, ՐՏ_372;
             var element, op;
             element = astElement.expression.resolveType(S.in_scope);
             op = astElement.operator;
@@ -6731,10 +6669,10 @@ var ՐՏ_modules = {};
                 if (op !== "!") {
                     throw croak("cannot perform unary '" + op + "' operation on incompatible element of type " + element);
                 }
-            } else if (!(ՐՏ_in(element, [ "Number", "?" ])) && ՐՏ_in(op, [ "+", "-" ]) || !(ՐՏ_in(element[0], [ "[", "{", "?" ])) && op === "*") {
-                if (element[0] === "[") {
+            } else if (!(ՐՏ_in(element, [ "Number", "?" ])) && ՐՏ_in(op, [ "+", "-" ]) || !(ՐՏ_in((ՐՏ_370 = element)[0], [ "[", "{", "?" ])) && op === "*") {
+                if ((ՐՏ_371 = element)[0] === "[") {
                     element = "Array";
-                } else if (element[0] === "{") {
+                } else if ((ՐՏ_372 = element)[0] === "{") {
                     element = "Object";
                 }
                 throw croak("cannot perform unary '" + op + "' operation on incompatible element of type " + element);
@@ -6742,28 +6680,28 @@ var ՐՏ_modules = {};
             return astElement;
         }
         function validateCallArgs(astElement) {
-            var ՐՏitr58, ՐՏidx58, ՐՏitr59, ՐՏidx59, ՐՏitr60, ՐՏidx60, ՐՏitr61, ՐՏidx61, ՐՏupk5;
+            var ՐՏitr61, ՐՏidx61, ՐՏitr62, ՐՏidx62, ՐՏ_373, ՐՏitr63, ՐՏidx63, ՐՏ_374, ՐՏ_375, ՐՏ_376, ՐՏitr64, ՐՏidx64, ՐՏupk5, ՐՏ_377;
             var name, found, scope, func, signature, variable, args, i, arg, expected, actual;
             if (astElement.expression instanceof ast.SymbolRef) {
                 name = astElement.expression.name;
                 found = false;
-                ՐՏitr58 = ՐՏ_Iterable(reversed(S.in_scope));
-                for (ՐՏidx58 = 0; ՐՏidx58 < ՐՏitr58.length; ՐՏidx58++) {
-                    scope = ՐՏitr58[ՐՏidx58];
-                    ՐՏitr59 = ՐՏ_Iterable(scope.functions);
-                    for (ՐՏidx59 = 0; ՐՏidx59 < ՐՏitr59.length; ՐՏidx59++) {
-                        func = ՐՏitr59[ՐՏidx59];
+                ՐՏitr61 = ՐՏ_Iterable(reversed(S.in_scope));
+                for (ՐՏidx61 = 0; ՐՏidx61 < ՐՏitr61.length; ՐՏidx61++) {
+                    scope = ՐՏitr61[ՐՏidx61];
+                    ՐՏitr62 = ՐՏ_Iterable(scope.functions);
+                    for (ՐՏidx62 = 0; ՐՏidx62 < ՐՏitr62.length; ՐՏidx62++) {
+                        func = ՐՏitr62[ՐՏidx62];
                         if (func === name) {
-                            signature = scope.functions[func];
+                            signature = (ՐՏ_373 = scope.functions)[func];
                             found = true;
                             break;
                         }
                     }
-                    ՐՏitr60 = ՐՏ_Iterable(scope.vars);
-                    for (ՐՏidx60 = 0; ՐՏidx60 < ՐՏitr60.length; ՐՏidx60++) {
-                        variable = ՐՏitr60[ՐՏidx60];
+                    ՐՏitr63 = ՐՏ_Iterable(scope.vars);
+                    for (ՐՏidx63 = 0; ՐՏidx63 < ՐՏitr63.length; ՐՏidx63++) {
+                        variable = ՐՏitr63[ՐՏidx63];
                         if (variable === name) {
-                            signature = scope.vars[func];
+                            signature = (ՐՏ_374 = scope.vars)[func];
                             found = true;
                             break;
                         }
@@ -6773,19 +6711,19 @@ var ՐՏ_modules = {};
                     }
                 }
                 if (signature && signature.slice(0, 9) === "Function(") {
-                    args = /\((.*)\)/.exec(signature)[1].split(",");
-                    if (args.length === 1 && !args[0].length) {
+                    args = (ՐՏ_375 = /\((.*)\)/.exec(signature))[1].split(",");
+                    if (args.length === 1 && !(ՐՏ_376 = args)[0].length) {
                         args.pop();
                     }
                     if (args.length < astElement.args.length) {
                         croak("Function '" + name + "' takes " + args.length + " arguments, yet your call contains " + astElement.args.length + "");
                     }
-                    ՐՏitr61 = ՐՏ_Iterable(enumerate(astElement.args));
-                    for (ՐՏidx61 = 0; ՐՏidx61 < ՐՏitr61.length; ՐՏidx61++) {
-                        ՐՏupk5 = ՐՏitr61[ՐՏidx61];
+                    ՐՏitr64 = ՐՏ_Iterable(enumerate(astElement.args));
+                    for (ՐՏidx64 = 0; ՐՏidx64 < ՐՏitr64.length; ՐՏidx64++) {
+                        ՐՏupk5 = ՐՏitr64[ՐՏidx64];
                         i = ՐՏupk5[0];
                         arg = ՐՏupk5[1];
-                        expected = args[i].trim();
+                        expected = (ՐՏ_377 = args)[i].trim();
                         actual = arg.resolveType(S.in_scope);
                         if (expected !== "?" && !(ՐՏ_in(actual, [ expected, "?" ]))) {
                             croak("Function '" + name + "' expects argument " + i + " type of " + expected + ", but you're passing " + actual + "");
@@ -6796,6 +6734,7 @@ var ՐՏ_modules = {};
             return astElement;
         }
         function expr_op(left, min_prec, no_in) {
+            var ՐՏ_378, ՐՏ_379, ՐՏ_380;
             var op, not_in, prec, right, ret;
             op = is_("operator") ? S.token.value : null;
             not_in = false;
@@ -6808,15 +6747,15 @@ var ՐՏ_modules = {};
                 if (no_in) {
                     op = null;
                 } else {
-                    ++BASELIB[op];
+                    ++(ՐՏ_378 = BASELIB)[op];
                 }
             }
-            prec = op !== null ? tokenizer.PRECEDENCE[op] : null;
+            prec = op !== null ? (ՐՏ_379 = tokenizer.PRECEDENCE)[op] : null;
             if (prec !== null && prec > min_prec) {
                 next();
                 right = expr_op(maybe_unary(true), prec, no_in);
                 if (ՐՏ_in(op, [ "==", "!=" ])) {
-                    ++BASELIB["eq"];
+                    ++(ՐՏ_380 = BASELIB)["eq"];
                     ret = new ast.DeepEquality({
                         start: left.start,
                         left: left,
@@ -6868,7 +6807,7 @@ var ՐՏ_modules = {};
             return expr;
         }
         function isAssignable(expr) {
-            var ՐՏitr62, ՐՏidx62;
+            var ՐՏitr65, ՐՏidx65;
             var element;
             if (expr instanceof ast.PropAccess) {
                 return true;
@@ -6880,9 +6819,9 @@ var ՐՏ_modules = {};
                 return true;
             }
             if (expr instanceof ast.Array) {
-                ՐՏitr62 = ՐՏ_Iterable(expr.elements);
-                for (ՐՏidx62 = 0; ՐՏidx62 < ՐՏitr62.length; ՐՏidx62++) {
-                    element = ՐՏitr62[ՐՏidx62];
+                ՐՏitr65 = ՐՏ_Iterable(expr.elements);
+                for (ՐՏidx65 = 0; ՐՏidx65 < ՐՏitr65.length; ՐՏidx65++) {
+                    element = ՐՏitr65[ՐՏidx65];
                     if (!isAssignable(element)) {
                         return false;
                     }
@@ -6897,13 +6836,14 @@ var ՐՏ_modules = {};
             return false;
         }
         function maybe_assign(no_in) {
+            var ՐՏ_381, ՐՏ_382, ՐՏ_383, ՐՏ_384;
             var start, left, val, right;
             start = S.token;
             left = maybe_conditional(no_in);
             val = S.token.value;
             if (is_("operator") && ASSIGNMENT(val)) {
                 if (isAssignable(left)) {
-                    if (left instanceof ast.SymbolRef && val !== "=" && !(ՐՏ_in(left.name, S.in_scope[S.in_scope.length-1].vars)) && (!S.in_scope[S.in_scope.length-1].args || !(ՐՏ_in(left.name, S.in_scope[S.in_scope.length-1].args))) && !(ՐՏ_in(left.name, S.in_scope[S.in_scope.length-1].nonlocal))) {
+                    if (left instanceof ast.SymbolRef && val !== "=" && !(ՐՏ_in(left.name, (ՐՏ_381 = S.in_scope)[ՐՏ_381.length-1].vars)) && (!(ՐՏ_382 = S.in_scope)[ՐՏ_382.length-1].args || !(ՐՏ_in(left.name, (ՐՏ_383 = S.in_scope)[ՐՏ_383.length-1].args))) && !(ՐՏ_in(left.name, (ՐՏ_384 = S.in_scope)[ՐՏ_384.length-1].nonlocal))) {
                         croak("Attempting to increment/modify uninitialized variable '" + left.name + "', this can also occur if you're trying to shadow without initializing the variable in local scope.");
                     }
                     next();
@@ -6924,7 +6864,7 @@ var ՐՏ_modules = {};
             return left;
         }
         function expression(commas, no_in) {
-            var ՐՏitr63, ՐՏidx63, ՐՏupk6, ՐՏitr64, ՐՏidx64, ՐՏupk7;
+            var ՐՏ_385, ՐՏ_386, ՐՏ_387, ՐՏ_388, ՐՏ_389, ՐՏitr66, ՐՏidx66, ՐՏupk6, ՐՏ_390, ՐՏ_391, ՐՏ_392, ՐՏ_393, ՐՏitr67, ՐՏidx67, ՐՏupk7, ՐՏ_394;
             var start, expr, left, leftAst, right, index, element, seq;
             start = S.token;
             expr = maybe_assign(no_in);
@@ -6934,12 +6874,12 @@ var ՐՏ_modules = {};
                     S.in_seq = true;
                     next();
                     if (expr instanceof ast.Assign) {
-                        left[left.length-1] = left[left.length-1].left;
+                        (ՐՏ_385 = left)[ՐՏ_385.length-1] = (ՐՏ_386 = left)[ՐՏ_386.length-1].left;
                         if (left.length === 1) {
-                            if (left[0] instanceof ast.Seq) {
-                                leftAst = seq_to_array(left[0]);
+                            if ((ՐՏ_387 = left)[0] instanceof ast.Seq) {
+                                leftAst = seq_to_array((ՐՏ_388 = left)[0]);
                             } else {
-                                leftAst = left[0];
+                                leftAst = (ՐՏ_389 = left)[0];
                             }
                         } else {
                             leftAst = new ast.Array({
@@ -6950,12 +6890,12 @@ var ՐՏ_modules = {};
                             car: expr.right,
                             cdr: expression(true, no_in)
                         }));
-                        ՐՏitr63 = ՐՏ_Iterable(enumerate(leftAst.elements));
-                        for (ՐՏidx63 = 0; ՐՏidx63 < ՐՏitr63.length; ՐՏidx63++) {
-                            ՐՏupk6 = ՐՏitr63[ՐՏidx63];
+                        ՐՏitr66 = ՐՏ_Iterable(enumerate(leftAst.elements));
+                        for (ՐՏidx66 = 0; ՐՏidx66 < ՐՏitr66.length; ՐՏidx66++) {
+                            ՐՏupk6 = ՐՏitr66[ՐՏidx66];
                             index = ՐՏupk6[0];
                             element = ՐՏupk6[1];
-                            mark_local_assignment(element, right.elements[index]);
+                            mark_local_assignment(element, (ՐՏ_390 = right.elements)[index]);
                         }
                         return new ast.Assign({
                             start: start,
@@ -6972,14 +6912,14 @@ var ՐՏ_modules = {};
                 if (expr instanceof ast.Assign && expr.left instanceof ast.Seq) {
                     expr.left = seq_to_array(expr.left);
                 }
-                if (left.length > 1 && left[left.length-1] instanceof ast.Assign) {
-                    left[left.length-1] = left[left.length-1].left;
-                    ՐՏitr64 = ՐՏ_Iterable(enumerate(left));
-                    for (ՐՏidx64 = 0; ՐՏidx64 < ՐՏitr64.length; ՐՏidx64++) {
-                        ՐՏupk7 = ՐՏitr64[ՐՏidx64];
+                if (left.length > 1 && (ՐՏ_391 = left)[ՐՏ_391.length-1] instanceof ast.Assign) {
+                    (ՐՏ_392 = left)[ՐՏ_392.length-1] = (ՐՏ_393 = left)[ՐՏ_393.length-1].left;
+                    ՐՏitr67 = ՐՏ_Iterable(enumerate(left));
+                    for (ՐՏidx67 = 0; ՐՏidx67 < ՐՏitr67.length; ՐՏidx67++) {
+                        ՐՏupk7 = ՐՏitr67[ՐՏidx67];
                         index = ՐՏupk7[0];
                         element = ՐՏupk7[1];
-                        mark_local_assignment(element, expr.right instanceof ast.Array ? expr.right.elements[index] : null);
+                        mark_local_assignment(element, expr.right instanceof ast.Array ? (ՐՏ_394 = expr.right.elements)[index] : null);
                     }
                     return new ast.Assign({
                         start: start,
@@ -6992,17 +6932,17 @@ var ՐՏ_modules = {};
                     });
                 }
                 seq = function build_seq(a) {
-                    var ՐՏitr65, ՐՏidx65, ՐՏupk8;
+                    var ՐՏitr68, ՐՏidx68, ՐՏupk8, ՐՏ_395;
                     var first, index, element;
                     first = a.shift();
                     if (first instanceof ast.Assign) {
                         if (first.left instanceof ast.Array) {
-                            ՐՏitr65 = ՐՏ_Iterable(enumerate(first.left.elements));
-                            for (ՐՏidx65 = 0; ՐՏidx65 < ՐՏitr65.length; ՐՏidx65++) {
-                                ՐՏupk8 = ՐՏitr65[ՐՏidx65];
+                            ՐՏitr68 = ՐՏ_Iterable(enumerate(first.left.elements));
+                            for (ՐՏidx68 = 0; ՐՏidx68 < ՐՏitr68.length; ՐՏidx68++) {
+                                ՐՏupk8 = ՐՏitr68[ՐՏidx68];
                                 index = ՐՏupk8[0];
                                 element = ՐՏupk8[1];
-                                mark_local_assignment(element, first.right instanceof ast.Array ? first.right.elements[index] : null);
+                                mark_local_assignment(element, first.right instanceof ast.Array ? (ՐՏ_395 = first.right.elements)[index] : null);
                             }
                         }
                     }
@@ -7028,8 +6968,8 @@ var ՐՏ_modules = {};
             return ret;
         }
         return function() {
-            var ՐՏitr66, ՐՏidx66;
-            var start, body, docstring, first_token, element, shebang, end, toplevel, assignments, callables, item;
+            var ՐՏ_396, ՐՏ_397, ՐՏitr69, ՐՏidx69, ՐՏ_401, ՐՏ_402, ՐՏ_403, ՐՏ_404, ՐՏ_405, ՐՏ_406;
+            var start, body, docstring, first_token, element, shebang, end, toplevel, assignments, callables, imports, item;
             start = S.token;
             body = [];
             docstring = null;
@@ -7066,39 +7006,40 @@ var ՐՏ_modules = {};
                 return arr.lastIndexOf(element) === index;
             }
             toplevel.filename = options.filename;
-            toplevel.nonlocalvars = Object.keys(S.in_scope[S.in_scope.length-1].nonlocal);
-            assignments = Object.keys(S.in_scope[S.in_scope.length-1].vars);
+            toplevel.nonlocalvars = Object.keys((ՐՏ_396 = S.in_scope)[ՐՏ_396.length-1].nonlocal);
+            assignments = Object.keys((ՐՏ_397 = S.in_scope)[ՐՏ_397.length-1].vars);
             callables = scan_for_top_level_callables(toplevel.body).filter(uniq);
+            imports = scan_for_top_level_imports(toplevel.body);
             toplevel.localvars = [];
-            ՐՏitr66 = ՐՏ_Iterable(assignments);
-            for (ՐՏidx66 = 0; ՐՏidx66 < ՐՏitr66.length; ՐՏidx66++) {
-                item = ՐՏitr66[ՐՏidx66];
+            ՐՏitr69 = ՐՏ_Iterable(assignments);
+            for (ՐՏidx69 = 0; ՐՏidx69 < ՐՏitr69.length; ՐՏidx69++) {
+                item = ՐՏitr69[ՐՏidx69];
                 if (!(ՐՏ_in(item, toplevel.nonlocalvars))) {
                     toplevel.localvars.push(new_symbol(ast.SymbolVar, item));
                 }
             }
-            toplevel.exports = toplevel.localvars.concat(callables).filter(uniq);
+            toplevel.exports = toplevel.localvars.concat(callables).concat(imports).filter(uniq);
             toplevel.depends_on = depends_on;
             toplevel.submodules = [];
             toplevel.classes = class_map;
             toplevel.top_classes = function(key) {
-                var ՐՏitr67, ՐՏidx67;
+                var ՐՏ_398, ՐՏ_399, ՐՏitr70, ՐՏidx70, ՐՏ_400;
                 var ret, cn, obj, sub_id, sub_key, sub;
                 ret = {};
                 key = key || "";
                 cn = "";
                 for (cn in this.classes) {
-                    obj = this.classes[cn];
-                    ret[key ? key + "." + cn : cn] = {
+                    obj = (ՐՏ_398 = this.classes)[cn];
+                    (ՐՏ_399 = ret)[key ? key + "." + cn : cn] = {
                         "static": obj.static,
                         "bound": obj.bound
                     };
                 }
-                ՐՏitr67 = ՐՏ_Iterable(this.submodules);
-                for (ՐՏidx67 = 0; ՐՏidx67 < ՐՏitr67.length; ՐՏidx67++) {
-                    sub_id = ՐՏitr67[ՐՏidx67];
+                ՐՏitr70 = ՐՏ_Iterable(this.submodules);
+                for (ՐՏidx70 = 0; ՐՏidx70 < ՐՏitr70.length; ՐՏidx70++) {
+                    sub_id = ՐՏitr70[ՐՏidx70];
                     sub_key = sub_id.replace(new RegExp("^" + this.module_id.replace(/\./g, "\\.")), key);
-                    sub = IMPORTED[sub_id];
+                    sub = (ՐՏ_400 = IMPORTED)[sub_id];
                     Object.assign(ret, sub.top_classes(sub_key));
                 }
                 return ret;
@@ -7106,57 +7047,55 @@ var ՐՏ_modules = {};
             toplevel.import_order = Object.keys(IMPORTED).length;
             toplevel.module_id = module_id;
             toplevel.is_package = (toplevel.filename || "").endsWith("/__init__.pyj");
-            IMPORTED[module_id] = toplevel;
+            (ՐՏ_401 = IMPORTED)[module_id] = toplevel;
             toplevel.imports = IMPORTED;
             toplevel.baselib = BASELIB;
-            IMPORTING[module_id] = false;
-            if (PRE_IMPORTED[module_id]) {
-                IMPORTED[module_id].submodules = PRE_IMPORTED[module_id].submodules;
-                delete PRE_IMPORTED[module_id];
+            (ՐՏ_402 = IMPORTING)[module_id] = false;
+            if ((ՐՏ_403 = PRE_IMPORTED)[module_id]) {
+                (ՐՏ_404 = IMPORTED)[module_id].submodules = (ՐՏ_405 = PRE_IMPORTED)[module_id].submodules;
+                delete (ՐՏ_406 = PRE_IMPORTED)[module_id];
             }
             return toplevel;
         }();
     }
-    ՐՏ_modules["parser"]["NATIVE_CLASSES"] = NATIVE_CLASSES;
-    ՐՏ_modules["parser"]["COMMON_STATIC"] = COMMON_STATIC;
-    ՐՏ_modules["parser"]["CLASS_MAP"] = CLASS_MAP;
-    ՐՏ_modules["parser"]["BASELIB"] = BASELIB;
-    ՐՏ_modules["parser"]["STDLIB"] = STDLIB;
-    ՐՏ_modules["parser"]["UNARY_PREFIX"] = UNARY_PREFIX;
-    ՐՏ_modules["parser"]["ASSIGNMENT"] = ASSIGNMENT;
-    ՐՏ_modules["parser"]["STATEMENTS_WITH_LABELS"] = STATEMENTS_WITH_LABELS;
-    ՐՏ_modules["parser"]["ATOMIC_START_TOKEN"] = ATOMIC_START_TOKEN;
-    ՐՏ_modules["parser"]["array_to_hash"] = array_to_hash;
-    ՐՏ_modules["parser"]["init_mod"] = init_mod;
-    ՐՏ_modules["parser"]["has_simple_decorator"] = has_simple_decorator;
-    ՐՏ_modules["parser"]["parse"] = parse;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:parser"];
+    ՐՏ_mod.export("NATIVE_CLASSES", function(){return NATIVE_CLASSES;}, function(ՐՏ_v){if (typeof NATIVE_CLASSES !== "undefined") {NATIVE_CLASSES = ՐՏ_v;};});
+    ՐՏ_mod.export("COMMON_STATIC", function(){return COMMON_STATIC;}, function(ՐՏ_v){if (typeof COMMON_STATIC !== "undefined") {COMMON_STATIC = ՐՏ_v;};});
+    ՐՏ_mod.export("CLASS_MAP", function(){return CLASS_MAP;}, function(ՐՏ_v){if (typeof CLASS_MAP !== "undefined") {CLASS_MAP = ՐՏ_v;};});
+    ՐՏ_mod.export("BASELIB", function(){return BASELIB;}, function(ՐՏ_v){if (typeof BASELIB !== "undefined") {BASELIB = ՐՏ_v;};});
+    ՐՏ_mod.export("STDLIB", function(){return STDLIB;}, function(ՐՏ_v){if (typeof STDLIB !== "undefined") {STDLIB = ՐՏ_v;};});
+    ՐՏ_mod.export("UNARY_PREFIX", function(){return UNARY_PREFIX;}, function(ՐՏ_v){if (typeof UNARY_PREFIX !== "undefined") {UNARY_PREFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("ASSIGNMENT", function(){return ASSIGNMENT;}, function(ՐՏ_v){if (typeof ASSIGNMENT !== "undefined") {ASSIGNMENT = ՐՏ_v;};});
+    ՐՏ_mod.export("STATEMENTS_WITH_LABELS", function(){return STATEMENTS_WITH_LABELS;}, function(ՐՏ_v){if (typeof STATEMENTS_WITH_LABELS !== "undefined") {STATEMENTS_WITH_LABELS = ՐՏ_v;};});
+    ՐՏ_mod.export("ATOMIC_START_TOKEN", function(){return ATOMIC_START_TOKEN;}, function(ՐՏ_v){if (typeof ATOMIC_START_TOKEN !== "undefined") {ATOMIC_START_TOKEN = ՐՏ_v;};});
+    ՐՏ_mod.export("array_to_hash", function(){return array_to_hash;}, function(ՐՏ_v){if (typeof array_to_hash !== "undefined") {array_to_hash = ՐՏ_v;};});
+    ՐՏ_mod.export("init_mod", function(){return init_mod;}, function(ՐՏ_v){if (typeof init_mod !== "undefined") {init_mod = ՐՏ_v;};});
+    ՐՏ_mod.export("has_simple_decorator", function(){return has_simple_decorator;}, function(ՐՏ_v){if (typeof has_simple_decorator !== "undefined") {has_simple_decorator = ՐՏ_v;};});
+    ՐՏ_mod.export("parse", function(){return parse;}, function(ՐՏ_v){if (typeof parse !== "undefined") {parse = ՐՏ_v;};});
+    ՐՏ_mod.export("find_if", function(){return find_if;}, function(ՐՏ_v){if (typeof find_if !== "undefined") {find_if = ՐՏ_v;};});
+    ՐՏ_mod.export("ast", function(){return ast;}, function(ՐՏ_v){if (typeof ast !== "undefined") {ast = ՐՏ_v;};});
+    ՐՏ_mod.export("tokenizer", function(){return tokenizer;}, function(ՐՏ_v){if (typeof tokenizer !== "undefined") {tokenizer = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:_baselib"].body = function(){
     var __name__ = "_baselib";
 
     var BASELIB;
-    BASELIB = '"""\n**********************************************************************\n\n  A RapydScript to JavaScript compiler.\n  https://github.com/atsepkov/RapydScript\n\n  -------------------------------- (C) ---------------------------------\n\n                       Author: Alexander Tsepkov\n                         <atsepkov@pyjeon.com>\n                         http://www.pyjeon.com\n\n  Distributed under BSD license:\n    Copyright 2013 (c) Alexander Tsepkov <atsepkov@pyjeon.com>\n\n **********************************************************************\n"""\n\n\n# for convenience we\'ll use a convention here that will work as follows:\n#\n#   if function is named, assume we\'ll be outputting the function itself\n#   if the given baselib chunk is triggered\n#\n#   if function is unnamed, assume the function is a container for the logic\n#   to be output. We\'re basically ignoring the wrapper and dumping what\'s inside\n\n{\n"abs": def abs(n):\n    return Math.abs(n)\n,\n"all": def all(a):\n    for e in a:\n        if not e: return False\n    return True\n,\n"any": def any(a):\n    for e in a:\n        if e: return True\n    return False\n,\n"bin": def bin(a): return \'0b\' + (a >>> 0).toString(2)\n,\n"bind": def ՐՏ_bind(fn, thisArg):\n    if fn.orig: fn = fn.orig\n    if thisArg is False: return fn\n    ret = def():\n        return fn.apply(thisArg, arguments)\n    ret.orig = fn\n    return ret\n,\n"rebind_all": def ՐՏ_rebindAll(thisArg, rebind):\n    if rebind is undefined: rebind = True\n    for JS(\'var p in thisArg\'):\n        if thisArg[p] and thisArg[p].orig:\n            if rebind: thisArg[p] = bind(thisArg[p], thisArg)\n            else: thisArg[p] = thisArg[p].orig\n,\n"with__name__": def ՐՏ_with__name__(fn, name):\n    fn.__name__ = name\n    return fn\n,\n"cmp": def cmp(a, b): return a < b ? -1 : a > b ? 1 : 0\n,\n"chr": def(): JS(\'var chr = String.fromCharCode\')\n,\n"dir": def dir(item):\n    # TODO: this isn\'t really representative of real Python\'s dir(), nor is it\n    # an intuitive replacement for "for ... in" loop, need to update this logic\n    # and introduce a different way of achieving "for ... in"\n    arr = []\n    for JS(\'var i in item\'): arr.push(i)\n    return arr\n,\n"enumerate": def enumerate(item):\n    arr = []\n    iter = ՐՏ_Iterable(item)\n    for i in range(iter.length):\n        arr[arr.length] = [i, item[i]]\n    return arr\n,\n"eslice": def ՐՏ_eslice(arr, step, start, end):\n    arr = arr[:]\n    if JS(\'typeof arr\') is \'string\' or isinstance(arr, String):\n        isString = True\n        arr = arr.split(\'\')\n\n    if step < 0:\n        step = -step\n        arr.reverse()\n        if JS(\'typeof start\') is not "undefined": start = arr.length - start - 1\n        if JS(\'typeof end\') is not "undefined": end = arr.length - end - 1\n    if JS(\'typeof start\') is "undefined": start = 0\n    if JS(\'typeof end\') is "undefined": end = arr.length\n\n    arr = arr.slice(start, end).filter(def(e, i): return i % step is 0;)\n    return isString ? arr.join(\'\') : arr\n,\n"extends": def ՐՏ_extends(child, parent):\n    child.prototype = Object.create(parent.prototype)\n    child.prototype.__base__ = parent     # since we don\'t support multiple inheritance, __base__ seemed more appropriate than __bases__ array of 1\n    child.prototype.constructor = child\n,\n"filter": def filter(oper, arr):\n    return arr.filter(oper)\n,\n"hex": def hex(a): return \'0x\' + (a >>> 0).toString(16)\n,\n"in": def ՐՏ_in(val, arr):\n    if JS(\'typeof arr.indexOf\') is \'function\': return arr.indexOf(val) is not -1\n    elif JS(\'typeof arr.has\') is \'function\': return arr.has(val)\n    return arr.hasOwnProperty(val)\n,\n"iterable": def ՐՏ_Iterable(iterable):\n    # can\'t use Symbol.iterator yet since it\'s not supported on all platforms until ES6 (i.e. mobile browsers don\'t have it)\n    if iterable.constructor is [].constructor\n    or iterable.constructor is \'\'.constructor\n    or (tmp = Array.prototype.slice.call(iterable)).length:\n        return tmp or iterable\n    if Set and iterable.constructor is Set:\n        return Array.from(iterable)\n    return Object.keys(iterable)    # so we can use \'for ... in\' syntax with hashes\n,\n"len": def len(obj):\n    # can\'t use Symbol.iterator yet since it\'s not supported on all platforms until ES6 (i.e. mobile browsers don\'t have it)\n    if obj.constructor is [].constructor\n    or obj.constructor is \'\'.constructor\n    or (tmp = Array.prototype.slice.call(obj)).length:\n        return (tmp or obj).length\n    if Set and obj.constructor is Set:\n        return obj.size\n    return Object.keys(obj).length\n,\n"map": def map(oper, arr):\n    return arr.map(oper)\n,\n"max": def max(a):\n    return Math.max.apply(None, Array.isArray(a) ? a : arguments)\n,\n"min": def min(a):\n    return Math.min.apply(None, Array.isArray(a) ? a : arguments)\n,\n"merge": def ՐՏ_merge(target, source, overwrite):\n    for JS(\'var i in source\'):\n        # instance variables\n        if source.hasOwnProperty(i) and (overwrite or JS(\'typeof target[i]\') is \'undefined\'): target[i] = source[i]\n    for prop in Object.getOwnPropertyNames(source.prototype):\n        # methods\n        if overwrite or JS(\'typeof target.prototype[prop]\') is \'undefined\':\n            Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop))\n,\n"mixin": def ՐՏ_mixin(*classes):\n    return def(baseClass):\n        for cls in classes:\n            for key in Object.getOwnPropertyNames(cls.prototype):\n                if key not in baseClass.prototype:\n                    Object.defineProperty(baseClass.prototype, key, Object.getOwnPropertyDescriptor(cls.prototype, key))\n        return baseClass\n\n,\n"print": def ՐՏ_print():\n    if JS(\'typeof console\') is \'object\': console.log.apply(console, arguments)\n,\n"range": def range(start, stop, step):\n    if arguments.length <= 1:\n        stop = start or 0\n        start = 0\n    step = arguments[2] or 1\n\n    length = Math.max(Math.ceil((stop - start) / step), 0)\n    idx = 0\n    range = Array(length)\n\n    while idx < length:\n        range[JS(\'idx++\')] = start\n        start += step\n    return range\n,\n"reduce": def reduce(f, a): return Array.reduce(a, f)\n,\n"reversed": def reversed(arr):\n    tmp = arr[:]\n    return tmp.reverse()\n,\n"sorted": def sorted(arr):\n    tmp = arr[:]\n    return tmp.sort()\n,\n"sum": def sum(arr, start=0):\n    return arr.reduce(\n        def(prev, cur): return prev+cur\n        ,\n        start\n    )\n,\n"type": def ՐՏ_type(obj):\n    return obj and obj.constructor and obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1)\n,\n"zip": def zip(a, b):\n    return [[a[i], b[i]] for i in range(Math.min(a.length, b.length))]\n,\n"getattr": def getattr(obj, name):\n    return obj[name]\n,\n"setattr": def setattr(obj, name, value):\n    obj[name] = value\n,\n"hasattr": def hasattr(obj, name):\n    return JS(\'name in obj\')\n,\n"eq": def ՐՏ_eq(a, b):\n    """\n    Equality comparison that works with all data types, returns true if structure and\n    contents of first object equal to those of second object\n\n    Arguments:\n        a: first object\n        b: second object\n    """\n    if a is b:\n        # simple object\n        return True\n\n    if a is undefined or b is undefined or a is None or b is None:\n        return False\n\n    if a.constructor is not b.constructor:\n        # object type mismatch\n        return False\n\n    if Array.isArray(a):\n        # arrays\n        if a.length is not b.length: return False\n        for i in range(a.length):\n            if not ՐՏ_eq(a[i], b[i]):\n                return False\n        return True\n    elif a.constructor is Object:\n        # hashes\n        # compare individual properties (order doesn\'t matter if it\'s a hash)\n        if Object.keys(a).length is not Object.keys(b).length: return False\n        for i in a:\n            # recursively test equality of object children\n            if not ՐՏ_eq(a[i], b[i]):\n                return False\n        return True\n    elif (Set and a.constructor is Set) or (Map and a.constructor is Map):\n        # sets and maps\n        if a.size is not b.size: return False\n        for JS(\'i of a\'):\n            if not b.has(i):\n                return False\n        return True\n    elif (a.constructor is Date):\n        # dates\n        return a.getTime() is b.getTime()\n    elif JS(\'typeof a.__eq__\') is \'function\':\n        # everything else that implements __eq__ method\n        return a.__eq__(b)\n    return False\n,\n"kwargs": def():\n    # WARNING: when using this function decorator, you will not be able to use obfuscators that rename local variables\n    def kwargs(f):\n        argNames = f.toString().match(/\\(([^\\)]+)/)[1]\n        if not kwargs.memo[argNames]:\n            kwargs.memo[argNames] = argNames ? argNames.split(\',\').map(def(s): return s.trim();) : []\n        argNames = kwargs.memo[argNames]\n        return def():\n            args = [].slice.call(arguments)\n            if args.length:\n                kw = args[-1]\n                if JS(\'typeof kw\') is \'object\':\n                    for i in range(argNames.length):\n                        if argNames[i] in kw:\n                            args[i] = kw[argNames[i]]\n                else:\n                    args.push(kw)\n\n            # This logic is very fragile and very subtle, it needs to work both in ES6 and ES5, don\'t try to optimize the\n            # apply away into *args because having it in this format ensures correct \'this\' context, otherwise the function\n            # ends up unbound. Similarly, the fallthrough to except handles class creation in ES6.\n            try:\n                return f.apply(this, args)\n            except as e:\n                if /Class constructor \\w+ cannot be invoked without \'new\'/.test(e):\n                    return new f(*args)\n                raise\n    kwargs.memo = {}\n,\n\n# Errors\n# temporarily implemented via a wrapper pattern since there is no mechanism for assigning\n# classes to dictionary keys yet\n"AssertionError": def():\n    class AssertionError(Error):\n        def __init__(self, message):\n            self.name = "AssertionError"\n            self.message = message\n,\n"IndexError": def():\n    class IndexError(Error):\n        def __init__(self, message):\n            self.name = "IndexError"\n            self.message = message\n,\n"KeyError": def():\n    class KeyError(Error):\n        def __init__(self, message):\n            self.name = "KeyError"\n            self.message = message\n,\n"TypeError": def():\n    class TypeError(Error):\n        def __init__(self, message):\n            self.name = "TypeError"\n            self.message = message\n,\n"ValueError": def():\n    class ValueError(Error):\n        def __init__(self, message):\n            self.name = "ValueError"\n            self.message = message\n,\n}\n';
-    ՐՏ_modules["_baselib"]["BASELIB"] = BASELIB;
-})();
+    BASELIB = '"""\n**********************************************************************\n\n  A RapydScript to JavaScript compiler.\n  https://github.com/atsepkov/RapydScript\n\n  -------------------------------- (C) ---------------------------------\n\n                       Author: Alexander Tsepkov\n                         <atsepkov@pyjeon.com>\n                         http://www.pyjeon.com\n\n  Distributed under BSD license:\n    Copyright 2013 (c) Alexander Tsepkov <atsepkov@pyjeon.com>\n\n **********************************************************************\n"""\n\n\n# for convenience we\'ll use a convention here that will work as follows:\n#\n#   if function is named, assume we\'ll be outputting the function itself\n#   if the given baselib chunk is triggered\n#\n#   if function is unnamed, assume the function is a container for the logic\n#   to be output. We\'re basically ignoring the wrapper and dumping what\'s inside\n\n{\n"abs": def abs(n):\n    return Math.abs(n)\n,\n"all": def all(a):\n    for e in a:\n        if not e: return False\n    return True\n,\n"any": def any(a):\n    for e in a:\n        if e: return True\n    return False\n,\n"bin": def bin(a): return \'0b\' + (a >>> 0).toString(2)\n,\n"bind": def ՐՏ_bind(fn, thisArg):\n    if fn.orig: fn = fn.orig\n    if thisArg is False: return fn\n    ret = def():\n        return fn.apply(thisArg, arguments)\n    ret.orig = fn\n    return ret\n,\n"rebind_all": def ՐՏ_rebindAll(thisArg, rebind):\n    if rebind is undefined: rebind = True\n    for v\'var p in thisArg\':\n        if thisArg[p] and thisArg[p].orig:\n            if rebind: thisArg[p] = bind(thisArg[p], thisArg)\n            else: thisArg[p] = thisArg[p].orig\n,\n"with__name__": def ՐՏ_with__name__(fn, name):\n    fn.__name__ = name\n    return fn\n,\n"def_modules": def ՐՏ_def_modules():\n    modules = {}\n    def mounter(mod_id):\n        rs_mod_id = "ՐՏ:"+ mod_id\n        rs_mod = modules[rs_mod_id] = {\n            "body": None,\n            "exports":None,\n        }\n        rs_mod["export"] = def(prop, get, set):\n            if not rs_mod["exports"]: rs_mod["exports"] = {}\n            Object.defineProperty( rs_mod["exports"], prop, {\n                configurable: True,\n                enumerable: True,\n                get: get,\n                set: set,\n            })\n        Object.defineProperty( modules,  mod_id, {\n            enumerable: True,\n            get: def():\n                return (mod = modules[rs_mod_id])["exports"] or mod["body"]()\n            , set: def(v):\n                modules[rs_mod_id]["exports"] = v\n        })\n        return rs_mod\n\n    Object.defineProperty( modules, \'ՐՏ_def\', {\n        configurable: False,\n        enumerable: False,\n        value: mounter\n    })\n    return modules\n,\n"cmp": def cmp(a, b): return a < b ? -1 : a > b ? 1 : 0\n,\n"chr": def(): v\'var chr = String.fromCharCode\'\n,\n"dir": def dir(item):\n    # TODO: this isn\'t really representative of real Python\'s dir(), nor is it\n    # an intuitive replacement for "for ... in" loop, need to update this logic\n    # and introduce a different way of achieving "for ... in"\n    arr = []\n    for v\'var i in item\': arr.push(i)\n    return arr\n,\n"enumerate": def enumerate(item):\n    arr = []\n    iter = ՐՏ_Iterable(item)\n    for i in range(iter.length):\n        arr[arr.length] = [i, item[i]]\n    return arr\n,\n"eslice": def ՐՏ_eslice(arr, step, start, end):\n    arr = arr[:]\n    if v\'typeof arr\' is \'string\' or isinstance(arr, String):\n        isString = True\n        arr = arr.split(\'\')\n\n    if step < 0:\n        step = -step\n        arr.reverse()\n        if v\'typeof start\' is not "undefined": start = arr.length - start - 1\n        if v\'typeof end\' is not "undefined": end = arr.length - end - 1\n    if v\'typeof start\' is "undefined": start = 0\n    if v\'typeof end\' is "undefined": end = arr.length\n\n    arr = arr.slice(start, end).filter(def(e, i): return i % step is 0;)\n    return isString ? arr.join(\'\') : arr\n,\n"extends": def ՐՏ_extends(child, parent):\n    child.prototype = Object.create(parent.prototype)\n    child.prototype.__base__ = parent     # since we don\'t support multiple inheritance, __base__ seemed more appropriate than __bases__ array of 1\n    child.prototype.constructor = child\n,\n"filter": def filter(oper, arr):\n    return arr.filter(oper)\n,\n"hex": def hex(a): return \'0x\' + (a >>> 0).toString(16)\n,\n"in": def ՐՏ_in(val, arr):\n    if v\'typeof arr.indexOf\' is \'function\': return arr.indexOf(val) is not -1\n    elif v\'typeof arr.has\' is \'function\': return arr.has(val)\n    return arr.hasOwnProperty(val)\n,\n"iterable": def ՐՏ_Iterable(iterable):\n    # can\'t use Symbol.iterator yet since it\'s not supported on all platforms until ES6 (i.e. mobile browsers don\'t have it)\n    if iterable.constructor is [].constructor\n    or iterable.constructor is \'\'.constructor\n    or (tmp = Array.prototype.slice.call(iterable)).length:\n        return tmp or iterable\n    if Set and iterable.constructor is Set:\n        return Array.from(iterable)\n    return Object.keys(iterable)    # so we can use \'for ... in\' syntax with hashes\n,\n"len": def len(obj):\n    # can\'t use Symbol.iterator yet since it\'s not supported on all platforms until ES6 (i.e. mobile browsers don\'t have it)\n    if obj.constructor is [].constructor\n    or obj.constructor is \'\'.constructor\n    or (tmp = Array.prototype.slice.call(obj)).length:\n        return (tmp or obj).length\n    if Set and obj.constructor is Set:\n        return obj.size\n    return Object.keys(obj).length\n,\n"map": def map(oper, arr):\n    return arr.map(oper)\n,\n"max": def max(a):\n    return Math.max.apply(None, Array.isArray(a) ? a : arguments)\n,\n"min": def min(a):\n    return Math.min.apply(None, Array.isArray(a) ? a : arguments)\n,\n"merge": def ՐՏ_merge(target, source, overwrite):\n    for v\'var i in source\':\n        # instance variables\n        if source.hasOwnProperty(i) and (overwrite or v\'typeof target[i]\' is \'undefined\'): target[i] = source[i]\n    for prop in Object.getOwnPropertyNames(source.prototype):\n        # methods\n        if overwrite or v\'typeof target.prototype[prop]\' is \'undefined\':\n            Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop))\n,\n"mixin": def ՐՏ_mixin(*classes):\n    return def(baseClass):\n        for cls in classes:\n            for key in Object.getOwnPropertyNames(cls.prototype):\n                if key not in baseClass.prototype:\n                    Object.defineProperty(baseClass.prototype, key, Object.getOwnPropertyDescriptor(cls.prototype, key))\n        return baseClass\n\n,\n"print": def ՐՏ_print():\n    if v\'typeof console\' is \'object\': console.log.apply(console, arguments)\n,\n"range": def range(start, stop, step):\n    if arguments.length <= 1:\n        stop = start or 0\n        start = 0\n    step = arguments[2] or 1\n\n    length = Math.max(Math.ceil((stop - start) / step), 0)\n    idx = 0\n    range = Array(length)\n\n    while idx < length:\n        range[v\'idx++\'] = start\n        start += step\n    return range\n,\n"reduce": def reduce(f, a): return Array.reduce(a, f)\n,\n"reversed": def reversed(arr):\n    tmp = arr[:]\n    return tmp.reverse()\n,\n"sorted": def sorted(arr):\n    tmp = arr[:]\n    return tmp.sort()\n,\n"sum": def sum(arr, start=0):\n    return arr.reduce(\n        def(prev, cur): return prev+cur\n        ,\n        start\n    )\n,\n"type": def ՐՏ_type(obj):\n    return obj and obj.constructor and obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1)\n,\n"zip": def zip(a, b):\n    return [[a[i], b[i]] for i in range(Math.min(a.length, b.length))]\n,\n"getattr": def getattr(obj, name):\n    return obj[name]\n,\n"setattr": def setattr(obj, name, value):\n    obj[name] = value\n,\n"hasattr": def hasattr(obj, name):\n    return v\'name in obj\'\n,\n"eq": def ՐՏ_eq(a, b):\n    """\n    Equality comparison that works with all data types, returns true if structure and\n    contents of first object equal to those of second object\n\n    Arguments:\n        a: first object\n        b: second object\n    """\n    if a is b:\n        # simple object\n        return True\n\n    if a is undefined or b is undefined or a is None or b is None:\n        return False\n\n    if a.constructor is not b.constructor:\n        # object type mismatch\n        return False\n\n    if Array.isArray(a):\n        # arrays\n        if a.length is not b.length: return False\n        for i in range(a.length):\n            if not ՐՏ_eq(a[i], b[i]):\n                return False\n        return True\n    elif a.constructor is Object:\n        # hashes\n        # compare individual properties (order doesn\'t matter if it\'s a hash)\n        if Object.keys(a).length is not Object.keys(b).length: return False\n        for i in a:\n            # recursively test equality of object children\n            if not ՐՏ_eq(a[i], b[i]):\n                return False\n        return True\n    elif (Set and a.constructor is Set) or (Map and a.constructor is Map):\n        # sets and maps\n        if a.size is not b.size: return False\n        for v\'i of a\':\n            if not b.has(i):\n                return False\n        return True\n    elif (a.constructor is Date):\n        # dates\n        return a.getTime() is b.getTime()\n    elif v\'typeof a.__eq__\' is \'function\':\n        # everything else that implements __eq__ method\n        return a.__eq__(b)\n    return False\n,\n"kwargs": def():\n    # WARNING: when using this function decorator, you will not be able to use obfuscators that rename local variables\n    def kwargs(f):\n        argNames = f.toString().match(/\\(([^\\)]+)/)[1]\n        if not kwargs.memo[argNames]:\n            kwargs.memo[argNames] = argNames ? argNames.split(\',\').map(def(s): return s.trim();) : []\n        argNames = kwargs.memo[argNames]\n        return def():\n            args = [].slice.call(arguments)\n            if args.length:\n                kw = args[-1]\n                if v\'typeof kw\' is \'object\':\n                    for i in range(argNames.length):\n                        if argNames[i] in kw:\n                            args[i] = kw[argNames[i]]\n                else:\n                    args.push(kw)\n\n            # This logic is very fragile and very subtle, it needs to work both in ES6 and ES5, don\'t try to optimize the\n            # apply away into *args because having it in this format ensures correct \'this\' context, otherwise the function\n            # ends up unbound. Similarly, the fallthrough to except handles class creation in ES6.\n            try:\n                return f.apply(this, args)\n            except as e:\n                if /Class constructor \\w+ cannot be invoked without \'new\'/.test(e):\n                    return new f(*args)\n                raise\n    kwargs.memo = {}\n,\n\n# Errors\n# temporarily implemented via a wrapper pattern since there is no mechanism for assigning\n# classes to dictionary keys yet\n"AssertionError": def():\n    class AssertionError(Error):\n        def __init__(self, message):\n            self.name = "AssertionError"\n            self.message = message\n,\n"IndexError": def():\n    class IndexError(Error):\n        def __init__(self, message):\n            self.name = "IndexError"\n            self.message = message\n,\n"KeyError": def():\n    class KeyError(Error):\n        def __init__(self, message):\n            self.name = "KeyError"\n            self.message = message\n,\n"TypeError": def():\n    class TypeError(Error):\n        def __init__(self, message):\n            self.name = "TypeError"\n            self.message = message\n,\n"ValueError": def():\n    class ValueError(Error):\n        def __init__(self, message):\n            self.name = "ValueError"\n            self.message = message\n,\n}\n';
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:_baselib"];
+    ՐՏ_mod.export("BASELIB", function(){return BASELIB;}, function(ՐՏ_v){if (typeof BASELIB !== "undefined") {BASELIB = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:stream"].body = function(){
     var __name__ = "stream";
 
-    var makePredicate = ՐՏ_modules["utils"].makePredicate;
-    var noop = ՐՏ_modules["utils"].noop;
-    var defaults = ՐՏ_modules["utils"].defaults;
-    var repeat_string = ՐՏ_modules["utils"].repeat_string;
-    var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
-    
+    var makePredicate = ՐՏ_modules["utils"].makePredicate;var noop = ՐՏ_modules["utils"].noop;var defaults = ՐՏ_modules["utils"].defaults;var repeat_string = ՐՏ_modules["utils"].repeat_string;var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
     var is_identifier_char = ՐՏ_modules["tokenizer"].is_identifier_char;
-    
     var ast = ՐՏ_modules["ast"];
-    
     var _baselib = ՐՏ_modules["_baselib"];
-    
     var parser = ՐՏ_modules["parser"];
-    
     function Stream(options) {
         var indentation, current_col, current_line, current_pos, BUFFERS, IMPORTED, might_need_space, might_need_semicolon, last, requireSemicolonChars, space, indent, with_indent, newline, semicolon, add_mapping, tmpIndex, stack, baselibCache;
         options = defaults(options, {
@@ -7286,17 +7225,18 @@ var ՐՏ_modules = {};
         }
         requireSemicolonChars = makePredicate("( [ + * / - , .");
         function print_(str_) {
+            var ՐՏ_407, ՐՏ_408, ՐՏ_409, ՐՏ_410, ՐՏ_411, ՐՏ_412, ՐՏ_413, ՐՏ_414, ՐՏ_415;
             var ch, target_line, prev, a, n;
             str_ = String(str_);
             ch = str_.charAt(0);
             if (might_need_semicolon) {
                 if ((!ch || !(ՐՏ_in(ch, ";}"))) && !/[;]$/.test(last)) {
                     if (options.semicolons || requireSemicolonChars(ch)) {
-                        BUFFERS[BUFFERS.length-1].output += ";";
+                        (ՐՏ_407 = BUFFERS)[ՐՏ_407.length-1].output += ";";
                         ++current_col;
                         ++current_pos;
                     } else {
-                        BUFFERS[BUFFERS.length-1].output += "\n";
+                        (ՐՏ_408 = BUFFERS)[ՐՏ_408.length-1].output += "\n";
                         ++current_pos;
                         ++current_line;
                         current_col = 0;
@@ -7308,10 +7248,10 @@ var ՐՏ_modules = {};
                 might_need_semicolon = false;
                 maybe_newline();
             }
-            if (!options.beautify && options.preserve_line && stack[stack.length - 1]) {
-                target_line = stack[stack.length - 1].start.line;
+            if (!options.beautify && options.preserve_line && (ՐՏ_409 = stack)[stack.length - 1]) {
+                target_line = (ՐՏ_410 = stack)[stack.length - 1].start.line;
                 while (current_line < target_line) {
-                    BUFFERS[BUFFERS.length-1].output += "\n";
+                    (ՐՏ_411 = BUFFERS)[ՐՏ_411.length-1].output += "\n";
                     ++current_pos;
                     ++current_line;
                     current_col = 0;
@@ -7321,7 +7261,7 @@ var ՐՏ_modules = {};
             if (might_need_space) {
                 prev = last_char();
                 if (is_identifier_char(prev) && (is_identifier_char(ch) || ch === "\\") || /^[\+\-\/]$/.test(ch) && ch === prev) {
-                    BUFFERS[BUFFERS.length-1].output += " ";
+                    (ՐՏ_412 = BUFFERS)[ՐՏ_412.length-1].output += " ";
                     ++current_col;
                     ++current_pos;
                 }
@@ -7331,13 +7271,13 @@ var ՐՏ_modules = {};
             n = a.length - 1;
             current_line += n;
             if (n === 0) {
-                current_col += a[n].length;
+                current_col += (ՐՏ_413 = a)[n].length;
             } else {
-                current_col = a[n].length;
+                current_col = (ՐՏ_414 = a)[n].length;
             }
             current_pos += str_.length;
             last = str_;
-            BUFFERS[BUFFERS.length-1].output += str_;
+            (ՐՏ_415 = BUFFERS)[ՐՏ_415.length-1].output += str_;
         }
         space = options.beautify ? function() {
             print_(" ");
@@ -7378,11 +7318,11 @@ var ՐՏ_modules = {};
             return indentation + options.indent_level;
         }
         function spaced() {
-            var ՐՏitr68, ՐՏidx68, ՐՏupk9;
+            var ՐՏitr71, ՐՏidx71, ՐՏupk9;
             var i, x;
-            ՐՏitr68 = ՐՏ_Iterable(enumerate(arguments));
-            for (ՐՏidx68 = 0; ՐՏidx68 < ՐՏitr68.length; ՐՏidx68++) {
-                ՐՏupk9 = ՐՏitr68[ՐՏidx68];
+            ՐՏitr71 = ՐՏ_Iterable(enumerate(arguments));
+            for (ՐՏidx71 = 0; ՐՏidx71 < ՐՏitr71.length; ՐՏidx71++) {
+                ՐՏupk9 = ՐՏitr71[ՐՏidx71];
                 i = ՐՏupk9[0];
                 x = ՐՏupk9[1];
                 if (i > 0) {
@@ -7426,7 +7366,7 @@ var ՐՏ_modules = {};
                 output.comma();
                 output.with_block(function() {
                     Object.keys(props).forEach(function(key, i) {
-                        var ՐՏitr69, ՐՏidx69;
+                        var ՐՏ_416, ՐՏ_417, ՐՏitr72, ՐՏidx72, ՐՏ_418, ՐՏ_419, ՐՏ_420, ՐՏ_421, ՐՏ_422, ՐՏ_423, ՐՏ_424, ՐՏ_425;
                         var print_name, prop_keys, prop_attrs, k;
                         print_name = function() {
                             output.print(key);
@@ -7437,18 +7377,19 @@ var ՐՏ_modules = {};
                                 "enumerable": "true",
                                 "writable": "true"
                             };
-                            prop_keys["value"] = props[key];
+                            (ՐՏ_416 = prop_keys)["value"] = (ՐՏ_417 = props)[key];
                         } else {
-                            ՐՏitr69 = ՐՏ_Iterable([ "get", "set", "value" ]);
-                            for (ՐՏidx69 = 0; ՐՏidx69 < ՐՏitr69.length; ՐՏidx69++) {
-                                k = ՐՏitr69[ՐՏidx69];
-                                if (props[key][k]) {
-                                    prop_keys[k] = props[key][k];
+                            ՐՏitr72 = ՐՏ_Iterable([ "get", "set", "value" ]);
+                            for (ՐՏidx72 = 0; ՐՏidx72 < ՐՏitr72.length; ՐՏidx72++) {
+                                k = ՐՏitr72[ՐՏidx72];
+                                if ((ՐՏ_418 = (ՐՏ_419 = props)[key])[k]) {
+                                    (ՐՏ_420 = prop_keys)[k] = (ՐՏ_421 = (ՐՏ_422 = props)[key])[k];
                                 }
                             }
-                            prop_attrs = props[key].attrs || {};
-                            print_name = props[key].name && props[key].name.print ? function() {
-                                props[key].name.print(output);
+                            prop_attrs = (ՐՏ_423 = props)[key].attrs || {};
+                            print_name = (ՐՏ_424 = props)[key].name && (ՐՏ_425 = props)[key].name.print ? function() {
+                                var ՐՏ_426;
+                                (ՐՏ_426 = props)[key].name.print(output);
                             } : print_name;
                         }
                         if (i) {
@@ -7459,22 +7400,22 @@ var ՐՏ_modules = {};
                         print_name();
                         output.colon();
                         output.with_block(function() {
-                            var ՐՏitr70, ՐՏidx70, ՐՏitr71, ՐՏidx71;
+                            var ՐՏitr73, ՐՏidx73, ՐՏ_427, ՐՏitr74, ՐՏidx74, ՐՏ_428;
                             var attr, i, k;
-                            ՐՏitr70 = ՐՏ_Iterable(prop_keys.value ? [ "enumerable", "writable" ] : [ "enumerable", "configurable" ]);
-                            for (ՐՏidx70 = 0; ՐՏidx70 < ՐՏitr70.length; ՐՏidx70++) {
-                                attr = ՐՏitr70[ՐՏidx70];
+                            ՐՏitr73 = ՐՏ_Iterable(prop_keys.value ? [ "enumerable", "writable" ] : [ "enumerable", "configurable" ]);
+                            for (ՐՏidx73 = 0; ՐՏidx73 < ՐՏitr73.length; ՐՏidx73++) {
+                                attr = ՐՏitr73[ՐՏidx73];
                                 output.indent();
                                 output.print(attr);
                                 output.colon();
-                                output.print(prop_attrs[attr] || "true");
+                                output.print((ՐՏ_427 = prop_attrs)[attr] || "true");
                                 output.comma();
                                 output.newline();
                             }
                             i = 0;
-                            ՐՏitr71 = ՐՏ_Iterable(prop_keys);
-                            for (ՐՏidx71 = 0; ՐՏidx71 < ՐՏitr71.length; ՐՏidx71++) {
-                                k = ՐՏitr71[ՐՏidx71];
+                            ՐՏitr74 = ՐՏ_Iterable(prop_keys);
+                            for (ՐՏidx74 = 0; ՐՏidx74 < ՐՏitr74.length; ՐՏidx74++) {
+                                k = ՐՏitr74[ՐՏidx74];
                                 if (i) {
                                     output.comma();
                                     output.newline();
@@ -7483,7 +7424,7 @@ var ՐՏ_modules = {};
                                 output.indent();
                                 output.print(k);
                                 output.colon();
-                                prop_keys[k](output);
+                                (ՐՏ_428 = prop_keys)[k](output);
                             }
                             output.newline();
                         });
@@ -7571,20 +7512,21 @@ var ՐՏ_modules = {};
             }
         } : noop;
         function get_() {
+            var ՐՏ_429, ՐՏ_430, ՐՏ_431, ՐՏ_432;
             var output, out;
             if (BUFFERS.len > 1) {
                 throw new Error("Something went wrong, output generator didn't exit all of its scopes properly.");
             }
             output = this;
-            if (BUFFERS[0].vars.length) {
+            if ((ՐՏ_429 = BUFFERS)[0].vars.length) {
                 BUFFERS.unshift({
                     vars: [],
                     output: ""
                 });
                 endLocalBuffer();
             }
-            out = BUFFERS[0].output;
-            BUFFERS[0].output = "";
+            out = (ՐՏ_430 = BUFFERS)[0].output;
+            (ՐՏ_431 = BUFFERS)[0].output = "";
             if (options.private_scope) {
                 output.with_parens(function() {
                     output.print("function()");
@@ -7599,7 +7541,7 @@ var ՐՏ_modules = {};
             } else {
                 output.print(out);
             }
-            return BUFFERS[BUFFERS.length-1].output;
+            return (ՐՏ_432 = BUFFERS)[ՐՏ_432.length-1].output;
         }
         function assign_var(name) {
             if (typeof name === "string") {
@@ -7618,19 +7560,21 @@ var ՐՏ_modules = {};
             "_": 0
         };
         function newTemp(subtype, buffer) {
+            var ՐՏ_433, ՐՏ_434, ՐՏ_435;
             subtype = subtype === void 0 ? "_" : subtype;
             buffer = buffer === void 0 ? true : buffer;
             var tmp;
-            ++tmpIndex[subtype];
-            tmp = RAPYD_PREFIX + subtype + tmpIndex[subtype];
+            ++(ՐՏ_433 = tmpIndex)[subtype];
+            tmp = RAPYD_PREFIX + subtype + (ՐՏ_434 = tmpIndex)[subtype];
             if (buffer) {
-                BUFFERS[BUFFERS.length-1].vars.push(tmp);
+                (ՐՏ_435 = BUFFERS)[ՐՏ_435.length-1].vars.push(tmp);
             }
             return tmp;
         }
         function prevTemp(subtype) {
+            var ՐՏ_436;
             subtype = subtype === void 0 ? "_" : subtype;
-            return RAPYD_PREFIX + subtype + tmpIndex[subtype];
+            return RAPYD_PREFIX + subtype + (ՐՏ_436 = tmpIndex)[subtype];
         }
         function startLocalBuffer() {
             BUFFERS.push({
@@ -7639,6 +7583,7 @@ var ՐՏ_modules = {};
             });
         }
         function endLocalBuffer(baselib) {
+            var ՐՏ_437, ՐՏ_438, ՐՏ_439;
             baselib = baselib === void 0 ? false : baselib;
             var localBuffer;
             localBuffer = BUFFERS.pop();
@@ -7655,15 +7600,15 @@ var ՐՏ_modules = {};
                 newline();
             }
             if (baselib) {
-                BUFFERS[BUFFERS.length-1].output = localBuffer.output + BUFFERS[BUFFERS.length-1].output;
+                (ՐՏ_437 = BUFFERS)[ՐՏ_437.length-1].output = localBuffer.output + (ՐՏ_438 = BUFFERS)[ՐՏ_438.length-1].output;
             } else {
-                BUFFERS[BUFFERS.length-1].output += localBuffer.output;
+                (ՐՏ_439 = BUFFERS)[ՐՏ_439.length-1].output += localBuffer.output;
             }
         }
         stack = [];
         baselibCache = {};
         function print_baselib(key) {
-            var ՐՏitr72, ՐՏidx72;
+            var ՐՏ_440, ՐՏitr75, ՐՏidx75, ՐՏ_441, ՐՏ_442;
             var baselibAst, hash, data, item, key_, value;
             if (!options.omit_baselib) {
                 if (!Object.keys(baselibCache).length) {
@@ -7672,23 +7617,24 @@ var ՐՏ_modules = {};
                         dropDocstrings: true,
                         filename: "_baselib.pyj"
                     });
-                    hash = baselibAst.body[baselibAst.body.length-1];
+                    hash = (ՐՏ_440 = baselibAst.body)[ՐՏ_440.length-1];
                     data = hash.body.properties;
-                    ՐՏitr72 = ՐՏ_Iterable(data);
-                    for (ՐՏidx72 = 0; ՐՏidx72 < ՐՏitr72.length; ՐՏidx72++) {
-                        item = ՐՏitr72[ՐՏidx72];
+                    ՐՏitr75 = ՐՏ_Iterable(data);
+                    for (ՐՏidx75 = 0; ՐՏidx75 < ՐՏitr75.length; ՐՏidx75++) {
+                        item = ՐՏitr75[ՐՏidx75];
                         key_ = item.key.value;
                         value = item.value.name ? [ item.value ] : item.value.body;
-                        baselibCache[key_] = splatBaselib(key_, value);
+                        (ՐՏ_441 = baselibCache)[key_] = splatBaselib(key_, value);
                     }
                 }
-                baselibCache[key].print(this);
+                (ՐՏ_442 = baselibCache)[key].print(this);
             }
             return null;
         }
         function import_(key) {
+            var ՐՏ_443;
             if (!IMPORTED.hasOwnProperty(key)) {
-                IMPORTED[key] = key;
+                (ՐՏ_443 = IMPORTED)[key] = key;
                 return true;
             }
             return false;
@@ -7742,10 +7688,12 @@ var ՐՏ_modules = {};
             print_baselib: print_baselib,
             import: import_,
             is_main: function() {
-                return BUFFERS.length === 1 && BUFFERS[BUFFERS.length-1].output.length === 0;
+                var ՐՏ_444;
+                return BUFFERS.length === 1 && (ՐՏ_444 = BUFFERS)[ՐՏ_444.length-1].output.length === 0;
             },
             option: function(opt) {
-                return options[opt];
+                var ՐՏ_445;
+                return (ՐՏ_445 = options)[opt];
             },
             line: function() {
                 return current_line;
@@ -7768,26 +7716,29 @@ var ՐՏ_modules = {};
             newTemp: newTemp,
             prevTemp: prevTemp,
             parent: function(n) {
-                return stack[stack.length - 2 - (n || 0)];
+                var ՐՏ_446;
+                return (ՐՏ_446 = stack)[stack.length - 2 - (n || 0)];
             }
         };
     }
-    ՐՏ_modules["stream"]["Stream"] = Stream;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:stream"];
+    ՐՏ_mod.export("Stream", function(){return Stream;}, function(ՐՏ_v){if (typeof Stream !== "undefined") {Stream = ՐՏ_v;};});
+    ՐՏ_mod.export("RAPYD_PREFIX", function(){return RAPYD_PREFIX;}, function(ՐՏ_v){if (typeof RAPYD_PREFIX !== "undefined") {RAPYD_PREFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("is_identifier_char", function(){return is_identifier_char;}, function(ՐՏ_v){if (typeof is_identifier_char !== "undefined") {is_identifier_char = ՐՏ_v;};});
+    ՐՏ_mod.export("ast", function(){return ast;}, function(ՐՏ_v){if (typeof ast !== "undefined") {ast = ՐՏ_v;};});
+    ՐՏ_mod.export("_baselib", function(){return _baselib;}, function(ՐՏ_v){if (typeof _baselib !== "undefined") {_baselib = ՐՏ_v;};});
+    ՐՏ_mod.export("parser", function(){return parser;}, function(ՐՏ_v){if (typeof parser !== "undefined") {parser = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:output"].body = function(){
     var __name__ = "output";
 
     var Stream;
-    var noop = ՐՏ_modules["utils"].noop;
-    var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
-    
+    var noop = ՐՏ_modules["utils"].noop;var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
     var PRECEDENCE = ՐՏ_modules["tokenizer"].PRECEDENCE;
-    
     var stream = ՐՏ_modules["stream"];
-    
     var ast = ՐՏ_modules["ast"];
-    
     Stream = stream.Stream;
     (function() {
         var SPECIAL_METHODS, BASELIB, CREATION;
@@ -7818,14 +7769,14 @@ var ՐՏ_modules = {};
                             output.assign(assign);
                         }
                         output.with_parens(function() {
-                            var ՐՏitr73, ՐՏidx73;
+                            var ՐՏitr76, ՐՏidx76;
                             var arg;
                             output.assign(tmp);
                             baseFn();
                             output.comma();
-                            ՐՏitr73 = ՐՏ_Iterable(args);
-                            for (ՐՏidx73 = 0; ՐՏidx73 < ՐՏitr73.length; ՐՏidx73++) {
-                                arg = ՐՏitr73[ՐՏidx73];
+                            ՐՏitr76 = ՐՏ_Iterable(args);
+                            for (ՐՏidx76 = 0; ՐՏidx76 < ՐՏitr76.length; ՐՏidx76++) {
+                                arg = ՐՏitr76[ՐՏidx76];
                                 if (!(ՐՏ_in(arg, [ null, void 0 ]))) {
                                     arg.call(output, tmp);
                                     output.comma();
@@ -7872,7 +7823,7 @@ var ՐՏ_modules = {};
             return s.get();
         };
         ast.Node.prototype.add_comments = function(output) {
-            var ՐՏitr74, ՐՏidx74;
+            var ՐՏitr77, ՐՏidx77;
             var c, self, start, comments;
             c = output.option("comments");
             self = this;
@@ -7894,9 +7845,9 @@ var ՐՏ_modules = {};
                             return c(self, comment);
                         });
                     }
-                    ՐՏitr74 = ՐՏ_Iterable(comments);
-                    for (ՐՏidx74 = 0; ՐՏidx74 < ՐՏitr74.length; ՐՏidx74++) {
-                        c = ՐՏitr74[ՐՏidx74];
+                    ՐՏitr77 = ՐՏ_Iterable(comments);
+                    for (ՐՏidx77 = 0; ՐՏidx77 < ՐՏitr77.length; ՐՏidx77++) {
+                        c = ՐՏitr77[ՐՏidx77];
                         if (c.subtype === "line") {
                             output.print("//" + c.value + "\n");
                             output.indent();
@@ -7939,6 +7890,7 @@ var ՐՏ_modules = {};
             return false;
         });
         PARENS(ast.Binary, function(output) {
+            var ՐՏ_447, ՐՏ_448;
             var p, po, pp, so, sp;
             p = output.parent();
             if (p instanceof ast.BaseCall && p.expression === this) {
@@ -7952,9 +7904,9 @@ var ՐՏ_modules = {};
             }
             if (p instanceof ast.Binary) {
                 po = p.operator;
-                pp = PRECEDENCE[po];
+                pp = (ՐՏ_447 = PRECEDENCE)[po];
                 so = this.operator;
-                sp = PRECEDENCE[so];
+                sp = (ՐՏ_448 = PRECEDENCE)[so];
                 if (pp > sp || pp === sp && this === p.right && !(so === po && (so === "*" || so === "&&" || so === "||"))) {
                     return true;
                 }
@@ -8038,12 +7990,13 @@ var ՐՏ_modules = {};
             output.semicolon();
         });
         function display_body(body, is_toplevel, output, with_return) {
+            var ՐՏ_449;
             var last;
             if (with_return) {
                 output.indent();
                 output.print("return");
                 output.space();
-                body[0].print(output);
+                (ՐՏ_449 = body)[0].print(output);
                 output.newline();
                 return;
             }
@@ -8074,42 +8027,49 @@ var ՐՏ_modules = {};
             }
         }
         function write_imports(module_, output) {
-            var ՐՏitr75, ՐՏidx75, ՐՏitr76, ՐՏidx76, ՐՏitr77, ՐՏidx77, ՐՏitr78, ՐՏidx78;
+            var ՐՏ_462, ՐՏitr78, ՐՏidx78, ՐՏitr79, ՐՏidx79, ՐՏ_463, ՐՏitr80, ՐՏidx80, ՐՏitr81, ՐՏidx81;
             var imports, nonlocalvars, name;
             function sort_imports(mod, imp_sorted, importing, done) {
+                var ՐՏ_454, ՐՏ_455, ՐՏ_456;
                 var imp_keys;
+                if (mod.async) {
+                    return imp_sorted;
+                }
                 imp_sorted = imp_sorted || [];
                 importing = importing || {};
                 done = done || {};
                 function push_key(k) {
-                    if (!done[k]) {
+                    var ՐՏ_450, ՐՏ_451;
+                    if (!(ՐՏ_450 = done)[k]) {
                         imp_sorted.push(k);
-                        done[k] = true;
+                        (ՐՏ_451 = done)[k] = true;
                     }
                 }
                 function sort_imp(a, b) {
-                    a = module_.imports[a].import_order;
-                    b = module_.imports[b].import_order;
+                    var ՐՏ_452, ՐՏ_453;
+                    a = (ՐՏ_452 = module_.imports)[a].import_order;
+                    b = (ՐՏ_453 = module_.imports)[b].import_order;
                     return a < b ? -1 : a > b ? 1 : 0;
                 }
-                if (importing[mod.module_id] || done[mod.module_id]) {
+                if ((ՐՏ_454 = importing)[mod.module_id] || (ՐՏ_455 = done)[mod.module_id]) {
                     return;
                 }
-                importing[mod.module_id] = true;
+                (ՐՏ_456 = importing)[mod.module_id] = true;
                 imp_keys = Object.keys(mod.depends_on).sort(sort_imp);
                 imp_keys.forEach(function(mod_id) {
-                    var ՐՏ_122;
+                    var ՐՏ_457, ՐՏ_458, ՐՏ_459;
                     var pack_id;
-                    pack_id = mod_id.split(".")[0];
-                    if ((pack_id !== (ՐՏ_122 = mod.module_id) && (typeof pack_id !== "object" || !ՐՏ_eq(pack_id, ՐՏ_122)))) {
-                        sort_imports(module_.imports[pack_id], imp_sorted, importing, done);
+                    pack_id = (ՐՏ_457 = mod_id.split("."))[0];
+                    if ((pack_id !== (ՐՏ_458 = mod.module_id) && (typeof pack_id !== "object" || !ՐՏ_eq(pack_id, ՐՏ_458)))) {
+                        sort_imports((ՐՏ_459 = module_.imports)[pack_id], imp_sorted, importing, done);
                         push_key(mod_id);
                     }
                 });
                 if (mod.submodules.length) {
                     mod.submodules.sort(sort_imp);
                     mod.submodules.forEach(function(sub_key) {
-                        sort_imports(module_.imports[sub_key], imp_sorted, importing, done);
+                        var ՐՏ_460;
+                        sort_imports((ՐՏ_460 = module_.imports)[sub_key], imp_sorted, importing, done);
                         push_key(sub_key);
                     });
                     push_key(mod.module_id);
@@ -8117,22 +8077,26 @@ var ՐՏ_modules = {};
                 return imp_sorted;
             }
             imports = sort_imports(module_).map(function(mid) {
-                return module_.imports[mid];
+                var ՐՏ_461;
+                return (ՐՏ_461 = module_.imports)[mid];
             });
-            imports.push(module_.imports["__main__"]);
+            imports.push((ՐՏ_462 = module_.imports)["__main__"]);
             if (imports.length > 1) {
                 output.indent();
-                output.spaced("var ՐՏ_modules", "=", "{};");
+                output.spaced("var ՐՏ_modules", "=", "ՐՏ_def_modules();");
                 output.newline();
             }
             nonlocalvars = {};
-            ՐՏitr75 = ՐՏ_Iterable(imports);
-            for (ՐՏidx75 = 0; ՐՏidx75 < ՐՏitr75.length; ՐՏidx75++) {
-                module_ = ՐՏitr75[ՐՏidx75];
-                ՐՏitr76 = ՐՏ_Iterable(module_.nonlocalvars);
-                for (ՐՏidx76 = 0; ՐՏidx76 < ՐՏitr76.length; ՐՏidx76++) {
-                    name = ՐՏitr76[ՐՏidx76];
-                    nonlocalvars[name] = true;
+            ՐՏitr78 = ՐՏ_Iterable(imports);
+            for (ՐՏidx78 = 0; ՐՏidx78 < ՐՏitr78.length; ՐՏidx78++) {
+                module_ = ՐՏitr78[ՐՏidx78];
+                if (module_.async) {
+                    continue;
+                }
+                ՐՏitr79 = ՐՏ_Iterable(module_.nonlocalvars);
+                for (ՐՏidx79 = 0; ՐՏidx79 < ՐՏitr79.length; ՐՏidx79++) {
+                    name = ՐՏitr79[ՐՏidx79];
+                    (ՐՏ_463 = nonlocalvars)[name] = true;
                 }
             }
             nonlocalvars = Object.getOwnPropertyNames(nonlocalvars).join(", ");
@@ -8141,20 +8105,19 @@ var ՐՏ_modules = {};
                 output.print("var " + nonlocalvars);
                 output.end_statement();
             }
-            ՐՏitr77 = ՐՏ_Iterable(imports);
-            for (ՐՏidx77 = 0; ՐՏidx77 < ՐՏitr77.length; ՐՏidx77++) {
-                module_ = ՐՏitr77[ՐՏidx77];
+            ՐՏitr80 = ՐՏ_Iterable(imports);
+            for (ՐՏidx80 = 0; ՐՏidx80 < ՐՏitr80.length; ՐՏidx80++) {
+                module_ = ՐՏitr80[ՐՏidx80];
                 if (module_.module_id !== "__main__") {
                     output.indent();
-                    output.assign('ՐՏ_modules["' + module_.module_id + '"]');
-                    output.print("{}");
+                    output.print('ՐՏ_modules.ՐՏ_def("' + module_.module_id + '")');
                     output.end_statement();
                 }
             }
-            ՐՏitr78 = ՐՏ_Iterable(imports);
-            for (ՐՏidx78 = 0; ՐՏidx78 < ՐՏitr78.length; ՐՏidx78++) {
-                module_ = ՐՏitr78[ՐՏidx78];
-                if (module_.module_id !== "__main__") {
+            ՐՏitr81 = ՐՏ_Iterable(imports);
+            for (ՐՏidx81 = 0; ՐՏidx81 < ՐՏitr81.length; ՐՏidx81++) {
+                module_ = ՐՏitr81[ՐՏidx81];
+                if (!module_.async && module_.module_id !== "__main__") {
                     print_module(module_, output);
                 }
             }
@@ -8168,6 +8131,7 @@ var ՐՏ_modules = {};
             }
         }
         function display_complex_body(node, is_toplevel, output) {
+            var ՐՏ_464, ՐՏ_465, ՐՏ_466, ՐՏ_467, ՐՏ_468, ՐՏ_469, ՐՏ_470, ՐՏ_471, ՐՏ_472, ՐՏ_473;
             var offset, needsSuper, delaySelfAssignment, arg, stmt, with_return;
             output.startLocalBuffer();
             offset = 0;
@@ -8189,7 +8153,7 @@ var ՐՏ_modules = {};
                         output.end_statement();
                     }
                     output.indent();
-                    output.spaced("var", node.argnames[0], "=", "this");
+                    output.spaced("var", (ՐՏ_464 = node.argnames)[0], "=", "this");
                     output.end_statement();
                 }
             }
@@ -8210,7 +8174,7 @@ var ՐՏ_modules = {};
                             output.indent();
                             output.spaced(arg, "=", arg, "===", "void 0", "?");
                             output.space();
-                            force_statement(node.argnames.defaults[arg], output);
+                            force_statement((ՐՏ_465 = node.argnames.defaults)[arg], output);
                             output.space();
                             output.colon();
                             output.print(arg);
@@ -8239,8 +8203,8 @@ var ՐՏ_modules = {};
                     output.end_statement();
                 }
             }
-            stmt = node instanceof ast.Lambda && node.body.length === 1 && !node.body[0].start.newline_before && node.body[0] instanceof ast.SimpleStatement && node.body[0].body;
-            with_return = stmt && (node.body[0].start.value === "(" || node.body[0].body instanceof ast.Array || node.body[0].body instanceof ast.ObjectLiteral || node.body[0].body instanceof ast.Dot || node.body[0].body instanceof ast.PropAccess);
+            stmt = node instanceof ast.Lambda && node.body.length === 1 && !(ՐՏ_466 = node.body)[0].start.newline_before && (ՐՏ_467 = node.body)[0] instanceof ast.SimpleStatement && (ՐՏ_468 = node.body)[0].body;
+            with_return = stmt && ((ՐՏ_469 = node.body)[0].start.value === "(" || (ՐՏ_470 = node.body)[0].body instanceof ast.Array || (ՐՏ_471 = node.body)[0].body instanceof ast.ObjectLiteral || (ՐՏ_472 = node.body)[0].body instanceof ast.Dot || (ՐՏ_473 = node.body)[0].body instanceof ast.PropAccess);
             display_body(node.body, is_toplevel, output, with_return);
             output.endLocalBuffer();
         }
@@ -8258,39 +8222,45 @@ var ՐՏ_modules = {};
             }
         }
         function declare_submodules(module_id, submodules, output) {
-            var ՐՏitr79, ՐՏidx79;
-            var seen, sub_module_id, key;
+            var ՐՏitr82, ՐՏidx82, ՐՏ_474, ՐՏ_475;
+            var seen, sub_module_id, key, sub_mod;
             seen = {};
             output.newline();
-            ՐՏitr79 = ՐՏ_Iterable(submodules);
-            for (ՐՏidx79 = 0; ՐՏidx79 < ՐՏitr79.length; ՐՏidx79++) {
-                sub_module_id = ՐՏitr79[ՐՏidx79];
+            ՐՏitr82 = ՐՏ_Iterable(submodules);
+            for (ՐՏidx82 = 0; ՐՏidx82 < ՐՏitr82.length; ՐՏidx82++) {
+                sub_module_id = ՐՏitr82[ՐՏidx82];
                 if (!seen.hasOwnProperty(sub_module_id)) {
-                    seen[sub_module_id] = true;
-                    key = sub_module_id.split(".")[sub_module_id.split(".").length-1];
+                    (ՐՏ_474 = seen)[sub_module_id] = true;
+                    key = (ՐՏ_475 = sub_module_id.split("."))[ՐՏ_475.length-1];
                     output.indent();
-                    output.print('ՐՏ_modules["' + module_id + '"]["' + key + '"] = ');
-                    output.print('ՐՏ_modules["' + sub_module_id + '"]');
+                    sub_mod = 'ՐՏ_modules["' + sub_module_id + '"]';
+                    output.print('ՐՏ_modules["ՐՏ:' + module_id + '"].export("' + key + '", function(){return ' + sub_mod + ';}, function(){throw new Error("use Object.defineProperty!");})');
                     output.end_statement();
                 }
             }
         }
         function declare_exports(module_id, exports, output) {
-            var ՐՏitr80, ՐՏidx80;
-            var seen, symbol;
+            var ՐՏitr83, ՐՏidx83, ՐՏ_476, ՐՏ_477;
+            var seen, rs_mod, symbol;
             output.newline();
             seen = {};
-            ՐՏitr80 = ՐՏ_Iterable(exports);
-            for (ՐՏidx80 = 0; ՐՏidx80 < ՐՏitr80.length; ՐՏidx80++) {
-                symbol = ՐՏitr80[ՐՏidx80];
-                if (!seen[symbol.name]) {
-                    seen[symbol.name] = true;
+            output.indent();
+            rs_mod = 'ՐՏ_modules["ՐՏ:' + module_id + '"]';
+            output.print('var ՐՏ_mod = ՐՏ_modules["ՐՏ:' + module_id + '"]');
+            output.end_statement();
+            ՐՏitr83 = ՐՏ_Iterable(exports);
+            for (ՐՏidx83 = 0; ՐՏidx83 < ՐՏitr83.length; ՐՏidx83++) {
+                symbol = ՐՏitr83[ՐՏidx83];
+                if (!(ՐՏ_476 = seen)[symbol.name]) {
+                    (ՐՏ_477 = seen)[symbol.name] = true;
                     output.indent();
-                    output.assign('ՐՏ_modules["' + module_id + '"]["' + symbol.name + '"]');
-                    output.print(symbol.name);
+                    output.print('ՐՏ_mod.export("' + symbol.name + '", function(){return ' + symbol.name + ";}, function(ՐՏ_v){if (typeof " + symbol.name + ' !== "undefined") {' + symbol.name + " = ՐՏ_v;};})");
                     output.end_statement();
                 }
             }
+            output.indent();
+            output.print('return ՐՏ_mod["exports"]');
+            output.end_statement();
         }
         function unpack_tuple(tuple, output, in_statement) {
             tuple.elements.forEach(function(elem, i) {
@@ -8360,30 +8330,32 @@ var ՐՏ_modules = {};
             if (is_main) {
                 output.startLocalBuffer();
                 Object.keys(BASELIB).filter(function(a) {
-                    return self.baselib[a] > 0;
+                    var ՐՏ_478;
+                    return (ՐՏ_478 = self.baselib)[a] > 0;
                 }).forEach(function(key) {
                     output.print_baselib(key);
                 });
+                if (Object.keys(self.imports).length > 1) {
+                    output.print_baselib("def_modules");
+                }
                 output.endLocalBuffer(true);
             }
         });
         function print_module(self, output) {
             output.newline();
             output.indent();
-            output.with_parens(function() {
-                output.print("function()");
-                output.with_block(function() {
-                    output.indent();
-                    output.assign("var __name__");
-                    output.print('"' + self.module_id + '"');
-                    output.end_statement();
-                    declare_submodules(self.module_id, self.submodules, output);
-                    declare_vars(self.localvars, output);
-                    display_body(self.body, true, output);
-                    declare_exports(self.module_id, self.exports, output);
-                });
+            output.assign('ՐՏ_modules["ՐՏ:' + self.module_id + '"].body');
+            output.print("function()");
+            output.with_block(function() {
+                output.indent();
+                output.assign("var __name__");
+                output.print('"' + self.module_id + '"');
+                output.end_statement();
+                declare_submodules(self.module_id, self.submodules, output);
+                declare_vars(self.localvars, output);
+                display_body(self.body, true, output);
+                declare_exports(self.module_id, self.exports, output);
             });
-            output.print("()");
             output.end_statement();
         }
         DEFPRINT(ast.Splat, function(self, output) {
@@ -8393,40 +8365,45 @@ var ՐՏ_modules = {};
             }
         });
         DEFPRINT(ast.Imports, function(container, output) {
-            var ՐՏitr81, ՐՏidx81, ՐՏitr82, ՐՏidx82;
-            var seen, self, argname, alias, bound_name;
+            var ՐՏitr84, ՐՏidx84, ՐՏitr85, ՐՏidx85, ՐՏ_484;
+            var seen, i, self, argname, alias, bound_name;
             seen = {};
+            i = 0;
             function add_aname(aname, key, from_import) {
-                var ՐՏ_123;
+                var ՐՏ_479, ՐՏ_480, ՐՏ_481, ՐՏ_482, ՐՏ_483;
                 var seen_key, tmp;
                 seen_key = key + (from_import ? "." + from_import : "");
-                if (seen[aname]) {
-                    if (((ՐՏ_123 = seen[aname]) === seen_key || typeof ՐՏ_123 === "object" && ՐՏ_eq(ՐՏ_123, seen_key))) {
+                if ((ՐՏ_479 = seen)[aname]) {
+                    if (((ՐՏ_480 = (ՐՏ_481 = seen)[aname]) === seen_key || typeof ՐՏ_480 === "object" && ՐՏ_eq(ՐՏ_480, seen_key))) {
                         return;
                     } else {
-                        tmp = aname + " : " + [ seen[aname], seen_key ].join(", ");
+                        tmp = aname + " : " + [ (ՐՏ_482 = seen)[aname], seen_key ].join(", ");
                         throw new Error("Something went wrong, 2 imports with the same name detected: " + tmp);
                     }
                 }
-                seen[aname] = seen_key;
+                (ՐՏ_483 = seen)[aname] = seen_key;
+                if (i) {
+                    output.newline();
+                    output.indent();
+                    ++i;
+                }
                 output.assign("var " + aname);
                 output.print('ՐՏ_modules["' + key + '"]');
                 if (from_import) {
                     output.print("." + from_import);
                 }
-                output.end_statement();
-                output.indent();
+                output.semicolon();
             }
-            ՐՏitr81 = ՐՏ_Iterable(container.imports);
-            for (ՐՏidx81 = 0; ՐՏidx81 < ՐՏitr81.length; ՐՏidx81++) {
-                self = ՐՏitr81[ՐՏidx81];
+            ՐՏitr84 = ՐՏ_Iterable(container.imports);
+            for (ՐՏidx84 = 0; ՐՏidx84 < ՐՏitr84.length; ՐՏidx84++) {
+                self = ՐՏitr84[ՐՏidx84];
                 if (self instanceof ast.Splat) {
                     output.import(self.module.name);
                 }
                 if (self.argnames) {
-                    ՐՏitr82 = ՐՏ_Iterable(self.argnames);
-                    for (ՐՏidx82 = 0; ՐՏidx82 < ՐՏitr82.length; ՐՏidx82++) {
-                        argname = ՐՏitr82[ՐՏidx82];
+                    ՐՏitr85 = ՐՏ_Iterable(self.argnames);
+                    for (ՐՏidx85 = 0; ՐՏidx85 < ՐՏitr85.length; ՐՏidx85++) {
+                        argname = ՐՏitr85[ՐՏidx85];
                         alias = argname.alias ? argname.alias.name : argname.name;
                         add_aname(alias, self.key, argname.name);
                     }
@@ -8434,7 +8411,7 @@ var ՐՏ_modules = {};
                     if (self.alias) {
                         add_aname(self.alias.name, self.key, false);
                     } else {
-                        bound_name = self.key.split(".", 1)[0];
+                        bound_name = (ՐՏ_484 = self.key.split(".", 1))[0];
                         add_aname(bound_name, bound_name, false);
                     }
                 }
@@ -8497,7 +8474,8 @@ var ՐՏ_modules = {};
             return false;
         }
         function is_simple_for(self) {
-            if (self.object instanceof ast.BaseCall && self.object.expression instanceof ast.SymbolRef && self.object.expression.name === "range" && !(self.init instanceof ast.Array) && (self.object.args.length < 3 || self.object.args[self.object.args.length-1][0] instanceof ast.Number || self.object.args[self.object.args.length-1][0] instanceof ast.Unary && self.object.args[self.object.args.length-1][0].operator === "-" && self.object.args[self.object.args.length-1][0].expression instanceof ast.Number)) {
+            var ՐՏ_485, ՐՏ_486, ՐՏ_487, ՐՏ_488, ՐՏ_489, ՐՏ_490, ՐՏ_491, ՐՏ_492;
+            if (self.object instanceof ast.BaseCall && self.object.expression instanceof ast.SymbolRef && self.object.expression.name === "range" && !(self.init instanceof ast.Array) && (self.object.args.length < 3 || (ՐՏ_485 = (ՐՏ_486 = self.object.args)[ՐՏ_486.length-1])[0] instanceof ast.Number || (ՐՏ_487 = (ՐՏ_488 = self.object.args)[ՐՏ_488.length-1])[0] instanceof ast.Unary && (ՐՏ_489 = (ՐՏ_490 = self.object.args)[ՐՏ_490.length-1])[0].operator === "-" && (ՐՏ_491 = (ՐՏ_492 = self.object.args)[ՐՏ_492.length-1])[0].expression instanceof ast.Number)) {
                 return true;
             }
             return false;
@@ -8547,6 +8525,7 @@ var ՐՏ_modules = {};
             });
         };
         DEFPRINT(ast.ForIn, function(self, output) {
+            var ՐՏ_493, ՐՏ_494, ՐՏ_495, ՐՏ_496, ՐՏ_497, ՐՏ_498;
             var increment, args, tmp_, start, end, iterator;
             if (is_simple_for(self)) {
                 increment = null;
@@ -8554,14 +8533,14 @@ var ՐՏ_modules = {};
                 tmp_ = args.length;
                 if (tmp_ === 1) {
                     start = 0;
-                    end = args[0];
+                    end = (ՐՏ_493 = args)[0];
                 } else if (tmp_ === 2) {
-                    start = args[0];
-                    end = args[1];
+                    start = (ՐՏ_494 = args)[0];
+                    end = (ՐՏ_495 = args)[1];
                 } else if (tmp_ === 3) {
-                    start = args[0];
-                    end = args[1];
-                    increment = args[2];
+                    start = (ՐՏ_496 = args)[0];
+                    end = (ՐՏ_497 = args)[1];
+                    increment = (ՐՏ_498 = args)[2];
                 }
                 output.print("for");
                 output.space();
@@ -8598,7 +8577,8 @@ var ՐՏ_modules = {};
                 output.print("for");
                 output.space();
                 output.with_parens(function() {
-                    output.spaced(self.init, "in", self.object.args[0]);
+                    var ՐՏ_499;
+                    output.spaced(self.init, "in", (ՐՏ_499 = self.object.args)[0]);
                 });
             } else {
                 iterator = output.newTemp("itr");
@@ -8648,11 +8628,12 @@ var ՐՏ_modules = {};
             self._do_print_body(output);
         });
         DEFPRINT(ast.ListComprehension, function(self, output) {
+            var ՐՏ_500;
             var constructor, iterator, index, result, add_entry;
-            constructor = {
+            constructor = (ՐՏ_500 = {
                 ListComprehension: "[]",
                 DictComprehension: "{}"
-            }[ՐՏ_type(self)];
+            })[ՐՏ_type(self)];
             iterator = output.newTemp("itr", false);
             index = output.newTemp("idx", false);
             result = RAPYD_PREFIX + "res";
@@ -8782,8 +8763,9 @@ var ՐՏ_modules = {};
             var pos, wrap;
             pos = 0;
             wrap = function() {
+                var ՐՏ_501;
                 if (pos < decorators.length) {
-                    decorators[pos].expression.print(output);
+                    (ՐՏ_501 = decorators)[pos].expression.print(output);
                     ++pos;
                     output.with_parens(function() {
                         wrap();
@@ -8802,7 +8784,7 @@ var ՐՏ_modules = {};
             };
         }
         ast.Lambda.prototype._do_print = function(output) {
-            var ՐՏ_124;
+            var ՐՏ_502;
             var self, name, is_like_method;
             self = this;
             function addDecorators() {
@@ -8851,7 +8833,7 @@ var ՐՏ_modules = {};
             }
             
             
-            var internalsub = (ՐՏ_124 = function internalsub(print_name) {
+            var internalsub = (ՐՏ_502 = function internalsub(print_name) {
                 print_name = print_name === void 0 ? true : print_name;
                 output.print("function");
                 if (self.generator) {
@@ -8863,6 +8845,7 @@ var ՐՏ_modules = {};
                 }
                 output.with_parens(function() {
                     self.argnames.forEach(function(arg, i) {
+                        var ՐՏ_503, ՐՏ_504;
                         if (is_like_method) {
                             if (i === 0) {
                                 return;
@@ -8873,9 +8856,9 @@ var ՐՏ_modules = {};
                             output.comma();
                         }
                         arg.print(output);
-                        if (output.option("es6") && self.argnames.defaults[arg.name]) {
+                        if (output.option("es6") && (ՐՏ_503 = self.argnames.defaults)[arg.name]) {
                             output.print("=");
-                            self.argnames.defaults[arg.name].print(output);
+                            (ՐՏ_504 = self.argnames.defaults)[arg.name].print(output);
                         }
                     });
                     if (self.kwargs) {
@@ -8887,7 +8870,7 @@ var ՐՏ_modules = {};
                 });
                 output.space();
                 print_bracketed(self, output, true);
-            }, ՐՏ_124 = unify(output, name, addDecorators(), addDocstring())(maybe_weird_name(ՐՏ_124)), ՐՏ_124);
+            }, ՐՏ_502 = unify(output, name, addDecorators(), addDocstring())(maybe_weird_name(ՐՏ_502)), ՐՏ_502);
             internalsub();
         };
         DEFPRINT(ast.Lambda, function(self, output) {
@@ -8913,12 +8896,12 @@ var ՐՏ_modules = {};
                 return null;
             }
             function getES6DecoratedMethods() {
-                var ՐՏitr83, ՐՏidx83;
+                var ՐՏitr86, ՐՏidx86;
                 var decorated_methods, stmt;
                 decorated_methods = [];
-                ՐՏitr83 = ՐՏ_Iterable(self.body);
-                for (ՐՏidx83 = 0; ՐՏidx83 < ՐՏitr83.length; ՐՏidx83++) {
-                    stmt = ՐՏitr83[ՐՏidx83];
+                ՐՏitr86 = ՐՏ_Iterable(self.body);
+                for (ՐՏidx86 = 0; ՐՏidx86 < ՐՏitr86.length; ՐՏidx86++) {
+                    stmt = ՐՏitr86[ՐՏidx86];
                     if (stmt instanceof ast.Lambda && stmt.decorators && stmt.decorators.length) {
                         decorated_methods.push(stmt);
                     }
@@ -8933,19 +8916,21 @@ var ՐՏ_modules = {};
                 name = "var " + self.name.name;
             }
             function outputEs6() {
-                var ՐՏ_125;
+                var ՐՏ_509;
                 function addClassVariablesAndMethDecorators(decorated_methods) {
+                    var ՐՏ_505;
                     var properties, class_vars, def_class_vars_and_decorators;
                     properties = {};
                     class_vars = [];
                     if (self.docstring) {
-                        properties["__doc__"] = function(output) {
+                        (ՐՏ_505 = properties)["__doc__"] = function(output) {
                             output.print_string(self.docstring);
                         };
                     }
                     self.body.forEach(function(stmt, i) {
+                        var ՐՏ_506;
                         if (stmt instanceof ast.SimpleStatement && stmt.body instanceof ast.Assign && stmt.body.operator === "=") {
-                            properties[stmt.body.left.name] = function(output) {
+                            (ՐՏ_506 = properties)[stmt.body.left.name] = function(output) {
                                 output.print(stmt.body.left.name);
                                 output.newline();
                             };
@@ -8959,14 +8944,14 @@ var ՐՏ_modules = {};
                     });
                     if (Object.keys(properties).length || decorated_methods && decorated_methods.length) {
                         def_class_vars_and_decorators = function(obj) {
-                            var ՐՏitr84, ՐՏidx84;
+                            var ՐՏitr87, ՐՏidx87, ՐՏ_507, ՐՏ_508;
                             var output, static_decorations, stmt, decoration;
                             output = this;
                             static_decorations = {};
                             if (decorated_methods) {
-                                ՐՏitr84 = ՐՏ_Iterable(decorated_methods);
-                                for (ՐՏidx84 = 0; ՐՏidx84 < ՐՏitr84.length; ՐՏidx84++) {
-                                    stmt = ՐՏitr84[ՐՏidx84];
+                                ՐՏitr87 = ՐՏ_Iterable(decorated_methods);
+                                for (ՐՏidx87 = 0; ՐՏidx87 < ՐՏitr87.length; ՐՏidx87++) {
+                                    stmt = ՐՏitr87[ՐՏidx87];
                                     function print_name(output, stmt_) {
                                         var pref;
                                         pref = obj + (stmt_.static ? "" : ".prototype");
@@ -8993,9 +8978,9 @@ var ՐՏ_modules = {};
                                         "name": stmt.name
                                     };
                                     if (stmt.static) {
-                                        static_decorations[stmt.name.name] = decoration;
+                                        (ՐՏ_507 = static_decorations)[stmt.name.name] = decoration;
                                     } else {
-                                        properties[stmt.name.name] = decoration;
+                                        (ՐՏ_508 = properties)[stmt.name.name] = decoration;
                                     }
                                 }
                             }
@@ -9015,7 +9000,7 @@ var ՐՏ_modules = {};
                     return null;
                 }
                 
-                var generateClass = (ՐՏ_125 = function generateClass() {
+                var generateClass = (ՐՏ_509 = function generateClass() {
                     output.print("class");
                     if (self.name) {
                         output.space();
@@ -9052,6 +9037,7 @@ var ՐՏ_modules = {};
                                 output.space();
                                 output.with_parens(function() {
                                     stmt.argnames.forEach(function(arg, i) {
+                                        var ՐՏ_510, ՐՏ_511;
                                         if (ՐՏ_in(stmt.name.name, self.static)) {
                                             ++i;
                                         }
@@ -9061,9 +9047,9 @@ var ՐՏ_modules = {};
                                         if (i) {
                                             arg.print(output);
                                         }
-                                        if (stmt.argnames.defaults[arg.name]) {
+                                        if ((ՐՏ_510 = stmt.argnames.defaults)[arg.name]) {
                                             output.print("=");
-                                            stmt.argnames.defaults[arg.name].print(output);
+                                            (ՐՏ_511 = stmt.argnames.defaults)[arg.name].print(output);
                                         }
                                     });
                                     if (self.kwargs) {
@@ -9079,11 +9065,11 @@ var ՐՏ_modules = {};
                             }
                         });
                     });
-                }, ՐՏ_125 = unify(output, name, addDecorators(), addClassVariablesAndMethDecorators(getES6DecoratedMethods()))(ՐՏ_125), ՐՏ_125);
+                }, ՐՏ_509 = unify(output, name, addDecorators(), addClassVariablesAndMethDecorators(getES6DecoratedMethods()))(ՐՏ_509), ՐՏ_509);
                 return generateClass;
             }
             function outputEs5() {
-                var ՐՏupk10, ՐՏ_126;
+                var ՐՏupk10, ՐՏ_515;
                 var methodsAndVars, staticmethods;
                 function define_method(stmt) {
                     return function(output) {
@@ -9152,25 +9138,27 @@ var ՐՏ_modules = {};
                     return null;
                 }
                 function addMethods() {
+                    var ՐՏ_512;
                     var methodsAndVars, staticMethods, class_vars, methodAndOutput, methodAndVarOutput, staticMethodOutput;
                     methodsAndVars = {};
                     staticMethods = {};
                     class_vars = [];
                     if (self.docstring) {
-                        methodsAndVars["__doc__"] = function(output) {
+                        (ՐՏ_512 = methodsAndVars)["__doc__"] = function(output) {
                             output.print_string(self.docstring);
                         };
                     }
                     self.body.forEach(function(stmt, i) {
+                        var ՐՏ_513, ՐՏ_514;
                         var meth_hash;
                         if (stmt instanceof ast.Method) {
                             meth_hash = stmt.static ? staticMethods : methodsAndVars;
-                            meth_hash[stmt.name.name] = {
+                            (ՐՏ_513 = meth_hash)[stmt.name.name] = {
                                 value: define_method(stmt),
                                 name: stmt.name
                             };
                         } else if (stmt instanceof ast.SimpleStatement && stmt.body instanceof ast.Assign && stmt.body.operator === "=") {
-                            methodsAndVars[stmt.body.left.name] = function(output) {
+                            (ՐՏ_514 = methodsAndVars)[stmt.body.left.name] = function(output) {
                                 output.print(stmt.body.left.name);
                             };
                             class_vars.push({
@@ -9200,7 +9188,7 @@ var ՐՏ_modules = {};
                 methodsAndVars = ՐՏupk10[0];
                 staticmethods = ՐՏupk10[1];
                 
-                var generateClass = (ՐՏ_126 = function generateClass() {
+                var generateClass = (ՐՏ_515 = function generateClass() {
                     if (self.init || self.parent || self.statements.length) {
                         output.print("function");
                         output.space();
@@ -9233,7 +9221,7 @@ var ՐՏ_modules = {};
                             bind_methods(self.bound, output);
                         });
                     }
-                }, ՐՏ_126 = unify(output, name, addInheritance(), addDecorators(), methodsAndVars, staticmethods)(ՐՏ_126), ՐՏ_126);
+                }, ՐՏ_515 = unify(output, name, addInheritance(), addDecorators(), methodsAndVars, staticmethods)(ՐՏ_515), ՐՏ_515);
                 return generateClass;
             }
             if (output.option("es6")) {
@@ -9388,13 +9376,14 @@ var ՐՏ_modules = {};
             }
         });
         DEFPRINT(ast.Catch, function(self, output) {
+            var ՐՏ_516, ՐՏ_517;
             output.print("catch");
             output.space();
             output.with_parens(function() {
                 output.print("ՐՏ_Exception");
             });
             output.space();
-            if (self.body.length > 1 || self.body[0].errors.length) {
+            if (self.body.length > 1 || (ՐՏ_516 = self.body)[0].errors.length) {
                 output.with_block(function() {
                     var no_default;
                     output.indent();
@@ -9437,7 +9426,7 @@ var ՐՏ_modules = {};
                     output.newline();
                 });
             } else {
-                print_bracketed(self.body[0], output, true);
+                print_bracketed((ՐՏ_517 = self.body)[0], output, true);
             }
         });
         DEFPRINT(ast.Finally, function(self, output) {
@@ -9500,6 +9489,7 @@ var ՐՏ_modules = {};
             var selfArg, object, has_kwarg_items, has_kwarg_formals, has_kwargs, obj, output_kwargs;
             selfArg = null;
             function call_format() {
+                var ՐՏ_518;
                 var rename;
                 if (self instanceof ast.ClassCall) {
                     if (self.static) {
@@ -9516,7 +9506,7 @@ var ՐՏ_modules = {};
                         output.print(".prototype." + self.method + ".call");
                     }
                 } else {
-                    rename = ՐՏ_in(self.expression.name, SPECIAL_METHODS) ? SPECIAL_METHODS[self.expression.name] : void 0;
+                    rename = ՐՏ_in(self.expression.name, SPECIAL_METHODS) ? (ՐՏ_518 = SPECIAL_METHODS)[self.expression.name] : void 0;
                     if (rename) {
                         output.print(rename);
                     } else {
@@ -9590,13 +9580,14 @@ var ՐՏ_modules = {};
                 if (has_kwarg_formals) {
                     output.print("{");
                     self.args.kwargs.forEach(function(pair, i) {
+                        var ՐՏ_519, ՐՏ_520;
                         if (i) {
                             output.comma();
                         }
-                        pair[0].print(output);
+                        (ՐՏ_519 = pair)[0].print(output);
                         output.print(":");
                         output.space();
-                        pair[1].print(output);
+                        (ՐՏ_520 = pair)[1].print(output);
                     });
                     output.print("}");
                 }
@@ -9616,6 +9607,7 @@ var ՐՏ_modules = {};
             } else if (self.args.starargs) {
                 output.print(".apply");
                 output.with_parens(function() {
+                    var ՐՏ_521;
                     obj.print(output);
                     output.comma();
                     if (self.args.length > 1) {
@@ -9628,13 +9620,14 @@ var ՐՏ_modules = {};
                             });
                         });
                     } else {
-                        self.args[0].print(output);
+                        (ՐՏ_521 = self.args)[0].print(output);
                     }
                     if (has_kwargs || self.args.length > 1) {
                         output.print(".concat");
                         output.with_parens(function() {
+                            var ՐՏ_522;
                             if (self.args.length > 1) {
-                                self.args[self.args.length-1].print(output);
+                                (ՐՏ_522 = self.args)[ՐՏ_522.length-1].print(output);
                                 if (has_kwargs) {
                                     output.comma();
                                 }
@@ -9646,12 +9639,12 @@ var ՐՏ_modules = {};
             } else if (has_kwargs && (self instanceof ast.New || self.expression && self.expression.expression)) {
                 output.print(".call");
                 output.with_parens(function() {
-                    var ՐՏitr85, ՐՏidx85;
+                    var ՐՏitr88, ՐՏidx88;
                     var arg;
                     obj.print(output);
-                    ՐՏitr85 = ՐՏ_Iterable(self.args);
-                    for (ՐՏidx85 = 0; ՐՏidx85 < ՐՏitr85.length; ՐՏidx85++) {
-                        arg = ՐՏitr85[ՐՏidx85];
+                    ՐՏitr88 = ՐՏ_Iterable(self.args);
+                    for (ՐՏidx88 = 0; ՐՏidx88 < ՐՏitr88.length; ՐՏidx88++) {
+                        arg = ՐՏitr88[ՐՏidx88];
                         output.comma();
                         arg.print(output);
                     }
@@ -9723,10 +9716,26 @@ var ՐՏ_modules = {};
             output.print_name(self.property);
         });
         DEFPRINT(ast.Sub, function(self, output) {
-            self.expression.print(output);
+            var exp_print, tmp;
+            if (self.expression instanceof ast.SymbolVar) {
+                self.expression.print(output);
+                exp_print = function() {
+                    self.expression.print(output);
+                };
+            } else {
+                tmp = null;
+                output.with_parens(function() {
+                    tmp = output.newTemp();
+                    output.assign(tmp);
+                    self.expression.print(output);
+                });
+                exp_print = function() {
+                    output.print(tmp);
+                };
+            }
             output.print("[");
             if (self.property instanceof ast.Unary && self.property.operator === "-" && self.property.expression instanceof ast.Number) {
-                self.expression.print(output);
+                exp_print();
                 output.print(".length");
             }
             self.property.print(output);
@@ -9771,6 +9780,7 @@ var ՐՏ_modules = {};
             output.print(self.operator);
         });
         DEFPRINT(ast.Binary, function(self, output) {
+            var ՐՏ_523, ՐՏ_524, ՐՏ_525;
             var comparators, function_ops, normalize, operator, leftvar;
             comparators = {
                 "<": true,
@@ -9794,7 +9804,7 @@ var ՐՏ_modules = {};
                 return op;
             };
             if (ՐՏ_in(self.operator, function_ops)) {
-                output.print(function_ops[self.operator]);
+                output.print((ՐՏ_523 = function_ops)[self.operator]);
                 output.with_parens(function() {
                     self.left.print(output);
                     if (self.operator === "//") {
@@ -9806,7 +9816,7 @@ var ՐՏ_modules = {};
                     }
                     self.right.print(output);
                 });
-            } else if (comparators[self.operator] && self.left instanceof ast.Binary && comparators[self.left.operator]) {
+            } else if ((ՐՏ_524 = comparators)[self.operator] && self.left instanceof ast.Binary && (ՐՏ_525 = comparators)[self.left.operator]) {
                 operator = normalize(self.operator);
                 if (self.left.right instanceof ast.Symbol) {
                     self.left.print(output);
@@ -9959,12 +9969,12 @@ var ՐՏ_modules = {};
             });
         });
         DEFPRINT(ast.Range, function(self, output) {
-            var ՐՏitr86, ՐՏidx86;
+            var ՐՏitr89, ՐՏidx89, ՐՏ_526, ՐՏ_527, ՐՏ_528, ՐՏ_529, ՐՏ_530, ՐՏ_531;
             var indexes, element, start, end, step;
             indexes = [];
-            ՐՏitr86 = ՐՏ_Iterable([ self.left, self.right ]);
-            for (ՐՏidx86 = 0; ՐՏidx86 < ՐՏitr86.length; ՐՏidx86++) {
-                element = ՐՏitr86[ՐՏidx86];
+            ՐՏitr89 = ՐՏ_Iterable([ self.left, self.right ]);
+            for (ՐՏidx89 = 0; ՐՏidx89 < ՐՏitr89.length; ՐՏidx89++) {
+                element = ՐՏitr89[ՐՏidx89];
                 if (element instanceof ast.UnaryPrefix && element.operator === "-" && element.expression instanceof ast.Number) {
                     indexes.push(parseFloat("-" + element.expression.value));
                 } else if (element instanceof ast.Number) {
@@ -9973,19 +9983,19 @@ var ՐՏ_modules = {};
                     indexes.push(null);
                 }
             }
-            if (indexes[0] && indexes[1] && Math.abs(indexes[1] - indexes[0]) < 50) {
-                start = indexes[0];
-                end = indexes[1];
+            if ((ՐՏ_526 = indexes)[0] && (ՐՏ_527 = indexes)[1] && Math.abs((ՐՏ_528 = indexes)[1] - (ՐՏ_529 = indexes)[0]) < 50) {
+                start = (ՐՏ_530 = indexes)[0];
+                end = (ՐՏ_531 = indexes)[1];
                 step = start < end ? 1 : -1;
                 if (self.operator === "to") {
                     end += step / 1e6;
                 }
                 output.with_square(function() {
-                    var ՐՏitr87, ՐՏidx87;
+                    var ՐՏitr90, ՐՏidx90;
                     var i;
-                    ՐՏitr87 = ՐՏ_Iterable(range(start, end, step));
-                    for (ՐՏidx87 = 0; ՐՏidx87 < ՐՏitr87.length; ՐՏidx87++) {
-                        i = ՐՏitr87[ՐՏidx87];
+                    ՐՏitr90 = ՐՏ_Iterable(range(start, end, step));
+                    for (ՐՏidx90 = 0; ՐՏidx90 < ՐՏitr90.length; ՐՏidx90++) {
+                        i = ՐՏitr90[ՐՏidx90];
                         if (i !== start) {
                             output.comma();
                         }
@@ -10008,13 +10018,13 @@ var ՐՏ_modules = {};
             }
         });
         DEFPRINT(ast.ObjectLiteral, function(self, output) {
-            var ՐՏitr88, ՐՏidx88, ՐՏ_127;
+            var ՐՏitr91, ՐՏidx91, ՐՏ_532, ՐՏ_533, ՐՏ_534, ՐՏ_535;
             var properties, p, v, key, v_key, h_, props, add_props;
             if (self.properties.length > 0) {
                 properties = {};
-                ՐՏitr88 = ՐՏ_Iterable(self.properties);
-                for (ՐՏidx88 = 0; ՐՏidx88 < ՐՏitr88.length; ՐՏidx88++) {
-                    p = ՐՏitr88[ՐՏidx88];
+                ՐՏitr91 = ՐՏ_Iterable(self.properties);
+                for (ՐՏidx91 = 0; ՐՏidx91 < ՐՏitr91.length; ՐՏidx91++) {
+                    p = ՐՏitr91[ՐՏidx91];
                     v = p.value;
                     key = p.key;
                     if (v_key = v instanceof ast.ObjectGetter ? "get" : v instanceof ast.ObjectSetter ? "set" : false) {
@@ -10023,15 +10033,15 @@ var ՐՏ_modules = {};
                                 v.print(output);
                             };
                         };
-                        if (!(props = properties[key.name])) {
-                            props = properties[key.name] = {
+                        if (!(props = (ՐՏ_532 = properties)[key.name])) {
+                            props = (ՐՏ_533 = properties)[key.name] = {
                                 "name": key,
                                 "attrs": {
                                     "enumerable": "true"
                                 }
                             };
                         }
-                        props[v_key] = h_(v);
+                        (ՐՏ_534 = props)[v_key] = h_(v);
                     }
                 }
                 add_props = null;
@@ -10043,7 +10053,7 @@ var ՐՏ_modules = {};
                     add_props = output.with_class_vars_init([], add_props);
                 }
                 
-                var inner = (ՐՏ_127 = function inner() {
+                var inner = (ՐՏ_535 = function inner() {
                     output.with_block(function() {
                         var j;
                         j = 0;
@@ -10060,7 +10070,7 @@ var ՐՏ_modules = {};
                         });
                         output.newline();
                     });
-                }, ՐՏ_127 = unify(output, null, add_props)(ՐՏ_127), ՐՏ_127);
+                }, ՐՏ_535 = unify(output, null, add_props)(ՐՏ_535), ՐՏ_535);
                 inner();
             } else {
                 output.print("{}");
@@ -10154,18 +10164,19 @@ var ՐՏ_modules = {};
             }
         }
         function first_in_statement(output) {
+            var ՐՏ_536, ՐՏ_537, ՐՏ_538;
             var processed, i, node, prev;
             processed = output.stack();
             i = processed.length;
-            node = processed[--i];
-            prev = processed[--i];
+            node = (ՐՏ_536 = processed)[--i];
+            prev = (ՐՏ_537 = processed)[--i];
             while (i > 0) {
                 if (prev instanceof ast.Statement && prev.body === node) {
                     return true;
                 }
                 if (prev instanceof ast.Seq && prev.car === node || prev instanceof ast.BaseCall && prev.expression === node || prev instanceof ast.Dot && prev.expression === node || prev instanceof ast.Sub && prev.expression === node || prev instanceof ast.Conditional && prev.condition === node || prev instanceof ast.Binary && prev.left === node || prev instanceof ast.UnaryPostfix && prev.expression === node) {
                     node = prev;
-                    prev = processed[--i];
+                    prev = (ՐՏ_538 = processed)[--i];
                 } else {
                     return false;
                 }
@@ -10175,18 +10186,20 @@ var ՐՏ_modules = {};
             return self.args.length === 0 && !output.option("beautify");
         }
         function best_of(choices) {
+            var ՐՏ_539, ՐՏ_540, ՐՏ_541;
             var best, len_, i;
-            best = choices[0];
+            best = (ՐՏ_539 = choices)[0];
             len_ = best.length;
             for (i = 1; i < choices.length; i++) {
-                if (choices[i].length < len_) {
-                    best = choices[i];
+                if ((ՐՏ_540 = choices)[i].length < len_) {
+                    best = (ՐՏ_541 = choices)[i];
                     len_ = best.length;
                 }
             }
             return best;
         }
         function make_num(num) {
+            var ՐՏ_542, ՐՏ_543, ՐՏ_544, ՐՏ_545, ՐՏ_546;
             var str_, choices, match;
             str_ = num.toString(10);
             choices = [ str_.replace(/^0\./, ".").replace("e+", "e") ];
@@ -10198,10 +10211,10 @@ var ՐՏ_modules = {};
                     choices.push("-0x" + (-num).toString(16).toLowerCase(), "-0" + (-num).toString(8));
                 }
                 if (match = /^(.*?)(0+)$/.exec(num)) {
-                    choices.push(match[1] + "e" + match[2].length);
+                    choices.push((ՐՏ_542 = match)[1] + "e" + (ՐՏ_543 = match)[2].length);
                 }
             } else if (match = /^0?\.(0+)(.*)$/.exec(num)) {
-                choices.push(match[2] + "e-" + (match[1].length + match[2].length), str_.substr(str_.indexOf(".")));
+                choices.push((ՐՏ_544 = match)[2] + "e-" + ((ՐՏ_545 = match)[1].length + (ՐՏ_546 = match)[2].length), str_.substr(str_.indexOf(".")));
             }
             return best_of(choices);
         }
@@ -10246,32 +10259,34 @@ var ՐՏ_modules = {};
             output.add_mapping(self.start, self.key);
         });
     })();
-    ՐՏ_modules["output"]["Stream"] = Stream;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:output"];
+    ՐՏ_mod.export("Stream", function(){return Stream;}, function(ՐՏ_v){if (typeof Stream !== "undefined") {Stream = ՐՏ_v;};});
+    ՐՏ_mod.export("RAPYD_PREFIX", function(){return RAPYD_PREFIX;}, function(ՐՏ_v){if (typeof RAPYD_PREFIX !== "undefined") {RAPYD_PREFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("PRECEDENCE", function(){return PRECEDENCE;}, function(ՐՏ_v){if (typeof PRECEDENCE !== "undefined") {PRECEDENCE = ՐՏ_v;};});
+    ՐՏ_mod.export("stream", function(){return stream;}, function(ՐՏ_v){if (typeof stream !== "undefined") {stream = ՐՏ_v;};});
+    ՐՏ_mod.export("ast", function(){return ast;}, function(ՐՏ_v){if (typeof ast !== "undefined") {ast = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 var browser_env, exports, rapydscript, compile;
 var utils = ՐՏ_modules["utils"];
-
 var ast = ՐՏ_modules["ast"];
-
 var tokenizer = ՐՏ_modules["tokenizer"];
-
 var parser = ՐՏ_modules["parser"];
-
 var output = ՐՏ_modules["output"];
-
 ast.Node.warn_function = function(txt) {
     console.error(txt);
 };
 function splatBaselib(key, value) {
+    var ՐՏ_547, ՐՏ_548;
     return new ast.Splat({
         module: new ast.SymbolVar({
             name: key
         }),
         body: new ast.TopLevel({
-            start: value[0].start,
+            start: (ՐՏ_547 = value)[0].start,
             body: value,
             strict: true,
-            end: value[value.length-1].end
+            end: (ՐՏ_548 = value)[ՐՏ_548.length-1].end
         })
     });
 }
@@ -10279,8 +10294,8 @@ browser_env = !exports;
 if (browser_env) {
     rapydscript = exports = {};
 }
-exports.parse_baselib = exports.parseBaselib = function(srcPath, beautify) {
-    var ՐՏitr89, ՐՏidx89;
+exports.parse_baselib = exports.parseBaselib = function(srcPath, es6) {
+    var ՐՏ_549, ՐՏitr92, ՐՏidx92, ՐՏ_550;
     var fs, baselibPath, baselibAst, hash, data, baselibList, item, key, value;
     try {
         fs = require("fs");
@@ -10288,7 +10303,8 @@ exports.parse_baselib = exports.parseBaselib = function(srcPath, beautify) {
         baselibAst = parser.parse(fs.readFileSync(baselibPath, "utf8"), {
             readfile: fs.readFileSync,
             dropDocstrings: true,
-            filename: "baselib.pyj"
+            filename: "baselib.pyj",
+            es6: es6
         });
     } catch (ՐՏ_Exception) {
         var e = ՐՏ_Exception;
@@ -10298,15 +10314,15 @@ exports.parse_baselib = exports.parseBaselib = function(srcPath, beautify) {
             throw ՐՏ_Exception;
         }
     }
-    hash = baselibAst.body[baselibAst.body.length-1];
+    hash = (ՐՏ_549 = baselibAst.body)[ՐՏ_549.length-1];
     data = hash.body.properties;
     baselibList = {};
-    ՐՏitr89 = ՐՏ_Iterable(data);
-    for (ՐՏidx89 = 0; ՐՏidx89 < ՐՏitr89.length; ՐՏidx89++) {
-        item = ՐՏitr89[ՐՏidx89];
+    ՐՏitr92 = ՐՏ_Iterable(data);
+    for (ՐՏidx92 = 0; ՐՏidx92 < ՐՏitr92.length; ՐՏidx92++) {
+        item = ՐՏitr92[ՐՏidx92];
         key = item.key.value;
         value = item.value.name ? [ item.value ] : item.value.body;
-        baselibList[key] = splatBaselib(key, value);
+        (ՐՏ_550 = baselibList)[key] = splatBaselib(key, value);
     }
     return baselibList;
 };
@@ -10328,63 +10344,40 @@ exports.get_import_dirs = function(paths_string, ignore_env) {
     return paths;
 };
 exports.compile = compile = function(code, options) {
-    var toplevel, stream;
-    if (browser_env) {
-        parser.init_mod();
-    }
+    var ՐՏitr93, ՐՏidx93, ՐՏitr94, ՐՏidx94, ՐՏ_552;
+    var toplevel, baselib_dep_map, fun, rex_key, rex, stream;
+    parser.init_mod();
     toplevel = parser.parse(code, utils.defaults(options, {
         toplevel: toplevel,
         output: {}
     }));
-    if (!options.omit_baselib && !browser_env) {
-        if (!toplevel.baselib["AssertionError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["IndexError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["KeyError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["TypeError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["ValueError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["kwargs"]) {
-            --toplevel.baselib["in"];
-            --toplevel.baselib["iterator"];
-            --toplevel.baselib["range"];
-            --toplevel.baselib["dir"];
-        }
-        if (!toplevel.baselib["eq"]) {
-            toplevel.baselib["iterator"] -= 2;
-            --toplevel.baselib["range"];
-        }
-        if (!toplevel.baselib["merge"]) {
-            --toplevel.baselib["iterator"];
-        }
-        if (!toplevel.baselib["mixin"]) {
-            --toplevel.baselib["in"];
-            toplevel.baselib["iterator"] -= 2;
-        }
-        if (!toplevel.baselib["enumerate"]) {
-            --toplevel.baselib["iterator"];
-            --toplevel.baselib["range"];
-        }
-        if (!toplevel.baselib["all"]) {
-            --toplevel.baselib["iterator"];
-        }
-        if (!toplevel.baselib["any"]) {
-            --toplevel.baselib["iterator"];
-        }
-        if (!toplevel.baselib["zip"]) {
-            --toplevel.baselib["iterator"];
-            --toplevel.baselib["range"];
-        }
-        if (!toplevel.baselib["rebind_all"]) {
-            --toplevel.baselib["bind"];
+    if (!options.omit_baselib) {
+        baselib_dep_map = {
+            ".+Error": [ "extends" ],
+            "all|any|zip|iterable|kwargs|eq|merge|mixin|enumerate": [ "iterable" ],
+            "kwargs": [ "in", "range", "merge", "dir" ],
+            "eq": [ "range" ],
+            "mixin": [ "in" ],
+            "zip": [ "range" ],
+            "rebind_all": [ "bind" ]
+        };
+        ՐՏitr93 = ՐՏ_Iterable(Object.keys(toplevel.baselib).filter(function(f) {
+            var ՐՏ_551;
+            return (ՐՏ_551 = toplevel.baselib)[f];
+        }));
+        for (ՐՏidx93 = 0; ՐՏidx93 < ՐՏitr93.length; ՐՏidx93++) {
+            fun = ՐՏitr93[ՐՏidx93];
+            ՐՏitr94 = ՐՏ_Iterable(baselib_dep_map);
+            for (ՐՏidx94 = 0; ՐՏidx94 < ՐՏitr94.length; ՐՏidx94++) {
+                rex_key = ՐՏitr94[ՐՏidx94];
+                rex = new RegExp("^(" + rex_key + ")$");
+                if (rex.test(fun)) {
+                    (ՐՏ_552 = baselib_dep_map)[rex_key].forEach(function(k) {
+                        var ՐՏ_553;
+                        (ՐՏ_553 = toplevel.baselib)[k] = 1;
+                    });
+                }
+            }
         }
     }
     stream = output.Stream(options);
@@ -10392,7 +10385,7 @@ exports.compile = compile = function(code, options) {
     return stream.toString();
 };
 exports.minify = function(files, options) {
-    var ՐՏitr90, ՐՏidx90;
+    var ՐՏitr95, ՐՏidx95;
     var file, code;
     options = utils.defaults(options, {
         fromString: false,
@@ -10401,9 +10394,9 @@ exports.minify = function(files, options) {
     if (typeof files === "string") {
         files = [ files ];
     }
-    ՐՏitr90 = ՐՏ_Iterable(files);
-    for (ՐՏidx90 = 0; ՐՏidx90 < ՐՏitr90.length; ՐՏidx90++) {
-        file = ՐՏitr90[ՐՏidx90];
+    ՐՏitr95 = ՐՏ_Iterable(files);
+    for (ՐՏidx95 = 0; ՐՏidx95 < ՐՏitr95.length; ՐՏidx95++) {
+        file = ՐՏitr95[ՐՏidx95];
         options.filename = options.fromString ? "?" : file;
         code = options.fromString ? file : require("fs").readFileSync(file, "utf8");
         return {
@@ -10426,4 +10419,4 @@ exports.ParseError = utils.ParseError;
 exports.ImportError = utils.ImportError;
 exports.ALL_KEYWORDS = tokenizer.ALL_KEYWORDS;
 exports.IDENTIFIER_PAT = tokenizer.IDENTIFIER_PAT;
-exports.colored = utils.colored;var ՐՏ_128, ՐՏ_129, ՐՏ_130, ՐՏ_131, ՐՏ_132;
+exports.colored = utils.colored;

--- a/lib/rapydscript_web.js
+++ b/lib/rapydscript_web.js
@@ -3,65 +3,7 @@
 
     function factory(){
         "use strict";
-        var ՐՏ_1, ՐՏ_2, ՐՏ_3, ՐՏ_4, ՐՏ_5, ՐՏ_6, ՐՏ_7, ՐՏ_8, ՐՏ_9, ՐՏ_10, ՐՏ_11, ՐՏ_12, ՐՏ_13, ՐՏ_14, ՐՏ_15, ՐՏ_16, ՐՏ_17, ՐՏ_18, ՐՏ_19, ՐՏ_20, ՐՏ_21, ՐՏ_22, ՐՏ_23, ՐՏ_24, ՐՏ_25, ՐՏ_26, ՐՏ_27, ՐՏ_28, ՐՏ_29, ՐՏ_31, ՐՏ_32, ՐՏ_33, ՐՏ_34, ՐՏ_35, ՐՏ_36, ՐՏ_37, ՐՏ_38, ՐՏ_39, ՐՏ_40, ՐՏ_41, ՐՏ_42, ՐՏ_43, ՐՏ_44, ՐՏ_45, ՐՏ_46, ՐՏ_47, ՐՏ_48, ՐՏ_49, ՐՏ_50, ՐՏ_51, ՐՏ_52, ՐՏ_53, ՐՏ_54, ՐՏ_55, ՐՏ_56, ՐՏ_57, ՐՏ_58, ՐՏ_59, ՐՏ_60, ՐՏ_62, ՐՏ_63, ՐՏ_64, ՐՏ_65, ՐՏ_66, ՐՏ_67, ՐՏ_68, ՐՏ_69, ՐՏ_70, ՐՏ_71, ՐՏ_72, ՐՏ_73, ՐՏ_74, ՐՏ_75, ՐՏ_76, ՐՏ_77, ՐՏ_78, ՐՏ_79, ՐՏ_80, ՐՏ_81, ՐՏ_82, ՐՏ_83, ՐՏ_84, ՐՏ_85, ՐՏ_86, ՐՏ_87, ՐՏ_88, ՐՏ_89, ՐՏ_90, ՐՏ_91, ՐՏ_92, ՐՏ_93, ՐՏ_94, ՐՏ_95, ՐՏ_96, ՐՏ_97, ՐՏ_98, ՐՏ_99, ՐՏ_100, ՐՏ_101, ՐՏ_102, ՐՏ_103, ՐՏ_104, ՐՏ_105, ՐՏ_106, ՐՏ_107, ՐՏ_108, ՐՏ_109, ՐՏ_110, ՐՏ_111, ՐՏ_112, ՐՏ_113, ՐՏ_114, ՐՏ_115;
-function abs(n) {
-    return Math.abs(n);
-}
-function all(a) {
-    var ՐՏitr91, ՐՏidx91;
-    var e;
-    ՐՏitr91 = ՐՏ_Iterable(a);
-    for (ՐՏidx91 = 0; ՐՏidx91 < ՐՏitr91.length; ՐՏidx91++) {
-        e = ՐՏitr91[ՐՏidx91];
-        if (!e) {
-            return false;
-        }
-    }
-    return true;
-}
-function any(a) {
-    var ՐՏitr92, ՐՏidx92;
-    var e;
-    ՐՏitr92 = ՐՏ_Iterable(a);
-    for (ՐՏidx92 = 0; ՐՏidx92 < ՐՏitr92.length; ՐՏidx92++) {
-        e = ՐՏitr92[ՐՏidx92];
-        if (e) {
-            return true;
-        }
-    }
-    return false;
-}
-function bin(a) {
-    return "0b" + (a >>> 0).toString(2);
-}
-function ՐՏ_bind(fn, thisArg) {
-    var ret;
-    if (fn.orig) {
-        fn = fn.orig;
-    }
-    if (thisArg === false) {
-        return fn;
-    }
-    ret = function() {
-        return fn.apply(thisArg, arguments);
-    };
-    ret.orig = fn;
-    return ret;
-}
-function ՐՏ_rebindAll(thisArg, rebind) {
-    if (rebind === void 0) {
-        rebind = true;
-    }
-    for (var p in thisArg) {
-        if (thisArg[p] && thisArg[p].orig) {
-            if (rebind) {
-                thisArg[p] = ՐՏ_bind(thisArg[p], thisArg);
-            } else {
-                thisArg[p] = thisArg[p].orig;
-            }
-        }
-    }
-}
+        var ՐՏ_4, ՐՏ_5, ՐՏ_35, ՐՏ_38, ՐՏ_39, ՐՏ_42, ՐՏ_43, ՐՏ_44, ՐՏ_45, ՐՏ_46, ՐՏ_47, ՐՏ_48, ՐՏ_49, ՐՏ_50, ՐՏ_51, ՐՏ_52, ՐՏ_53, ՐՏ_54, ՐՏ_55, ՐՏ_56, ՐՏ_57, ՐՏ_58, ՐՏ_59, ՐՏ_60, ՐՏ_61, ՐՏ_62, ՐՏ_63, ՐՏ_64, ՐՏ_65, ՐՏ_71, ՐՏ_72, ՐՏ_73, ՐՏ_74, ՐՏ_75, ՐՏ_76, ՐՏ_77, ՐՏ_78, ՐՏ_79, ՐՏ_80, ՐՏ_81, ՐՏ_82, ՐՏ_83, ՐՏ_84, ՐՏ_85, ՐՏ_86, ՐՏ_87, ՐՏ_88, ՐՏ_89, ՐՏ_90, ՐՏ_91, ՐՏ_92, ՐՏ_93, ՐՏ_94, ՐՏ_95, ՐՏ_96, ՐՏ_97, ՐՏ_98, ՐՏ_99, ՐՏ_100, ՐՏ_121, ՐՏ_124, ՐՏ_125, ՐՏ_128, ՐՏ_129, ՐՏ_132, ՐՏ_137, ՐՏ_138, ՐՏ_139, ՐՏ_140, ՐՏ_141, ՐՏ_142, ՐՏ_143, ՐՏ_144, ՐՏ_145, ՐՏ_146, ՐՏ_148, ՐՏ_149, ՐՏ_153, ՐՏ_154, ՐՏ_155, ՐՏ_156, ՐՏ_157, ՐՏ_158, ՐՏ_159, ՐՏ_160, ՐՏ_161, ՐՏ_162, ՐՏ_163, ՐՏ_164, ՐՏ_165, ՐՏ_166, ՐՏ_167, ՐՏ_168, ՐՏ_169, ՐՏ_170, ՐՏ_171, ՐՏ_175, ՐՏ_176, ՐՏ_177, ՐՏ_178, ՐՏ_179, ՐՏ_180, ՐՏ_181, ՐՏ_182, ՐՏ_183, ՐՏ_184, ՐՏ_185, ՐՏ_186, ՐՏ_187, ՐՏ_188, ՐՏ_189, ՐՏ_190, ՐՏ_191;
 function ՐՏ_with__name__(fn, name) {
     fn.__name__ = name;
     return fn;
@@ -69,7 +11,6 @@ function ՐՏ_with__name__(fn, name) {
 function cmp(a, b) {
     return a < b ? -1 : a > b ? 1 : 0;
 }
-var chr = String.fromCharCode;
 function dir(item) {
     var arr;
     arr = [];
@@ -79,52 +20,19 @@ function dir(item) {
     return arr;
 }
 function enumerate(item) {
+    var ՐՏ_554, ՐՏ_555;
     var arr, iter, i;
     arr = [];
     iter = ՐՏ_Iterable(item);
     for (i = 0; i < iter.length; i++) {
-        arr[arr.length] = [ i, item[i] ];
+        (ՐՏ_554 = arr)[arr.length] = [ i, (ՐՏ_555 = item)[i] ];
     }
     return arr;
-}
-function ՐՏ_eslice(arr, step, start, end) {
-    var isString;
-    arr = arr.slice(0);
-    if (typeof arr === "string" || arr instanceof String) {
-        isString = true;
-        arr = arr.split("");
-    }
-    if (step < 0) {
-        step = -step;
-        arr.reverse();
-        if (typeof start !== "undefined") {
-            start = arr.length - start - 1;
-        }
-        if (typeof end !== "undefined") {
-            end = arr.length - end - 1;
-        }
-    }
-    if (typeof start === "undefined") {
-        start = 0;
-    }
-    if (typeof end === "undefined") {
-        end = arr.length;
-    }
-    arr = arr.slice(start, end).filter(function(e, i) {
-        return i % step === 0;
-    });
-    return isString ? arr.join("") : arr;
 }
 function ՐՏ_extends(child, parent) {
     child.prototype = Object.create(parent.prototype);
     child.prototype.__base__ = parent;
     child.prototype.constructor = child;
-}
-function filter(oper, arr) {
-    return arr.filter(oper);
-}
-function hex(a) {
-    return "0x" + (a >>> 0).toString(16);
 }
 function ՐՏ_in(val, arr) {
     if (typeof arr.indexOf === "function") {
@@ -154,115 +62,49 @@ function len(obj) {
     }
     return Object.keys(obj).length;
 }
-function map(oper, arr) {
-    return arr.map(oper);
-}
-function max(a) {
-    return Math.max.apply(null, Array.isArray(a) ? a : arguments);
-}
-function min(a) {
-    return Math.min.apply(null, Array.isArray(a) ? a : arguments);
-}
 function ՐՏ_merge(target, source, overwrite) {
-    var ՐՏitr93, ՐՏidx93;
+    var ՐՏ_556, ՐՏ_557, ՐՏitr96, ՐՏidx96;
     var prop;
     for (var i in source) {
         if (source.hasOwnProperty(i) && (overwrite || typeof target[i] === "undefined")) {
-            target[i] = source[i];
+            (ՐՏ_556 = target)[i] = (ՐՏ_557 = source)[i];
         }
     }
-    ՐՏitr93 = ՐՏ_Iterable(Object.getOwnPropertyNames(source.prototype));
-    for (ՐՏidx93 = 0; ՐՏidx93 < ՐՏitr93.length; ՐՏidx93++) {
-        prop = ՐՏitr93[ՐՏidx93];
+    ՐՏitr96 = ՐՏ_Iterable(Object.getOwnPropertyNames(source.prototype));
+    for (ՐՏidx96 = 0; ՐՏidx96 < ՐՏitr96.length; ՐՏidx96++) {
+        prop = ՐՏitr96[ՐՏidx96];
         if (overwrite || typeof target.prototype[prop] === "undefined") {
             Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop));
         }
     }
 }
-function ՐՏ_mixin() {
-    var classes = [].slice.call(arguments, 0);
-    return function(baseClass) {
-        var ՐՏitr94, ՐՏidx94, ՐՏitr95, ՐՏidx95;
-        var cls, key;
-        ՐՏitr94 = ՐՏ_Iterable(classes);
-        for (ՐՏidx94 = 0; ՐՏidx94 < ՐՏitr94.length; ՐՏidx94++) {
-            cls = ՐՏitr94[ՐՏidx94];
-            ՐՏitr95 = ՐՏ_Iterable(Object.getOwnPropertyNames(cls.prototype));
-            for (ՐՏidx95 = 0; ՐՏidx95 < ՐՏitr95.length; ՐՏidx95++) {
-                key = ՐՏitr95[ՐՏidx95];
-                if (!(ՐՏ_in(key, baseClass.prototype))) {
-                    Object.defineProperty(baseClass.prototype, key, Object.getOwnPropertyDescriptor(cls.prototype, key));
-                }
-            }
-        }
-        return baseClass;
-    };
-}
-function ՐՏ_print() {
-    if (typeof console === "object") {
-        console.log.apply(console, arguments);
-    }
-}
 function range(start, stop, step) {
+    var ՐՏ_558, ՐՏ_559;
     var length, idx, range;
     if (arguments.length <= 1) {
         stop = start || 0;
         start = 0;
     }
-    step = arguments[2] || 1;
+    step = (ՐՏ_558 = arguments)[2] || 1;
     length = Math.max(Math.ceil((stop - start) / step), 0);
     idx = 0;
     range = new Array(length);
     while (idx < length) {
-        range[idx++] = start;
+        (ՐՏ_559 = range)[idx++] = start;
         start += step;
     }
     return range;
-}
-function reduce(f, a) {
-    return Array.prototype.reduce.call(a, f);
 }
 function reversed(arr) {
     var tmp;
     tmp = arr.slice(0);
     return tmp.reverse();
 }
-function sorted(arr) {
-    var tmp;
-    tmp = arr.slice(0);
-    return tmp.sort();
-}
-function sum(arr, start) {
-    start = start === void 0 ? 0 : start;
-    return arr.reduce(function(prev, cur) {
-        return prev + cur;
-    }, start);
-}
 function ՐՏ_type(obj) {
     return obj && obj.constructor && obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1);
 }
-function zip(a, b) {
-    var i;
-    return (function() {
-        var ՐՏidx96, ՐՏitr96 = ՐՏ_Iterable(range(Math.min(a.length, b.length))), ՐՏres = [], i;
-        for (ՐՏidx96 = 0; ՐՏidx96 < ՐՏitr96.length; ՐՏidx96++) {
-            i = ՐՏitr96[ՐՏidx96];
-            ՐՏres.push([ a[i], b[i] ]);
-        }
-        return ՐՏres;
-    })();
-}
-function getattr(obj, name) {
-    return obj[name];
-}
-function setattr(obj, name, value) {
-    obj[name] = value;
-}
-function hasattr(obj, name) {
-    return name in obj;
-}
 function ՐՏ_eq(a, b) {
-    var ՐՏitr97, ՐՏidx97;
+    var ՐՏ_560, ՐՏ_561, ՐՏitr97, ՐՏidx97, ՐՏ_562, ՐՏ_563;
     var i;
     if (a === b) {
         return true;
@@ -278,7 +120,7 @@ function ՐՏ_eq(a, b) {
             return false;
         }
         for (i = 0; i < a.length; i++) {
-            if (!ՐՏ_eq(a[i], b[i])) {
+            if (!ՐՏ_eq((ՐՏ_560 = a)[i], (ՐՏ_561 = b)[i])) {
                 return false;
             }
         }
@@ -290,7 +132,7 @@ function ՐՏ_eq(a, b) {
         ՐՏitr97 = ՐՏ_Iterable(a);
         for (ՐՏidx97 = 0; ՐՏidx97 < ՐՏitr97.length; ՐՏidx97++) {
             i = ՐՏitr97[ՐՏidx97];
-            if (!ՐՏ_eq(a[i], b[i])) {
+            if (!ՐՏ_eq((ՐՏ_562 = a)[i], (ՐՏ_563 = b)[i])) {
                 return false;
             }
         }
@@ -313,23 +155,25 @@ function ՐՏ_eq(a, b) {
     return false;
 }
 function kwargs(f) {
+    var ՐՏ_564, ՐՏ_565, ՐՏ_566, ՐՏ_567;
     var argNames;
-    argNames = f.toString().match(/\(([^\)]+)/)[1];
-    if (!kwargs.memo[argNames]) {
-        kwargs.memo[argNames] = argNames ? argNames.split(",").map(function(s) {
+    argNames = (ՐՏ_564 = f.toString().match(/\(([^\)]+)/))[1];
+    if (!(ՐՏ_565 = kwargs.memo)[argNames]) {
+        (ՐՏ_566 = kwargs.memo)[argNames] = argNames ? argNames.split(",").map(function(s) {
             return s.trim();
         }) : [];
     }
-    argNames = kwargs.memo[argNames];
+    argNames = (ՐՏ_567 = kwargs.memo)[argNames];
     return function() {
+        var ՐՏ_568, ՐՏ_569, ՐՏ_570, ՐՏ_571, ՐՏ_572;
         var args, kw, i;
         args = [].slice.call(arguments);
         if (args.length) {
-            kw = args[args.length-1];
+            kw = (ՐՏ_568 = args)[ՐՏ_568.length-1];
             if (typeof kw === "object") {
                 for (i = 0; i < argNames.length; i++) {
-                    if (ՐՏ_in(argNames[i], kw)) {
-                        args[i] = kw[argNames[i]];
+                    if (ՐՏ_in((ՐՏ_569 = argNames)[i], kw)) {
+                        (ՐՏ_570 = args)[i] = (ՐՏ_571 = kw)[(ՐՏ_572 = argNames)[i]];
                     }
                 }
             } else {
@@ -348,86 +192,60 @@ function kwargs(f) {
     };
 }
 kwargs.memo = {};
-var AssertionError = (ՐՏ_128 = function AssertionError() {
-    AssertionError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_128, Error), Object.defineProperties(ՐՏ_128.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "AssertionError";
-            self.message = message;
-        }
-
+function ՐՏ_def_modules() {
+    var modules;
+    modules = {};
+    function mounter(mod_id) {
+        var ՐՏ_573, ՐՏ_574;
+        var rs_mod_id, rs_mod;
+        rs_mod_id = "ՐՏ:" + mod_id;
+        rs_mod = (ՐՏ_573 = modules)[rs_mod_id] = {
+            "body": null,
+            "exports": null
+        };
+        (ՐՏ_574 = rs_mod)["export"] = function(prop, get, set) {
+            var ՐՏ_575, ՐՏ_576, ՐՏ_577;
+            if (!(ՐՏ_575 = rs_mod)["exports"]) {
+                (ՐՏ_576 = rs_mod)["exports"] = {};
+            }
+            Object.defineProperty((ՐՏ_577 = rs_mod)["exports"], prop, {
+                configurable: true,
+                enumerable: true,
+                get: get,
+                set: set
+            });
+        };
+        Object.defineProperty(modules, mod_id, {
+            enumerable: true,
+            get: function() {
+                var ՐՏ_578, ՐՏ_579, ՐՏ_580;
+                var mod;
+                return (ՐՏ_578 = (mod = (ՐՏ_579 = modules)[rs_mod_id]))["exports"] || (ՐՏ_580 = mod)["body"]();
+            },
+            set: function(v) {
+                var ՐՏ_581, ՐՏ_582;
+                (ՐՏ_581 = (ՐՏ_582 = modules)[rs_mod_id])["exports"] = v;
+            }
+        });
+        return rs_mod;
     }
-}), ՐՏ_128);
-var IndexError = (ՐՏ_129 = function IndexError() {
-    IndexError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_129, Error), Object.defineProperties(ՐՏ_129.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "IndexError";
-            self.message = message;
-        }
+    Object.defineProperty(modules, "ՐՏ_def", {
+        configurable: false,
+        enumerable: false,
+        value: mounter
+    });
+    return modules;
+}
+var ՐՏ_modules = ՐՏ_def_modules();
+ՐՏ_modules.ՐՏ_def("utils");
+ՐՏ_modules.ՐՏ_def("ast");
+ՐՏ_modules.ՐՏ_def("tokenizer");
+ՐՏ_modules.ՐՏ_def("parser");
+ՐՏ_modules.ՐՏ_def("_baselib");
+ՐՏ_modules.ՐՏ_def("stream");
+ՐՏ_modules.ՐՏ_def("output");
 
-    }
-}), ՐՏ_129);
-var KeyError = (ՐՏ_130 = function KeyError() {
-    KeyError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_130, Error), Object.defineProperties(ՐՏ_130.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "KeyError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_130);
-var TypeError = (ՐՏ_131 = function TypeError() {
-    TypeError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_131, Error), Object.defineProperties(ՐՏ_131.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "TypeError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_131);
-var ValueError = (ՐՏ_132 = function ValueError() {
-    ValueError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_132, Error), Object.defineProperties(ՐՏ_132.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "ValueError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_132);
-var ՐՏ_modules = {};
-ՐՏ_modules["utils"] = {};
-ՐՏ_modules["ast"] = {};
-ՐՏ_modules["tokenizer"] = {};
-ՐՏ_modules["parser"] = {};
-ՐՏ_modules["_baselib"] = {};
-ՐՏ_modules["stream"] = {};
-ՐՏ_modules["output"] = {};
-
-(function(){
+ՐՏ_modules["ՐՏ:utils"].body = function(){
     var __name__ = "utils";
 
     var RAPYD_PREFIX, MAP, colors;
@@ -436,22 +254,23 @@ var ՐՏ_modules = {};
         return Array.prototype.slice.call(a, start || 0);
     }
     function member(name, array) {
-        var ՐՏitr1, ՐՏidx1;
+        var ՐՏitr1, ՐՏidx1, ՐՏ_1;
         var i;
         ՐՏitr1 = ՐՏ_Iterable(range(array.length - 1, -1, -1));
         for (ՐՏidx1 = 0; ՐՏidx1 < ՐՏitr1.length; ՐՏidx1++) {
             i = ՐՏitr1[ՐՏidx1];
-            if (array[i] === name) {
+            if ((ՐՏ_1 = array)[i] === name) {
                 return true;
             }
         }
         return false;
     }
     function find_if(func, array) {
+        var ՐՏ_2, ՐՏ_3;
         var i;
         for (i = 0; i < len(array); i++) {
-            if (func(array[i])) {
-                return array[i];
+            if (func((ՐՏ_2 = array)[i])) {
+                return (ՐՏ_3 = array)[i];
             }
         }
     }
@@ -474,9 +293,9 @@ var ՐՏ_modules = {};
         this.msg = msg;
         this.defs = defs;
     }
-    var ImportError = (ՐՏ_1 = function ImportError() {
+    var ImportError = (ՐՏ_4 = function ImportError() {
         ImportError.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_1, Error), Object.defineProperties(ՐՏ_1.prototype, {
+    }, ՐՏ_extends(ՐՏ_4, Error), Object.defineProperties(ՐՏ_4.prototype, {
         __init__: {
             enumerable: true, 
             writable: true, 
@@ -488,10 +307,10 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_1);
-    var ParseError = (ՐՏ_2 = function ParseError() {
+    }), ՐՏ_4);
+    var ParseError = (ՐՏ_5 = function ParseError() {
         ParseError.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_2, Error), Object.defineProperties(ՐՏ_2.prototype, {
+    }, ՐՏ_extends(ՐՏ_5, Error), Object.defineProperties(ՐՏ_5.prototype, {
         __init__: {
             enumerable: true, 
             writable: true, 
@@ -516,9 +335,9 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_2);
+    }), ՐՏ_5);
     function defaults(args, defs, croak) {
-        var ՐՏitr2, ՐՏidx2, ՐՏitr3, ՐՏidx3;
+        var ՐՏitr2, ՐՏidx2, ՐՏitr3, ՐՏidx3, ՐՏ_6, ՐՏ_7, ՐՏ_8;
         var ret, key;
         if (args === true) {
             args = {};
@@ -536,17 +355,17 @@ var ՐՏ_modules = {};
         ՐՏitr3 = ՐՏ_Iterable(defs);
         for (ՐՏidx3 = 0; ՐՏidx3 < ՐՏitr3.length; ՐՏidx3++) {
             key = ՐՏitr3[ՐՏidx3];
-            ret[key] = args && ՐՏ_in(key, args) ? args[key] : defs[key];
+            (ՐՏ_6 = ret)[key] = args && ՐՏ_in(key, args) ? (ՐՏ_7 = args)[key] : (ՐՏ_8 = defs)[key];
         }
         return ret;
     }
     function merge(obj, ext) {
-        var ՐՏitr4, ՐՏidx4;
+        var ՐՏitr4, ՐՏidx4, ՐՏ_9, ՐՏ_10;
         var key;
         ՐՏitr4 = ՐՏ_Iterable(ext);
         for (ՐՏidx4 = 0; ՐՏidx4 < ՐՏitr4.length; ՐՏidx4++) {
             key = ՐՏitr4[ՐՏidx4];
-            obj[key] = ext[key];
+            (ՐՏ_9 = obj)[key] = (ՐՏ_10 = ext)[key];
         }
         return obj;
     }
@@ -560,8 +379,9 @@ var ՐՏ_modules = {};
             ret = [];
             top = [];
             function doit() {
+                var ՐՏ_11;
                 var val, is_last;
-                val = f(a[i], i);
+                val = f((ՐՏ_11 = a)[i], i);
                 is_last = val instanceof Last;
                 if (is_last) {
                     val = val.v;
@@ -639,16 +459,17 @@ var ՐՏ_modules = {};
     }
     function string_template(text, props) {
         return text.replace(/\{(.+?)\}/g, function(str_, p) {
-            return props[p];
+            var ՐՏ_12;
+            return (ՐՏ_12 = props)[p];
         });
     }
     function remove(array, el) {
-        var ՐՏitr6, ՐՏidx6;
+        var ՐՏitr6, ՐՏidx6, ՐՏ_13;
         var idx;
         ՐՏitr6 = ՐՏ_Iterable(range(array.length - 1, -1, -1));
         for (ՐՏidx6 = 0; ՐՏidx6 < ՐՏitr6.length; ՐՏidx6++) {
             idx = ՐՏitr6[ՐՏidx6];
-            if (array[idx] === el) {
+            if ((ՐՏ_13 = array)[idx] === el) {
                 array.splice(i, 1);
             }
         }
@@ -658,17 +479,18 @@ var ՐՏ_modules = {};
             return array.slice();
         }
         function merge(a, b) {
+            var ՐՏ_14, ՐՏ_15, ՐՏ_16, ՐՏ_17, ՐՏ_18, ՐՏ_19;
             var r, ai, bi, i;
             r = [];
             ai = 0;
             bi = 0;
             i = 0;
             while (ai < a.length && bi < b.length) {
-                if (cmp(a[ai], b[bi]) <= 0) {
-                    r[i] = a[ai];
+                if (cmp((ՐՏ_14 = a)[ai], (ՐՏ_15 = b)[bi]) <= 0) {
+                    (ՐՏ_16 = r)[i] = (ՐՏ_17 = a)[ai];
                     ++ai;
                 } else {
-                    r[i] = b[bi];
+                    (ՐՏ_18 = r)[i] = (ՐՏ_19 = b)[bi];
                     ++bi;
                 }
                 ++i;
@@ -706,6 +528,7 @@ var ՐՏ_modules = {};
         });
     }
     function makePredicate(words) {
+        var ՐՏ_20, ՐՏ_21, ՐՏ_22, ՐՏ_23, ՐՏ_24, ՐՏ_25, ՐՏ_28, ՐՏ_29;
         var f, cats, i, skip, j, cat;
         if (!Array.isArray(words)) {
             words = words.split(" ");
@@ -715,24 +538,25 @@ var ՐՏ_modules = {};
         for (i = 0; i < len(words); i++) {
             skip = false;
             for (j = 0; j < len(cats); j++) {
-                if (cats[j][0].length === words[i].length) {
-                    cats[j].push(words[i]);
+                if ((ՐՏ_20 = (ՐՏ_21 = cats)[j])[0].length === (ՐՏ_22 = words)[i].length) {
+                    (ՐՏ_23 = cats)[j].push((ՐՏ_24 = words)[i]);
                     skip = true;
                     break;
                 }
             }
             if (!skip) {
-                cats.push([ words[i] ]);
+                cats.push([ (ՐՏ_25 = words)[i] ]);
             }
         }
         function compareTo(arr) {
+            var ՐՏ_26, ՐՏ_27;
             var i;
             if (arr.length === 1) {
-                return f += "return str === " + JSON.stringify(arr[0]) + ";";
+                return f += "return str === " + JSON.stringify((ՐՏ_26 = arr)[0]) + ";";
             }
             f += "switch(str){";
             for (i = 0; i < len(arr); i++) {
-                f += "case " + JSON.stringify(arr[i]) + ":";
+                f += "case " + JSON.stringify((ՐՏ_27 = arr)[i]) + ":";
             }
             f += "return true}return false;";
         }
@@ -742,8 +566,8 @@ var ՐՏ_modules = {};
             });
             f += "switch(str.length){";
             for (i = 0; i < len(cats); i++) {
-                cat = cats[i];
-                f += "case " + cat[0].length + ":";
+                cat = (ՐՏ_28 = cats)[i];
+                f += "case " + (ՐՏ_29 = cat)[0].length + ":";
                 compareTo(cat);
             }
             f += "}";
@@ -758,10 +582,11 @@ var ՐՏ_modules = {};
     }
     Dictionary.prototype = {
         set: function(key, val) {
+            var ՐՏ_30;
             if (!this.has(key)) {
                 ++this._size;
             }
-            this._values["$" + key] = val;
+            (ՐՏ_30 = this._values)["$" + key] = val;
             return this;
         },
         add: function(key, val) {
@@ -773,12 +598,14 @@ var ՐՏ_modules = {};
             return this;
         },
         get: function(key) {
-            return this._values["$" + key];
+            var ՐՏ_31;
+            return (ՐՏ_31 = this._values)["$" + key];
         },
         del_: function(key) {
+            var ՐՏ_32;
             if (this.has(key)) {
                 --this._size;
-                delete this._values["$" + key];
+                delete (ՐՏ_32 = this._values)["$" + key];
             }
             return this;
         },
@@ -786,19 +613,21 @@ var ՐՏ_modules = {};
             return ՐՏ_in("$" + key, this._values);
         },
         each: function(f) {
+            var ՐՏ_33;
             var i;
             for (i in this._values) {
-                f(this._values[i], i.substr(1));
+                f((ՐՏ_33 = this._values)[i], i.substr(1));
             }
         },
         size: function() {
             return this._size;
         },
         map: function(f) {
+            var ՐՏ_34;
             var ret, i;
             ret = [];
             for (i in this._values) {
-                ret.push(f(this._values[i], i.substr(1)));
+                ret.push(f((ՐՏ_34 = this._values)[i], i.substr(1)));
             }
             return ret;
         }
@@ -819,38 +648,37 @@ var ՐՏ_modules = {};
         }
         return prefix.join("") + string + ansi(0);
     }
-    ՐՏ_modules["utils"]["RAPYD_PREFIX"] = RAPYD_PREFIX;
-    ՐՏ_modules["utils"]["MAP"] = MAP;
-    ՐՏ_modules["utils"]["colors"] = colors;
-    ՐՏ_modules["utils"]["slice"] = slice;
-    ՐՏ_modules["utils"]["member"] = member;
-    ՐՏ_modules["utils"]["find_if"] = find_if;
-    ՐՏ_modules["utils"]["repeat_string"] = repeat_string;
-    ՐՏ_modules["utils"]["DefaultsError"] = DefaultsError;
-    ՐՏ_modules["utils"]["ImportError"] = ImportError;
-    ՐՏ_modules["utils"]["ParseError"] = ParseError;
-    ՐՏ_modules["utils"]["defaults"] = defaults;
-    ՐՏ_modules["utils"]["merge"] = merge;
-    ՐՏ_modules["utils"]["noop"] = noop;
-    ՐՏ_modules["utils"]["push_uniq"] = push_uniq;
-    ՐՏ_modules["utils"]["string_template"] = string_template;
-    ՐՏ_modules["utils"]["remove"] = remove;
-    ՐՏ_modules["utils"]["mergeSort"] = mergeSort;
-    ՐՏ_modules["utils"]["set_difference"] = set_difference;
-    ՐՏ_modules["utils"]["set_intersection"] = set_intersection;
-    ՐՏ_modules["utils"]["makePredicate"] = makePredicate;
-    ՐՏ_modules["utils"]["Dictionary"] = Dictionary;
-    ՐՏ_modules["utils"]["ansi"] = ansi;
-    ՐՏ_modules["utils"]["colored"] = colored;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:utils"];
+    ՐՏ_mod.export("RAPYD_PREFIX", function(){return RAPYD_PREFIX;}, function(ՐՏ_v){if (typeof RAPYD_PREFIX !== "undefined") {RAPYD_PREFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("MAP", function(){return MAP;}, function(ՐՏ_v){if (typeof MAP !== "undefined") {MAP = ՐՏ_v;};});
+    ՐՏ_mod.export("colors", function(){return colors;}, function(ՐՏ_v){if (typeof colors !== "undefined") {colors = ՐՏ_v;};});
+    ՐՏ_mod.export("slice", function(){return slice;}, function(ՐՏ_v){if (typeof slice !== "undefined") {slice = ՐՏ_v;};});
+    ՐՏ_mod.export("member", function(){return member;}, function(ՐՏ_v){if (typeof member !== "undefined") {member = ՐՏ_v;};});
+    ՐՏ_mod.export("find_if", function(){return find_if;}, function(ՐՏ_v){if (typeof find_if !== "undefined") {find_if = ՐՏ_v;};});
+    ՐՏ_mod.export("repeat_string", function(){return repeat_string;}, function(ՐՏ_v){if (typeof repeat_string !== "undefined") {repeat_string = ՐՏ_v;};});
+    ՐՏ_mod.export("DefaultsError", function(){return DefaultsError;}, function(ՐՏ_v){if (typeof DefaultsError !== "undefined") {DefaultsError = ՐՏ_v;};});
+    ՐՏ_mod.export("ImportError", function(){return ImportError;}, function(ՐՏ_v){if (typeof ImportError !== "undefined") {ImportError = ՐՏ_v;};});
+    ՐՏ_mod.export("ParseError", function(){return ParseError;}, function(ՐՏ_v){if (typeof ParseError !== "undefined") {ParseError = ՐՏ_v;};});
+    ՐՏ_mod.export("defaults", function(){return defaults;}, function(ՐՏ_v){if (typeof defaults !== "undefined") {defaults = ՐՏ_v;};});
+    ՐՏ_mod.export("merge", function(){return merge;}, function(ՐՏ_v){if (typeof merge !== "undefined") {merge = ՐՏ_v;};});
+    ՐՏ_mod.export("noop", function(){return noop;}, function(ՐՏ_v){if (typeof noop !== "undefined") {noop = ՐՏ_v;};});
+    ՐՏ_mod.export("push_uniq", function(){return push_uniq;}, function(ՐՏ_v){if (typeof push_uniq !== "undefined") {push_uniq = ՐՏ_v;};});
+    ՐՏ_mod.export("string_template", function(){return string_template;}, function(ՐՏ_v){if (typeof string_template !== "undefined") {string_template = ՐՏ_v;};});
+    ՐՏ_mod.export("remove", function(){return remove;}, function(ՐՏ_v){if (typeof remove !== "undefined") {remove = ՐՏ_v;};});
+    ՐՏ_mod.export("mergeSort", function(){return mergeSort;}, function(ՐՏ_v){if (typeof mergeSort !== "undefined") {mergeSort = ՐՏ_v;};});
+    ՐՏ_mod.export("set_difference", function(){return set_difference;}, function(ՐՏ_v){if (typeof set_difference !== "undefined") {set_difference = ՐՏ_v;};});
+    ՐՏ_mod.export("set_intersection", function(){return set_intersection;}, function(ՐՏ_v){if (typeof set_intersection !== "undefined") {set_intersection = ՐՏ_v;};});
+    ՐՏ_mod.export("makePredicate", function(){return makePredicate;}, function(ՐՏ_v){if (typeof makePredicate !== "undefined") {makePredicate = ՐՏ_v;};});
+    ՐՏ_mod.export("Dictionary", function(){return Dictionary;}, function(ՐՏ_v){if (typeof Dictionary !== "undefined") {Dictionary = ՐՏ_v;};});
+    ՐՏ_mod.export("ansi", function(){return ansi;}, function(ՐՏ_v){if (typeof ansi !== "undefined") {ansi = ՐՏ_v;};});
+    ՐՏ_mod.export("colored", function(){return colored;}, function(ՐՏ_v){if (typeof colored !== "undefined") {colored = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:ast"].body = function(){
     var __name__ = "ast";
 
-    var noop = ՐՏ_modules["utils"].noop;
-    var string_template = ՐՏ_modules["utils"].string_template;
-    var colored = ՐՏ_modules["utils"].colored;
-    
+    var noop = ՐՏ_modules["utils"].noop;var string_template = ՐՏ_modules["utils"].string_template;var colored = ՐՏ_modules["utils"].colored;
     function memoized(f) {
         return function(x) {
             if (!this.computedType) {
@@ -859,11 +687,11 @@ var ՐՏ_modules = {};
             return this.computedType;
         };
     }
-    var AST = (ՐՏ_3 = function AST() {
+    var AST = (ՐՏ_35 = function AST() {
         AST.prototype.__init__.apply(this, arguments);
     }, (function(){
         var properties = {};
-        Object.defineProperties(ՐՏ_3.prototype, {
+        Object.defineProperties(ՐՏ_35.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -873,13 +701,14 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: function __init__(initializer){
+                    var ՐՏ_36, ՐՏ_37;
                     var self = this;
                     var obj, i;
                     if (initializer) {
                         obj = self;
                         while (obj) {
                             for (i in obj.properties) {
-                                self[i] = initializer[i];
+                                (ՐՏ_36 = self)[i] = (ՐՏ_37 = initializer)[i];
                             }
                             obj = Object.getPrototypeOf(obj);
                         }
@@ -896,10 +725,10 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_3);
-    var Token = (ՐՏ_4 = function Token() {
+        })    })(), ՐՏ_35);
+    var Token = (ՐՏ_38 = function Token() {
         AST.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_4, AST), (function(){
+    }, ՐՏ_extends(ՐՏ_38, AST), (function(){
         var properties = {
             "type": "The type of the token",
             "subtype": "The subtype of the token",
@@ -914,22 +743,22 @@ var ՐՏ_modules = {};
             "comma_expected": "True if comma was expected instead of this token",
             "file": "Name of the file currently being parsed"
         };
-        Object.defineProperties(ՐՏ_4.prototype, {
+        Object.defineProperties(ՐՏ_38.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_4);
-    var Node = (ՐՏ_5 = function Node() {
+        })    })(), ՐՏ_38);
+    var Node = (ՐՏ_39 = function Node() {
         AST.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_5, AST), (function(){
+    }, ՐՏ_extends(ՐՏ_39, AST), (function(){
         var properties = {
             "start": "[Token] The first token of this node",
             "end": "[Token] The last token of this node"
         };
         var computedType = null;
-        Object.defineProperties(ՐՏ_5.prototype, {
+        Object.defineProperties(ՐՏ_39.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -971,7 +800,7 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: function _dump(depth, omit, offset, include_name, compact){
-                    var ՐՏitr7, ՐՏidx7, ՐՏitr8, ՐՏidx8, ՐՏitr9, ՐՏidx9, ՐՏitr10, ՐՏidx10;
+                    var ՐՏitr7, ՐՏidx7, ՐՏ_40, ՐՏitr8, ՐՏidx8, ՐՏitr9, ՐՏidx9, ՐՏitr10, ՐՏidx10, ՐՏ_41;
                     var self = this;
                     var key, colored_key, value, element, property;
                     function out(string) {
@@ -989,7 +818,7 @@ var ՐՏ_modules = {};
                             continue;
                         }
                         colored_key = colored(key + ": ", "blue");
-                        value = self[key];
+                        value = (ՐՏ_40 = self)[key];
                         if (Array.isArray(value)) {
                             if (value.length) {
                                 out(" " + colored_key + "[");
@@ -1022,7 +851,7 @@ var ՐՏ_modules = {};
                                         ՐՏitr10 = ՐՏ_Iterable(value);
                                         for (ՐՏidx10 = 0; ՐՏidx10 < ՐՏitr10.length; ՐՏidx10++) {
                                             property = ՐՏitr10[ՐՏidx10];
-                                            out("   " + colored(property + ": ", "blue") + value[property]);
+                                            out("   " + colored(property + ": ", "blue") + (ՐՏ_41 = value)[property]);
                                         }
                                     }
                                 } else {
@@ -1061,7 +890,7 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), Object.defineProperties(ՐՏ_5, {
+        })    })(), Object.defineProperties(ՐՏ_39, {
         warn_function: {
             enumerable: true, 
             writable: true, 
@@ -1079,34 +908,34 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_5);
-    var Statement = (ՐՏ_6 = function Statement() {
+    }), ՐՏ_39);
+    var Statement = (ՐՏ_42 = function Statement() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_6, Node), ՐՏ_6);
-    var Debugger = (ՐՏ_7 = function Debugger() {
+    }, ՐՏ_extends(ՐՏ_42, Node), ՐՏ_42);
+    var Debugger = (ՐՏ_43 = function Debugger() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_7, Statement), ՐՏ_7);
-    var Directive = (ՐՏ_8 = function Directive() {
+    }, ՐՏ_extends(ՐՏ_43, Statement), ՐՏ_43);
+    var Directive = (ՐՏ_44 = function Directive() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_8, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_44, Statement), (function(){
         var properties = {
             value: "[string] The value of this directive as a plain string (it's not a String!)",
             scope: "[Scope/S] The scope that this directive affects"
         };
-        Object.defineProperties(ՐՏ_8.prototype, {
+        Object.defineProperties(ՐՏ_44.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_8);
-    var SimpleStatement = (ՐՏ_9 = function SimpleStatement() {
+        })    })(), ՐՏ_44);
+    var SimpleStatement = (ՐՏ_45 = function SimpleStatement() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_9, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_45, Statement), (function(){
         var properties = {
             body: "[Node] an expression node (should not be instanceof Statement)"
         };
-        Object.defineProperties(ՐՏ_9.prototype, {
+        Object.defineProperties(ՐՏ_45.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1125,7 +954,7 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_9);
+        })    })(), ՐՏ_45);
     function walk_body(node, visitor) {
         var ՐՏitr11, ՐՏidx11;
         var stat;
@@ -1139,13 +968,13 @@ var ՐՏ_modules = {};
             }
         }
     }
-    var Block = (ՐՏ_10 = function Block() {
+    var Block = (ՐՏ_46 = function Block() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_10, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_46, Statement), (function(){
         var properties = {
             body: "[Statement*] an array of statements"
         };
-        Object.defineProperties(ՐՏ_10.prototype, {
+        Object.defineProperties(ՐՏ_46.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1162,13 +991,13 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_10);
-    var BlockStatement = (ՐՏ_11 = function BlockStatement() {
+        })    })(), ՐՏ_46);
+    var BlockStatement = (ՐՏ_47 = function BlockStatement() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_11, Block), ՐՏ_11);
-    var EmptyStatement = (ՐՏ_12 = function EmptyStatement() {
+    }, ՐՏ_extends(ՐՏ_47, Block), ՐՏ_47);
+    var EmptyStatement = (ՐՏ_48 = function EmptyStatement() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_12, Statement), Object.defineProperties(ՐՏ_12.prototype, {
+    }, ՐՏ_extends(ՐՏ_48, Statement), Object.defineProperties(ՐՏ_48.prototype, {
         _walk: {
             enumerable: true, 
             writable: true, 
@@ -1178,14 +1007,14 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_12);
-    var StatementWithBody = (ՐՏ_13 = function StatementWithBody() {
+    }), ՐՏ_48);
+    var StatementWithBody = (ՐՏ_49 = function StatementWithBody() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_13, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_49, Statement), (function(){
         var properties = {
             body: "[Statement] the body; this should always be present, even if it's an EmptyStatement"
         };
-        Object.defineProperties(ՐՏ_13.prototype, {
+        Object.defineProperties(ՐՏ_49.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1202,14 +1031,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_13);
-    var LabeledStatement = (ՐՏ_14 = function LabeledStatement() {
+        })    })(), ՐՏ_49);
+    var LabeledStatement = (ՐՏ_50 = function LabeledStatement() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_14, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_50, StatementWithBody), (function(){
         var properties = {
             label: "[Label] a label definition"
         };
-        Object.defineProperties(ՐՏ_14.prototype, {
+        Object.defineProperties(ՐՏ_50.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1227,14 +1056,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_14);
-    var DWLoop = (ՐՏ_15 = function DWLoop() {
+        })    })(), ՐՏ_50);
+    var DWLoop = (ՐՏ_51 = function DWLoop() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_15, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_51, StatementWithBody), (function(){
         var properties = {
             condition: "[Node] the loop condition.  Should not be instanceof Statement"
         };
-        Object.defineProperties(ՐՏ_15.prototype, {
+        Object.defineProperties(ՐՏ_51.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1252,22 +1081,22 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_15);
-    var Do = (ՐՏ_16 = function Do() {
+        })    })(), ՐՏ_51);
+    var Do = (ՐՏ_52 = function Do() {
         DWLoop.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_16, DWLoop), ՐՏ_16);
-    var While = (ՐՏ_17 = function While() {
+    }, ՐՏ_extends(ՐՏ_52, DWLoop), ՐՏ_52);
+    var While = (ՐՏ_53 = function While() {
         DWLoop.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_17, DWLoop), ՐՏ_17);
-    var ForIn = (ՐՏ_18 = function ForIn() {
+    }, ՐՏ_extends(ՐՏ_53, DWLoop), ՐՏ_53);
+    var ForIn = (ՐՏ_54 = function ForIn() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_18, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_54, StatementWithBody), (function(){
         var properties = {
             init: "[Node] the `for/in` initialization code",
             name: "[SymbolRef?] the loop variable, only if `init` is Var",
             object: "[Node] the object that we're looping through"
         };
-        Object.defineProperties(ՐՏ_18.prototype, {
+        Object.defineProperties(ՐՏ_54.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1286,28 +1115,28 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_18);
-    var ForJS = (ՐՏ_19 = function ForJS() {
+        })    })(), ՐՏ_54);
+    var ForJS = (ՐՏ_55 = function ForJS() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_19, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_55, StatementWithBody), (function(){
         var properties = {
             condition: "[Verbatim] raw JavaScript conditional"
         };
-        Object.defineProperties(ՐՏ_19.prototype, {
+        Object.defineProperties(ՐՏ_55.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_19);
-    var ListComprehension = (ՐՏ_20 = function ListComprehension() {
+        })    })(), ՐՏ_55);
+    var ListComprehension = (ՐՏ_56 = function ListComprehension() {
         ForIn.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_20, ForIn), (function(){
+    }, ՐՏ_extends(ՐՏ_56, ForIn), (function(){
         var properties = {
             condition: "[Node] the `if` condition",
             statement: "[Node] statement to perform on each element before returning it"
         };
-        Object.defineProperties(ՐՏ_20.prototype, {
+        Object.defineProperties(ՐՏ_56.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1328,14 +1157,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_20);
-    var DictComprehension = (ՐՏ_21 = function DictComprehension() {
+        })    })(), ՐՏ_56);
+    var DictComprehension = (ՐՏ_57 = function DictComprehension() {
         ListComprehension.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_21, ListComprehension), (function(){
+    }, ՐՏ_extends(ՐՏ_57, ListComprehension), (function(){
         var properties = {
             value_statement: "[Node] statement to perform on each value before returning it"
         };
-        Object.defineProperties(ՐՏ_21.prototype, {
+        Object.defineProperties(ՐՏ_57.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1357,14 +1186,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_21);
-    var With = (ՐՏ_22 = function With() {
+        })    })(), ՐՏ_57);
+    var With = (ՐՏ_58 = function With() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_22, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_58, StatementWithBody), (function(){
         var properties = {
             expression: "[Node] the `with` expression"
         };
-        Object.defineProperties(ՐՏ_22.prototype, {
+        Object.defineProperties(ՐՏ_58.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1382,10 +1211,10 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_22);
-    var Scope = (ՐՏ_23 = function Scope() {
+        })    })(), ՐՏ_58);
+    var Scope = (ՐՏ_59 = function Scope() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_23, Block), (function(){
+    }, ՐՏ_extends(ՐՏ_59, Block), (function(){
         var properties = {
             docstring: "[string?] docstring for this scope, if any",
             directives: "[string*/S] an array of directives declared in this scope",
@@ -1395,17 +1224,18 @@ var ՐՏ_modules = {};
             parent_scope: "[Scope?/S] link to the parent scope",
             enclosed: "[SymbolDef*/S] a list of all symbol definitions that are accessed from this scope or any subscopes"
         };
-        Object.defineProperties(ՐՏ_23.prototype, {
+        Object.defineProperties(ՐՏ_59.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_23);
-    var TopLevel = (ՐՏ_24 = function TopLevel() {
+        })    })(), ՐՏ_59);
+    var TopLevel = (ՐՏ_60 = function TopLevel() {
         Scope.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_24, Scope), (function(){
+    }, ՐՏ_extends(ՐՏ_60, Scope), (function(){
         var properties = {
+            async: "[boolean] if True this is async (external) module should be set at runtime",
             globals: "[Object/S] a map of name -> SymbolDef for all undeclared names",
             baselib: "[Object/s] a collection of used parts of baselib",
             imports: "[Object/S] a map of module_id->TopLevel for all imported modules",
@@ -1420,39 +1250,39 @@ var ՐՏ_modules = {};
             filename: "[string] The absolute path to the file from which this module was read",
             srchash: "[string] SHA1 hash of source code, used for caching"
         };
-        Object.defineProperties(ՐՏ_24.prototype, {
+        Object.defineProperties(ՐՏ_60.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_24);
-    var Splat = (ՐՏ_25 = function Splat() {
+        })    })(), ՐՏ_60);
+    var Splat = (ՐՏ_61 = function Splat() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_25, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_61, Statement), (function(){
         var properties = {
             module: "[SymbolVar] name of the module we're splatting",
             key: "[string] The key by which this module is stored in the global modules mapping",
             body: "[TopLevel] parsed contents of the imported file"
         };
-        Object.defineProperties(ՐՏ_25.prototype, {
+        Object.defineProperties(ՐՏ_61.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_25);
-    var Import = (ՐՏ_26 = function Import() {
+        })    })(), ՐՏ_61);
+    var Import = (ՐՏ_62 = function Import() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_26, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_62, Statement), (function(){
         var properties = {
             module: "[SymbolVar] name of the module we're importing",
             key: "[string] The key by which this module is stored in the global modules mapping",
             alias: "[SymbolAlias] The name this module is imported as, can be None. For import x as y statements.",
             argnames: "[ImportedVar*] names of objects to be imported",
-            body: "[TopLevel] parsed contents of the imported file"
+            body: "[Function -> TopLevel] returns parsed contents of the imported file"
         };
-        Object.defineProperties(ՐՏ_26.prototype, {
+        Object.defineProperties(ՐՏ_62.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1475,14 +1305,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_26);
-    var Imports = (ՐՏ_27 = function Imports() {
+        })    })(), ՐՏ_62);
+    var Imports = (ՐՏ_63 = function Imports() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_27, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_63, Statement), (function(){
         var properties = {
             "imports": "[Import+] array of imports"
         };
-        Object.defineProperties(ՐՏ_27.prototype, {
+        Object.defineProperties(ՐՏ_63.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1505,14 +1335,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_27);
-    var Decorator = (ՐՏ_28 = function Decorator() {
+        })    })(), ՐՏ_63);
+    var Decorator = (ՐՏ_64 = function Decorator() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_28, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_64, Node), (function(){
         var properties = {
             expression: "[Node] decorator expression"
         };
-        Object.defineProperties(ՐՏ_28.prototype, {
+        Object.defineProperties(ՐՏ_64.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1529,14 +1359,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_28);
-    var Annotation = (ՐՏ_29 = function Annotation() {
+        })    })(), ՐՏ_64);
+    var Annotation = (ՐՏ_65 = function Annotation() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_29, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_65, Node), (function(){
         var properties = {
             expression: "[Node] decorator expression"
         };
-        Object.defineProperties(ՐՏ_29.prototype, {
+        Object.defineProperties(ՐՏ_65.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1559,16 +1389,16 @@ var ՐՏ_modules = {};
                 value: memoized(function resolveType(heap){
                     var self = this;
                     function parse(obj) {
-                        var ՐՏ_30;
+                        var ՐՏ_66, ՐՏ_67, ՐՏ_68, ՐՏ_69, ՐՏ_70;
                         if (obj instanceof Array) {
                             if (obj.elements.length === 1) {
-                                return "[" + parse(obj.elements[0]) + "]";
+                                return "[" + parse((ՐՏ_66 = obj.elements)[0]) + "]";
                             }
                             return "[?]";
                         }
                         if (obj instanceof ObjectLiteral) {
                             if (obj.properties.length === 1) {
-                                return "{String:" + parse(obj.properties[0].value) + "}";
+                                return "{String:" + parse((ՐՏ_67 = obj.properties)[0].value) + "}";
                             }
                             return "{String:?}";
                         }
@@ -1577,11 +1407,11 @@ var ՐՏ_modules = {};
                         }
                         if (obj instanceof Call) {
                             if (obj.expression instanceof SymbolRef && obj.expression.name === "Array" && obj.args.length === 1) {
-                                return "[" + parse(obj.args[0]) + "]";
+                                return "[" + parse((ՐՏ_68 = obj.args)[0]) + "]";
                             }
                             if (obj.expression instanceof SymbolRef && ՐՏ_in(obj.expression.name, [ "Object", "Dictionary" ])) {
-                                if (1 <= (ՐՏ_30 = obj.args.length) && ՐՏ_30 <= 2) {
-                                    return "{String:" + parse(obj.args[obj.args.length-1]) + "}";
+                                if (1 <= (ՐՏ_69 = obj.args.length) && ՐՏ_69 <= 2) {
+                                    return "{String:" + parse((ՐՏ_70 = obj.args)[ՐՏ_70.length-1]) + "}";
                                 }
                                 return "{String:?}";
                             }
@@ -1592,10 +1422,10 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_29);
-    var Lambda = (ՐՏ_31 = function Lambda() {
+        })    })(), ՐՏ_65);
+    var Lambda = (ՐՏ_71 = function Lambda() {
         Scope.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_31, Scope), (function(){
+    }, ՐՏ_extends(ՐՏ_71, Scope), (function(){
         var properties = {
             name: "[SymbolDeclaration?] the name of this function/class/method",
             argnames: "[SymbolFunarg*] array of arguments",
@@ -1605,7 +1435,7 @@ var ՐՏ_modules = {};
             generator: "[boolean] true if this is a generator function (false by default)",
             return_annotation: "[Annotation?] the return type annotation provided (if any)"
         };
-        Object.defineProperties(ՐՏ_31.prototype, {
+        Object.defineProperties(ՐՏ_71.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1645,13 +1475,13 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_31);
-    var Accessor = (ՐՏ_32 = function Accessor() {
+        })    })(), ՐՏ_71);
+    var Accessor = (ՐՏ_72 = function Accessor() {
         Lambda.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_32, Lambda), ՐՏ_32);
-    var Function = (ՐՏ_33 = function Function() {
+    }, ՐՏ_extends(ՐՏ_72, Lambda), ՐՏ_72);
+    var Function = (ՐՏ_73 = function Function() {
         Lambda.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_33, Lambda), Object.defineProperties(ՐՏ_33.prototype, {
+    }, ՐՏ_extends(ՐՏ_73, Lambda), Object.defineProperties(ՐՏ_73.prototype, {
         resolveType: {
             enumerable: true, 
             writable: true, 
@@ -1697,10 +1527,10 @@ var ՐՏ_modules = {};
             })
 
         }
-    }), ՐՏ_33);
-    var Class = (ՐՏ_34 = function Class() {
+    }), ՐՏ_73);
+    var Class = (ՐՏ_74 = function Class() {
         Scope.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_34, Scope), (function(){
+    }, ՐՏ_extends(ՐՏ_74, Scope), (function(){
         var properties = {
             name: "[SymbolDeclaration?] the name of this class",
             init: "[Function] constructor for the class",
@@ -1712,7 +1542,7 @@ var ՐՏ_modules = {};
             module_id: "[string] The id of the module this class is defined in",
             statements: "[Node*] list of statements in the class scope (excluding method definitions)"
         };
-        Object.defineProperties(ՐՏ_34.prototype, {
+        Object.defineProperties(ՐՏ_74.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1742,59 +1572,59 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_34);
-    var Module = (ՐՏ_35 = function Module() {
+        })    })(), ՐՏ_74);
+    var Module = (ՐՏ_75 = function Module() {
         Scope.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_35, Scope), (function(){
+    }, ՐՏ_extends(ՐՏ_75, Scope), (function(){
         var properties = {
             name: "[SymbolDeclaration?] the name of this class",
             external: "[boolean] true if module is declared elsewhere, but will be within current scope at runtime",
             decorators: "[Decorator*] module decorators, if any"
         };
-        Object.defineProperties(ՐՏ_35.prototype, {
+        Object.defineProperties(ՐՏ_75.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_35);
-    var Method = (ՐՏ_36 = function Method() {
+        })    })(), ՐՏ_75);
+    var Method = (ՐՏ_76 = function Method() {
         Lambda.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_36, Lambda), (function(){
+    }, ՐՏ_extends(ՐՏ_76, Lambda), (function(){
         var properties = {
             static: "[boolean] true if method is static"
         };
-        Object.defineProperties(ՐՏ_36.prototype, {
+        Object.defineProperties(ՐՏ_76.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_36);
-    var Constructor = (ՐՏ_37 = function Constructor() {
+        })    })(), ՐՏ_76);
+    var Constructor = (ՐՏ_77 = function Constructor() {
         Method.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_37, Method), (function(){
+    }, ՐՏ_extends(ՐՏ_77, Method), (function(){
         var properties = {
             callsSuper: "[boolean] true if user manually called super or Parent.__init__",
             parent: "[string?] parent class this class inherits from"
         };
-        Object.defineProperties(ՐՏ_37.prototype, {
+        Object.defineProperties(ՐՏ_77.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_37);
-    var Jump = (ՐՏ_38 = function Jump() {
+        })    })(), ՐՏ_77);
+    var Jump = (ՐՏ_78 = function Jump() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_38, Statement), ՐՏ_38);
-    var Exit = (ՐՏ_39 = function Exit() {
+    }, ՐՏ_extends(ՐՏ_78, Statement), ՐՏ_78);
+    var Exit = (ՐՏ_79 = function Exit() {
         Jump.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_39, Jump), (function(){
+    }, ՐՏ_extends(ՐՏ_79, Jump), (function(){
         var properties = {
             value: "[Node?] the value returned or thrown by this statement; could be null for Return"
         };
-        Object.defineProperties(ՐՏ_39.prototype, {
+        Object.defineProperties(ՐՏ_79.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1822,34 +1652,34 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_39);
-    var Return = (ՐՏ_40 = function Return() {
+        })    })(), ՐՏ_79);
+    var Return = (ՐՏ_80 = function Return() {
         Exit.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_40, Exit), ՐՏ_40);
-    var Yield = (ՐՏ_41 = function Yield() {
+    }, ՐՏ_extends(ՐՏ_80, Exit), ՐՏ_80);
+    var Yield = (ՐՏ_81 = function Yield() {
         Exit.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_41, Exit), (function(){
+    }, ՐՏ_extends(ՐՏ_81, Exit), (function(){
         var properties = {
             yield_from: "[boolean] true if it is `yield from` i.e. JS `yield*` ",
             yield_request: "[boolean] true if some value is requested from `yield`: `a = yield` or `f(yield, ...) ` and so on"
         };
-        Object.defineProperties(ՐՏ_41.prototype, {
+        Object.defineProperties(ՐՏ_81.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_41);
-    var Throw = (ՐՏ_42 = function Throw() {
+        })    })(), ՐՏ_81);
+    var Throw = (ՐՏ_82 = function Throw() {
         Exit.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_42, Exit), ՐՏ_42);
-    var LoopControl = (ՐՏ_43 = function LoopControl() {
+    }, ՐՏ_extends(ՐՏ_82, Exit), ՐՏ_82);
+    var LoopControl = (ՐՏ_83 = function LoopControl() {
         Jump.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_43, Jump), (function(){
+    }, ՐՏ_extends(ՐՏ_83, Jump), (function(){
         var properties = {
             label: "[LabelRef?] the label, or null if none"
         };
-        Object.defineProperties(ՐՏ_43.prototype, {
+        Object.defineProperties(ՐՏ_83.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1868,21 +1698,21 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_43);
-    var Break = (ՐՏ_44 = function Break() {
+        })    })(), ՐՏ_83);
+    var Break = (ՐՏ_84 = function Break() {
         LoopControl.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_44, LoopControl), ՐՏ_44);
-    var Continue = (ՐՏ_45 = function Continue() {
+    }, ՐՏ_extends(ՐՏ_84, LoopControl), ՐՏ_84);
+    var Continue = (ՐՏ_85 = function Continue() {
         LoopControl.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_45, LoopControl), ՐՏ_45);
-    var If = (ՐՏ_46 = function If() {
+    }, ՐՏ_extends(ՐՏ_85, LoopControl), ՐՏ_85);
+    var If = (ՐՏ_86 = function If() {
         StatementWithBody.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_46, StatementWithBody), (function(){
+    }, ՐՏ_extends(ՐՏ_86, StatementWithBody), (function(){
         var properties = {
             condition: "[Node] the `if` condition",
             alternative: "[Statement?] the `else` part, or null if not present"
         };
-        Object.defineProperties(ՐՏ_46.prototype, {
+        Object.defineProperties(ՐՏ_86.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1903,14 +1733,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_46);
-    var Switch = (ՐՏ_47 = function Switch() {
+        })    })(), ՐՏ_86);
+    var Switch = (ՐՏ_87 = function Switch() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_47, Block), (function(){
+    }, ՐՏ_extends(ՐՏ_87, Block), (function(){
         var properties = {
             expression: "[Node] the `switch` “discriminant”"
         };
-        Object.defineProperties(ՐՏ_47.prototype, {
+        Object.defineProperties(ՐՏ_87.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1928,20 +1758,20 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_47);
-    var SwitchBranch = (ՐՏ_48 = function SwitchBranch() {
+        })    })(), ՐՏ_87);
+    var SwitchBranch = (ՐՏ_88 = function SwitchBranch() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_48, Block), ՐՏ_48);
-    var Default = (ՐՏ_49 = function Default() {
+    }, ՐՏ_extends(ՐՏ_88, Block), ՐՏ_88);
+    var Default = (ՐՏ_89 = function Default() {
         SwitchBranch.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_49, SwitchBranch), ՐՏ_49);
-    var Case = (ՐՏ_50 = function Case() {
+    }, ՐՏ_extends(ՐՏ_89, SwitchBranch), ՐՏ_89);
+    var Case = (ՐՏ_90 = function Case() {
         SwitchBranch.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_50, SwitchBranch), (function(){
+    }, ՐՏ_extends(ՐՏ_90, SwitchBranch), (function(){
         var properties = {
             expression: "[Node] the `case` expression"
         };
-        Object.defineProperties(ՐՏ_50.prototype, {
+        Object.defineProperties(ՐՏ_90.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1959,15 +1789,15 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_50);
-    var Try = (ՐՏ_51 = function Try() {
+        })    })(), ՐՏ_90);
+    var Try = (ՐՏ_91 = function Try() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_51, Block), (function(){
+    }, ՐՏ_extends(ՐՏ_91, Block), (function(){
         var properties = {
             bcatch: "[Catch?] the catch block, or null if not present",
             bfinally: "[Finally?] the finally block, or null if not present"
         };
-        Object.defineProperties(ՐՏ_51.prototype, {
+        Object.defineProperties(ՐՏ_91.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -1990,18 +1820,18 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_51);
-    var Catch = (ՐՏ_52 = function Catch() {
+        })    })(), ՐՏ_91);
+    var Catch = (ՐՏ_92 = function Catch() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_52, Block), ՐՏ_52);
-    var Except = (ՐՏ_53 = function Except() {
+    }, ՐՏ_extends(ՐՏ_92, Block), ՐՏ_92);
+    var Except = (ՐՏ_93 = function Except() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_53, Block), (function(){
+    }, ՐՏ_extends(ՐՏ_93, Block), (function(){
         var properties = {
             argname: "[SymbolCatch] symbol for the exception",
             errors: "[SymbolVar*] error classes to catch in this block"
         };
-        Object.defineProperties(ՐՏ_53.prototype, {
+        Object.defineProperties(ՐՏ_93.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2030,17 +1860,17 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_53);
-    var Finally = (ՐՏ_54 = function Finally() {
+        })    })(), ՐՏ_93);
+    var Finally = (ՐՏ_94 = function Finally() {
         Block.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_54, Block), ՐՏ_54);
-    var Definitions = (ՐՏ_55 = function Definitions() {
+    }, ՐՏ_extends(ՐՏ_94, Block), ՐՏ_94);
+    var Definitions = (ՐՏ_95 = function Definitions() {
         Statement.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_55, Statement), (function(){
+    }, ՐՏ_extends(ՐՏ_95, Statement), (function(){
         var properties = {
             definitions: "[VarDef*] array of variable definitions"
         };
-        Object.defineProperties(ՐՏ_55.prototype, {
+        Object.defineProperties(ՐՏ_95.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2063,21 +1893,21 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_55);
-    var Var = (ՐՏ_56 = function Var() {
+        })    })(), ՐՏ_95);
+    var Var = (ՐՏ_96 = function Var() {
         Definitions.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_56, Definitions), ՐՏ_56);
-    var Const = (ՐՏ_57 = function Const() {
+    }, ՐՏ_extends(ՐՏ_96, Definitions), ՐՏ_96);
+    var Const = (ՐՏ_97 = function Const() {
         Definitions.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_57, Definitions), ՐՏ_57);
-    var VarDef = (ՐՏ_58 = function VarDef() {
+    }, ՐՏ_extends(ՐՏ_97, Definitions), ՐՏ_97);
+    var VarDef = (ՐՏ_98 = function VarDef() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_58, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_98, Node), (function(){
         var properties = {
             name: "[SymbolVar|SymbolConst] name of the variable",
             value: "[Node?] initializer, or null if there's no initializer"
         };
-        Object.defineProperties(ՐՏ_58.prototype, {
+        Object.defineProperties(ՐՏ_98.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2097,27 +1927,27 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_58);
-    var BaseCall = (ՐՏ_59 = function BaseCall() {
+        })    })(), ՐՏ_98);
+    var BaseCall = (ՐՏ_99 = function BaseCall() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_59, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_99, Node), (function(){
         var properties = {
             args: "[Node*] array of arguments"
         };
-        Object.defineProperties(ՐՏ_59.prototype, {
+        Object.defineProperties(ՐՏ_99.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_59);
-    var Call = (ՐՏ_60 = function Call() {
+        })    })(), ՐՏ_99);
+    var Call = (ՐՏ_100 = function Call() {
         BaseCall.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_60, BaseCall), (function(){
+    }, ՐՏ_extends(ՐՏ_100, BaseCall), (function(){
         var properties = {
             expression: "[Node] expression to invoke as function"
         };
-        Object.defineProperties(ՐՏ_60.prototype, {
+        Object.defineProperties(ՐՏ_100.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2129,7 +1959,7 @@ var ՐՏ_modules = {};
                 value: function _walk(visitor){
                     var self = this;
                     return visitor._visit(self, function() {
-                        var ՐՏitr19, ՐՏidx19, ՐՏitr20, ՐՏidx20, ՐՏitr21, ՐՏidx21;
+                        var ՐՏitr19, ՐՏidx19, ՐՏitr20, ՐՏidx20, ՐՏ_101, ՐՏ_102, ՐՏitr21, ՐՏidx21;
                         var arg;
                         self.expression._walk(visitor);
                         ՐՏitr19 = ՐՏ_Iterable(self.args);
@@ -2141,8 +1971,8 @@ var ՐՏ_modules = {};
                             ՐՏitr20 = ՐՏ_Iterable(self.args.kwargs);
                             for (ՐՏidx20 = 0; ՐՏidx20 < ՐՏitr20.length; ՐՏidx20++) {
                                 arg = ՐՏitr20[ՐՏidx20];
-                                arg[0]._walk(visitor);
-                                arg[1]._walk(visitor);
+                                (ՐՏ_101 = arg)[0]._walk(visitor);
+                                (ՐՏ_102 = arg)[1]._walk(visitor);
                             }
                         }
                         if (self.args.kwarg_items) {
@@ -2160,7 +1990,7 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: memoized(function resolveType(heap){
-                    var ՐՏitr22, ՐՏidx22;
+                    var ՐՏitr22, ՐՏidx22, ՐՏ_103, ՐՏ_104, ՐՏ_105, ՐՏ_106, ՐՏ_107, ՐՏ_108, ՐՏ_109, ՐՏ_110, ՐՏ_111, ՐՏ_112, ՐՏ_113;
                     var self = this;
                     var scope, exp_name, parse, result;
                     if (self.expression instanceof SymbolRef) {
@@ -2168,13 +1998,13 @@ var ՐՏ_modules = {};
                         for (ՐՏidx22 = 0; ՐՏidx22 < ՐՏitr22.length; ՐՏidx22++) {
                             scope = ՐՏitr22[ՐՏidx22];
                             exp_name = self.expression.name;
-                            if (ՐՏ_in(exp_name, scope.vars) && scope.vars[exp_name][scope.vars[exp_name].length-1] && ՐՏ_in("->", scope.vars[exp_name][scope.vars[exp_name].length-1])) {
-                                return scope.vars[exp_name][scope.vars[exp_name].length-1].split("->")[1].trim();
-                            } else if (ՐՏ_in(exp_name, scope.functions) && scope.functions[exp_name] && ՐՏ_in("->", scope.functions[exp_name])) {
-                                return scope.functions[exp_name].split("->")[1].trim();
+                            if (ՐՏ_in(exp_name, scope.vars) && (ՐՏ_103 = (ՐՏ_104 = scope.vars)[exp_name])[ՐՏ_103.length-1] && ՐՏ_in("->", (ՐՏ_105 = (ՐՏ_106 = scope.vars)[exp_name])[ՐՏ_105.length-1])) {
+                                return (ՐՏ_107 = (ՐՏ_108 = (ՐՏ_109 = scope.vars)[exp_name])[ՐՏ_108.length-1].split("->"))[1].trim();
+                            } else if (ՐՏ_in(exp_name, scope.functions) && (ՐՏ_110 = scope.functions)[exp_name] && ՐՏ_in("->", (ՐՏ_111 = scope.functions)[exp_name])) {
+                                return (ՐՏ_112 = (ՐՏ_113 = scope.functions)[exp_name].split("->"))[1].trim();
                             } else if (scope.type === "function" && exp_name === scope.name && scope.return) {
                                 parse = function(variable) {
-                                    var ՐՏ_61;
+                                    var ՐՏ_114, ՐՏ_115, ՐՏ_116, ՐՏ_117, ՐՏ_118, ՐՏ_119, ՐՏ_120;
                                     var wrap, wrapper, element, result;
                                     wrap = {
                                         "array": function(value) {
@@ -2193,22 +2023,22 @@ var ՐՏ_modules = {};
                                             return;
                                         }
                                         wrapper = "array";
-                                        element = variable.elements[0];
+                                        element = (ՐՏ_114 = variable.elements)[0];
                                     } else if (variable instanceof Call && variable.expression instanceof SymbolRef && variable.expression.name === "Array") {
                                         if (variable.args.length !== 1) {
                                             return;
                                         }
                                         wrapper = "array";
-                                        element = variable.args[0];
+                                        element = (ՐՏ_115 = variable.args)[0];
                                     } else if (variable instanceof ObjectLiteral) {
                                         if (variable.properties.length !== 1) {
                                             return;
                                         }
                                         wrapper = "dict";
-                                        element = variable.properties[0].value;
+                                        element = (ՐՏ_116 = variable.properties)[0].value;
                                     } else if (variable instanceof Call && variable.expression instanceof SymbolRef && ՐՏ_in(variable.expression.name, [ "Object", "Dictionary" ])) {
-                                        if (1 <= (ՐՏ_61 = variable.args.length) && ՐՏ_61 <= 2) {
-                                            element = variable.args[variable.args.length-1];
+                                        if (1 <= (ՐՏ_117 = variable.args.length) && ՐՏ_117 <= 2) {
+                                            element = (ՐՏ_118 = variable.args)[ՐՏ_118.length-1];
                                             wrapper = "dict";
                                         } else {
                                             return;
@@ -2217,11 +2047,11 @@ var ՐՏ_modules = {};
                                         element = variable;
                                     }
                                     if (element instanceof SymbolRef && ՐՏ_in(element.name, NATIVE_CLASSES)) {
-                                        return wrap[wrapper](element.name);
+                                        return (ՐՏ_119 = wrap)[wrapper](element.name);
                                     } else if (element instanceof Array || element instanceof ObjectLiteral || element instanceof Call) {
                                         result = parse(element);
                                         if (result) {
-                                            return wrap[wrapper](result);
+                                            return (ՐՏ_120 = wrap)[wrapper](result);
                                         }
                                     }
                                 };
@@ -2236,17 +2066,17 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_60);
-    var ClassCall = (ՐՏ_62 = function ClassCall() {
+        })    })(), ՐՏ_100);
+    var ClassCall = (ՐՏ_121 = function ClassCall() {
         BaseCall.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_62, BaseCall), (function(){
+    }, ՐՏ_extends(ՐՏ_121, BaseCall), (function(){
         var properties = {
             class: "[string] name of the class method belongs to",
             super: "[boolean] this call can be replaced with a super() call",
             method: "[string] class method being called",
             static: "[boolean] defines whether the method is static"
         };
-        Object.defineProperties(ՐՏ_62.prototype, {
+        Object.defineProperties(ՐՏ_121.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2258,7 +2088,7 @@ var ՐՏ_modules = {};
                 value: function _walk(visitor){
                     var self = this;
                     return visitor._visit(self, function() {
-                        var ՐՏitr23, ՐՏidx23, ՐՏitr24, ՐՏidx24, ՐՏitr25, ՐՏidx25;
+                        var ՐՏitr23, ՐՏidx23, ՐՏitr24, ՐՏidx24, ՐՏ_122, ՐՏ_123, ՐՏitr25, ՐՏidx25;
                         var arg;
                         if (self.expression) {
                             self.expression._walk(visitor);
@@ -2271,8 +2101,8 @@ var ՐՏ_modules = {};
                         ՐՏitr24 = ՐՏ_Iterable(self.args.kwargs);
                         for (ՐՏidx24 = 0; ՐՏidx24 < ՐՏitr24.length; ՐՏidx24++) {
                             arg = ՐՏitr24[ՐՏidx24];
-                            arg[0]._walk(visitor);
-                            arg[1]._walk(visitor);
+                            (ՐՏ_122 = arg)[0]._walk(visitor);
+                            (ՐՏ_123 = arg)[1]._walk(visitor);
                         }
                         ՐՏitr25 = ՐՏ_Iterable(self.args.kwarg_items);
                         for (ՐՏidx25 = 0; ՐՏidx25 < ՐՏitr25.length; ՐՏidx25++) {
@@ -2283,18 +2113,18 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_62);
-    var New = (ՐՏ_63 = function New() {
+        })    })(), ՐՏ_121);
+    var New = (ՐՏ_124 = function New() {
         Call.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_63, Call), ՐՏ_63);
-    var Seq = (ՐՏ_64 = function Seq() {
+    }, ՐՏ_extends(ՐՏ_124, Call), ՐՏ_124);
+    var Seq = (ՐՏ_125 = function Seq() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_64, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_125, Node), (function(){
         var properties = {
             car: "[Node] first element in sequence",
             cdr: "[Node] second element in sequence"
         };
-        Object.defineProperties(ՐՏ_64.prototype, {
+        Object.defineProperties(ՐՏ_125.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2317,20 +2147,20 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: function from_array(array){
-                    var ՐՏitr26, ՐՏidx26;
+                    var ՐՏ_126, ՐՏitr26, ՐՏidx26, ՐՏ_127;
                     var self = this;
                     var list, i, p;
                     if (array.length === 0) {
                         return null;
                     }
                     if (array.length === 1) {
-                        return array[0].clone();
+                        return (ՐՏ_126 = array)[0].clone();
                     }
                     list = null;
                     ՐՏitr26 = ՐՏ_Iterable(range(array.length - 1, -1, -1));
                     for (ՐՏidx26 = 0; ՐՏidx26 < ՐՏitr26.length; ՐՏidx26++) {
                         i = ՐՏitr26[ՐՏidx26];
-                        list = Seq.prototype.cons.call(array[i], list);
+                        list = Seq.prototype.cons.call((ՐՏ_127 = array)[i], list);
                     }
                     p = list;
                     while (p) {
@@ -2395,24 +2225,24 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_64);
-    var PropAccess = (ՐՏ_65 = function PropAccess() {
+        })    })(), ՐՏ_125);
+    var PropAccess = (ՐՏ_128 = function PropAccess() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_65, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_128, Node), (function(){
         var properties = {
             expression: "[Node] the “container” expression",
             property: "[Node|string] the property to access. For Dot this is always a plain string, while for Sub it's an arbitrary Node"
         };
-        Object.defineProperties(ՐՏ_65.prototype, {
+        Object.defineProperties(ՐՏ_128.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_65);
-    var Dot = (ՐՏ_66 = function Dot() {
+        })    })(), ՐՏ_128);
+    var Dot = (ՐՏ_129 = function Dot() {
         PropAccess.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_66, PropAccess), Object.defineProperties(ՐՏ_66.prototype, {
+    }, ՐՏ_extends(ՐՏ_129, PropAccess), Object.defineProperties(ՐՏ_129.prototype, {
         _walk: {
             enumerable: true, 
             writable: true, 
@@ -2428,20 +2258,21 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: memoized(function resolveType(heap){
+                var ՐՏ_130, ՐՏ_131;
                 var self = this;
                 var containerType;
                 containerType = self.expression.resolveType(heap);
-                if (containerType && containerType[0] === "{") {
-                    return /\{\w+:(.*)\}/.exec(containerType)[1];
+                if (containerType && (ՐՏ_130 = containerType)[0] === "{") {
+                    return (ՐՏ_131 = /\{\w+:(.*)\}/.exec(containerType))[1];
                 }
                 return "?";
             })
 
         }
-    }), ՐՏ_66);
-    var Sub = (ՐՏ_67 = function Sub() {
+    }), ՐՏ_129);
+    var Sub = (ՐՏ_132 = function Sub() {
         PropAccess.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_67, PropAccess), Object.defineProperties(ՐՏ_67.prototype, {
+    }, ՐՏ_extends(ՐՏ_132, PropAccess), Object.defineProperties(ՐՏ_132.prototype, {
         _walk: {
             enumerable: true, 
             writable: true, 
@@ -2458,30 +2289,31 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: memoized(function resolveType(heap){
+                var ՐՏ_133, ՐՏ_134, ՐՏ_135, ՐՏ_136;
                 var self = this;
                 var containerType;
                 containerType = self.expression.resolveType(heap);
                 if (containerType) {
-                    if (containerType[0] === "[" && self.property instanceof Number) {
-                        return /\[(.*)\]/.exec(containerType)[1];
+                    if ((ՐՏ_133 = containerType)[0] === "[" && self.property instanceof Number) {
+                        return (ՐՏ_134 = /\[(.*)\]/.exec(containerType))[1];
                     }
-                    if (containerType[0] === "{") {
-                        return /\{\w+:(.*)\}/.exec(containerType)[1];
+                    if ((ՐՏ_135 = containerType)[0] === "{") {
+                        return (ՐՏ_136 = /\{\w+:(.*)\}/.exec(containerType))[1];
                     }
                 }
                 return "?";
             })
 
         }
-    }), ՐՏ_67);
-    var Slice = (ՐՏ_68 = function Slice() {
+    }), ՐՏ_132);
+    var Slice = (ՐՏ_137 = function Slice() {
         PropAccess.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_68, PropAccess), (function(){
+    }, ՐՏ_extends(ՐՏ_137, PropAccess), (function(){
         var properties = {
             property2: "[Node] the 2nd property to access - typically ending index for the array.",
             assignment: "[Node] The data being spliced in."
         };
-        Object.defineProperties(ՐՏ_68.prototype, {
+        Object.defineProperties(ՐՏ_137.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2509,15 +2341,15 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_68);
-    var Unary = (ՐՏ_69 = function Unary() {
+        })    })(), ՐՏ_137);
+    var Unary = (ՐՏ_138 = function Unary() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_69, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_138, Node), (function(){
         var properties = {
             operator: "[string] the operator",
             expression: "[Node] expression that this unary operator applies to"
         };
-        Object.defineProperties(ՐՏ_69.prototype, {
+        Object.defineProperties(ՐՏ_138.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2549,22 +2381,22 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_69);
-    var UnaryPrefix = (ՐՏ_70 = function UnaryPrefix() {
+        })    })(), ՐՏ_138);
+    var UnaryPrefix = (ՐՏ_139 = function UnaryPrefix() {
         Unary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_70, Unary), ՐՏ_70);
-    var UnaryPostfix = (ՐՏ_71 = function UnaryPostfix() {
+    }, ՐՏ_extends(ՐՏ_139, Unary), ՐՏ_139);
+    var UnaryPostfix = (ՐՏ_140 = function UnaryPostfix() {
         Unary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_71, Unary), ՐՏ_71);
-    var Binary = (ՐՏ_72 = function Binary() {
+    }, ՐՏ_extends(ՐՏ_140, Unary), ՐՏ_140);
+    var Binary = (ՐՏ_141 = function Binary() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_72, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_141, Node), (function(){
         var properties = {
             left: "[Node] left-hand side expression",
             operator: "[string] the operator",
             right: "[Node] right-hand side expression"
         };
-        Object.defineProperties(ՐՏ_72.prototype, {
+        Object.defineProperties(ՐՏ_141.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2606,10 +2438,10 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_72);
-    var Range = (ՐՏ_73 = function Range() {
+        })    })(), ՐՏ_141);
+    var Range = (ՐՏ_142 = function Range() {
         Binary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_73, Binary), Object.defineProperties(ՐՏ_73.prototype, {
+    }, ՐՏ_extends(ՐՏ_142, Binary), Object.defineProperties(ՐՏ_142.prototype, {
         resolveType: {
             enumerable: true, 
             writable: true, 
@@ -2619,10 +2451,10 @@ var ՐՏ_modules = {};
             })
 
         }
-    }), ՐՏ_73);
-    var DeepEquality = (ՐՏ_74 = function DeepEquality() {
+    }), ՐՏ_142);
+    var DeepEquality = (ՐՏ_143 = function DeepEquality() {
         Binary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_74, Binary), Object.defineProperties(ՐՏ_74.prototype, {
+    }, ՐՏ_extends(ՐՏ_143, Binary), Object.defineProperties(ՐՏ_143.prototype, {
         resolveType: {
             enumerable: true, 
             writable: true, 
@@ -2632,16 +2464,16 @@ var ՐՏ_modules = {};
             })
 
         }
-    }), ՐՏ_74);
-    var Conditional = (ՐՏ_75 = function Conditional() {
+    }), ՐՏ_143);
+    var Conditional = (ՐՏ_144 = function Conditional() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_75, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_144, Node), (function(){
         var properties = {
             condition: "[Node] test to run before deciding the return value",
             consequent: "[Node] return expression in the event on truthy test evaluation",
             alternative: "[Node] return expression in the event of falsy test evaluation"
         };
-        Object.defineProperties(ՐՏ_75.prototype, {
+        Object.defineProperties(ՐՏ_144.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2671,10 +2503,10 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_75);
-    var Assign = (ՐՏ_76 = function Assign() {
+        })    })(), ՐՏ_144);
+    var Assign = (ՐՏ_145 = function Assign() {
         Binary.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_76, Binary), Object.defineProperties(ՐՏ_76.prototype, {
+    }, ՐՏ_extends(ՐՏ_145, Binary), Object.defineProperties(ՐՏ_145.prototype, {
         resolveType: {
             enumerable: true, 
             writable: true, 
@@ -2687,14 +2519,14 @@ var ՐՏ_modules = {};
             })
 
         }
-    }), ՐՏ_76);
-    var Array = (ՐՏ_77 = function Array() {
+    }), ՐՏ_145);
+    var Array = (ՐՏ_146 = function Array() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_77, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_146, Node), (function(){
         var properties = {
             elements: "[Node*] array of elements"
         };
-        Object.defineProperties(ՐՏ_77.prototype, {
+        Object.defineProperties(ՐՏ_146.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2721,13 +2553,13 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: memoized(function resolveType(heap){
-                    var ՐՏitr28, ՐՏidx28;
+                    var ՐՏ_147, ՐՏitr28, ՐՏidx28;
                     var self = this;
                     var expected, element, current;
                     if (!self.elements.length) {
                         return "[?]";
                     }
-                    expected = self.elements[0].resolveType(heap);
+                    expected = (ՐՏ_147 = self.elements)[0].resolveType(heap);
                     if (!expected) {
                         return "[?]";
                     }
@@ -2746,15 +2578,15 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_77);
-    var TupleUnpack = (ՐՏ_78 = function TupleUnpack() {
+        })    })(), ՐՏ_146);
+    var TupleUnpack = (ՐՏ_148 = function TupleUnpack() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_78, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_148, Node), (function(){
         var properties = {
             elements: "[Node*] array of elements being assigned to",
             right: "[Node] right-hand side expression"
         };
-        Object.defineProperties(ՐՏ_78.prototype, {
+        Object.defineProperties(ՐՏ_148.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2778,14 +2610,14 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_78);
-    var ObjectLiteral = (ՐՏ_79 = function ObjectLiteral() {
+        })    })(), ՐՏ_148);
+    var ObjectLiteral = (ՐՏ_149 = function ObjectLiteral() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_79, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_149, Node), (function(){
         var properties = {
             properties: "[ObjectProperty*] array of properties"
         };
-        Object.defineProperties(ՐՏ_79.prototype, {
+        Object.defineProperties(ՐՏ_149.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2812,7 +2644,7 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: memoized(function resolveType(heap){
-                    var ՐՏitr31, ՐՏidx31;
+                    var ՐՏ_150, ՐՏ_151, ՐՏ_152, ՐՏitr31, ՐՏidx31;
                     var self = this;
                     var start, spread, expected, element, current, result;
                     if (!self.properties.length) {
@@ -2820,14 +2652,14 @@ var ՐՏ_modules = {};
                     }
                     start = 0;
                     spread = null;
-                    while (self.properties[start] instanceof UnaryPrefix) {
-                        spread = self.properties[start].expression.resolveType(heap);
+                    while ((ՐՏ_150 = self.properties)[start] instanceof UnaryPrefix) {
+                        spread = (ՐՏ_151 = self.properties)[start].expression.resolveType(heap);
                         if (ՐՏ_in("?", spread)) {
                             return "{String:?}";
                         }
                         ++start;
                     }
-                    expected = self.properties[start].value.resolveType(heap);
+                    expected = (ՐՏ_152 = self.properties)[start].value.resolveType(heap);
                     if (!expected) {
                         return "{String:?}";
                     }
@@ -2868,15 +2700,15 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_79);
-    var ObjectProperty = (ՐՏ_80 = function ObjectProperty() {
+        })    })(), ՐՏ_149);
+    var ObjectProperty = (ՐՏ_153 = function ObjectProperty() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_80, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_153, Node), (function(){
         var properties = {
             key: "[Node] the property name or expression for computed key ",
             value: "[Node] property value. For setters and getters this is an Function."
         };
-        Object.defineProperties(ՐՏ_80.prototype, {
+        Object.defineProperties(ՐՏ_153.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -2894,127 +2726,127 @@ var ՐՏ_modules = {};
                 }
 
             }
-        })    })(), ՐՏ_80);
-    var ObjectKeyVal = (ՐՏ_81 = function ObjectKeyVal() {
+        })    })(), ՐՏ_153);
+    var ObjectKeyVal = (ՐՏ_154 = function ObjectKeyVal() {
         ObjectProperty.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_81, ObjectProperty), ՐՏ_81);
-    var ObjectSetter = (ՐՏ_82 = function ObjectSetter() {
+    }, ՐՏ_extends(ՐՏ_154, ObjectProperty), ՐՏ_154);
+    var ObjectSetter = (ՐՏ_155 = function ObjectSetter() {
         Accessor.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_82, Accessor), ՐՏ_82);
-    var ObjectGetter = (ՐՏ_83 = function ObjectGetter() {
+    }, ՐՏ_extends(ՐՏ_155, Accessor), ՐՏ_155);
+    var ObjectGetter = (ՐՏ_156 = function ObjectGetter() {
         Accessor.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_83, Accessor), ՐՏ_83);
-    var Symbol = (ՐՏ_84 = function Symbol() {
+    }, ՐՏ_extends(ՐՏ_156, Accessor), ՐՏ_156);
+    var Symbol = (ՐՏ_157 = function Symbol() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_84, Node), (function(){
+    }, ՐՏ_extends(ՐՏ_157, Node), (function(){
         var properties = {
             name: "[string] name of this symbol",
             scope: "[Scope/S] the current scope (not necessarily the definition scope)",
             thedef: "[SymbolDef/S] the definition of this symbol"
         };
-        Object.defineProperties(ՐՏ_84.prototype, {
+        Object.defineProperties(ՐՏ_157.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_84);
-    var SymbolAlias = (ՐՏ_85 = function SymbolAlias() {
+        })    })(), ՐՏ_157);
+    var SymbolAlias = (ՐՏ_158 = function SymbolAlias() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_85, Symbol), ՐՏ_85);
-    var SymbolDeclaration = (ՐՏ_86 = function SymbolDeclaration() {
+    }, ՐՏ_extends(ՐՏ_158, Symbol), ՐՏ_158);
+    var SymbolDeclaration = (ՐՏ_159 = function SymbolDeclaration() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_86, Symbol), (function(){
+    }, ՐՏ_extends(ՐՏ_159, Symbol), (function(){
         var properties = {
             init: "[Node*/S] array of initializers for this declaration."
         };
-        Object.defineProperties(ՐՏ_86.prototype, {
+        Object.defineProperties(ՐՏ_159.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_86);
-    var SymbolVar = (ՐՏ_87 = function SymbolVar() {
+        })    })(), ՐՏ_159);
+    var SymbolVar = (ՐՏ_160 = function SymbolVar() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_87, SymbolDeclaration), ՐՏ_87);
-    var SymbolNonlocal = (ՐՏ_88 = function SymbolNonlocal() {
+    }, ՐՏ_extends(ՐՏ_160, SymbolDeclaration), ՐՏ_160);
+    var SymbolNonlocal = (ՐՏ_161 = function SymbolNonlocal() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_88, SymbolDeclaration), ՐՏ_88);
-    var ImportedVar = (ՐՏ_89 = function ImportedVar() {
+    }, ՐՏ_extends(ՐՏ_161, SymbolDeclaration), ՐՏ_161);
+    var ImportedVar = (ՐՏ_162 = function ImportedVar() {
         SymbolVar.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_89, SymbolVar), (function(){
+    }, ՐՏ_extends(ՐՏ_162, SymbolVar), (function(){
         var properties = {
             alias: "SymbolAlias the alias for this imported symbol"
         };
-        Object.defineProperties(ՐՏ_89.prototype, {
+        Object.defineProperties(ՐՏ_162.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_89);
-    var SymbolConst = (ՐՏ_90 = function SymbolConst() {
+        })    })(), ՐՏ_162);
+    var SymbolConst = (ՐՏ_163 = function SymbolConst() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_90, SymbolDeclaration), ՐՏ_90);
-    var SymbolFunarg = (ՐՏ_91 = function SymbolFunarg() {
+    }, ՐՏ_extends(ՐՏ_163, SymbolDeclaration), ՐՏ_163);
+    var SymbolFunarg = (ՐՏ_164 = function SymbolFunarg() {
         SymbolVar.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_91, SymbolVar), (function(){
+    }, ՐՏ_extends(ՐՏ_164, SymbolVar), (function(){
         var properties = {
             annotation: "[Annotation?] annotation provided for this argument, if any"
         };
-        Object.defineProperties(ՐՏ_91.prototype, {
+        Object.defineProperties(ՐՏ_164.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_91);
-    var SymbolClass = (ՐՏ_92 = function SymbolClass() {
+        })    })(), ՐՏ_164);
+    var SymbolClass = (ՐՏ_165 = function SymbolClass() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_92, SymbolDeclaration), ՐՏ_92);
-    var SymbolDefun = (ՐՏ_93 = function SymbolDefun() {
+    }, ՐՏ_extends(ՐՏ_165, SymbolDeclaration), ՐՏ_165);
+    var SymbolDefun = (ՐՏ_166 = function SymbolDefun() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_93, SymbolDeclaration), (function(){
+    }, ՐՏ_extends(ՐՏ_166, SymbolDeclaration), (function(){
         var properties = {
             js_reserved: "[boolean/S] If True, the method name must be omitted and defined as anonymous function (does matter in es5 only)"
         };
-        Object.defineProperties(ՐՏ_93.prototype, {
+        Object.defineProperties(ՐՏ_166.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_93);
-    var SymbolAccessor = (ՐՏ_94 = function SymbolAccessor() {
+        })    })(), ՐՏ_166);
+    var SymbolAccessor = (ՐՏ_167 = function SymbolAccessor() {
         SymbolDefun.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_94, SymbolDefun), ՐՏ_94);
-    var SymbolLambda = (ՐՏ_95 = function SymbolLambda() {
+    }, ՐՏ_extends(ՐՏ_167, SymbolDefun), ՐՏ_167);
+    var SymbolLambda = (ՐՏ_168 = function SymbolLambda() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_95, SymbolDeclaration), ՐՏ_95);
-    var SymbolCatch = (ՐՏ_96 = function SymbolCatch() {
+    }, ՐՏ_extends(ՐՏ_168, SymbolDeclaration), ՐՏ_168);
+    var SymbolCatch = (ՐՏ_169 = function SymbolCatch() {
         SymbolDeclaration.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_96, SymbolDeclaration), ՐՏ_96);
-    var Label = (ՐՏ_97 = function Label() {
+    }, ՐՏ_extends(ՐՏ_169, SymbolDeclaration), ՐՏ_169);
+    var Label = (ՐՏ_170 = function Label() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_97, Symbol), (function(){
+    }, ՐՏ_extends(ՐՏ_170, Symbol), (function(){
         var properties = {
             references: "[LabelRef*] a list of nodes referring to this label"
         };
-        Object.defineProperties(ՐՏ_97.prototype, {
+        Object.defineProperties(ՐՏ_170.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_97);
-    var SymbolRef = (ՐՏ_98 = function SymbolRef() {
+        })    })(), ՐՏ_170);
+    var SymbolRef = (ՐՏ_171 = function SymbolRef() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_98, Symbol), (function(){
+    }, ՐՏ_extends(ՐՏ_171, Symbol), (function(){
         var properties = {
             parens: "[boolean/S] if true, this variable is wrapped in parentheses"
         };
-        Object.defineProperties(ՐՏ_98.prototype, {
+        Object.defineProperties(ՐՏ_171.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3024,46 +2856,46 @@ var ՐՏ_modules = {};
                 enumerable: true, 
                 writable: true, 
                 value: memoized(function resolveType(heap){
-                    var ՐՏitr32, ՐՏidx32;
+                    var ՐՏitr32, ՐՏidx32, ՐՏ_172, ՐՏ_173, ՐՏ_174;
                     var self = this;
                     var scope;
                     ՐՏitr32 = ՐՏ_Iterable(reversed(heap));
                     for (ՐՏidx32 = 0; ՐՏidx32 < ՐՏitr32.length; ՐՏidx32++) {
                         scope = ՐՏitr32[ՐՏidx32];
                         if (ՐՏ_in(self.name, scope.vars)) {
-                            return scope.vars[self.name][scope.vars[self.name].length-1];
+                            return (ՐՏ_172 = (ՐՏ_173 = scope.vars)[self.name])[ՐՏ_172.length-1];
                         }
                         if (scope.args && ՐՏ_in(self.name, scope.args)) {
-                            return scope.args[self.name];
+                            return (ՐՏ_174 = scope.args)[self.name];
                         }
                     }
                     return "?";
                 })
 
             }
-        })    })(), ՐՏ_98);
-    var SymbolClassRef = (ՐՏ_99 = function SymbolClassRef() {
+        })    })(), ՐՏ_171);
+    var SymbolClassRef = (ՐՏ_175 = function SymbolClassRef() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_99, Symbol), (function(){
+    }, ՐՏ_extends(ՐՏ_175, Symbol), (function(){
         var properties = {
             class: "[SymbolDeclaration?] the name of this class"
         };
-        Object.defineProperties(ՐՏ_99.prototype, {
+        Object.defineProperties(ՐՏ_175.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
                 value: properties
             }
-        })    })(), ՐՏ_99);
-    var LabelRef = (ՐՏ_100 = function LabelRef() {
+        })    })(), ՐՏ_175);
+    var LabelRef = (ՐՏ_176 = function LabelRef() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_100, Symbol), ՐՏ_100);
-    var This = (ՐՏ_101 = function This() {
+    }, ՐՏ_extends(ՐՏ_176, Symbol), ՐՏ_176);
+    var This = (ՐՏ_177 = function This() {
         Symbol.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_101, Symbol), ՐՏ_101);
-    var Constant = (ՐՏ_102 = function Constant() {
+    }, ՐՏ_extends(ՐՏ_177, Symbol), ՐՏ_177);
+    var Constant = (ՐՏ_178 = function Constant() {
         Node.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_102, Node), Object.defineProperties(ՐՏ_102.prototype, {
+    }, ՐՏ_extends(ՐՏ_178, Node), Object.defineProperties(ՐՏ_178.prototype, {
         getValue: {
             enumerable: true, 
             writable: true, 
@@ -3073,15 +2905,15 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_102);
-    var String = (ՐՏ_103 = function String() {
+    }), ՐՏ_178);
+    var String = (ՐՏ_179 = function String() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_103, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_179, Constant), (function(){
         var properties = {
             value: "[string] the contents of this string",
             modifier: "[string] string type modifier"
         };
-        Object.defineProperties(ՐՏ_103.prototype, {
+        Object.defineProperties(ՐՏ_179.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3096,14 +2928,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_103);
-    var Verbatim = (ՐՏ_104 = function Verbatim() {
+        })    })(), ՐՏ_179);
+    var Verbatim = (ՐՏ_180 = function Verbatim() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_104, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_180, Constant), (function(){
         var properties = {
             value: "[string] A string of raw JS code"
         };
-        Object.defineProperties(ՐՏ_104.prototype, {
+        Object.defineProperties(ՐՏ_180.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3118,14 +2950,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_104);
-    var Number = (ՐՏ_105 = function Number() {
+        })    })(), ՐՏ_180);
+    var Number = (ՐՏ_181 = function Number() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_105, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_181, Constant), (function(){
         var properties = {
             value: "[number] the numeric value"
         };
-        Object.defineProperties(ՐՏ_105.prototype, {
+        Object.defineProperties(ՐՏ_181.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3140,14 +2972,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_105);
-    var Identifier = (ՐՏ_106 = function Identifier() {
+        })    })(), ՐՏ_181);
+    var Identifier = (ՐՏ_182 = function Identifier() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_106, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_182, Constant), (function(){
         var properties = {
             value: "[string] the name of this key"
         };
-        Object.defineProperties(ՐՏ_106.prototype, {
+        Object.defineProperties(ՐՏ_182.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3162,14 +2994,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_106);
-    var RegExp = (ՐՏ_107 = function RegExp() {
+        })    })(), ՐՏ_182);
+    var RegExp = (ՐՏ_183 = function RegExp() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_107, Constant), (function(){
+    }, ՐՏ_extends(ՐՏ_183, Constant), (function(){
         var properties = {
             value: "[RegExp] the actual regexp"
         };
-        Object.defineProperties(ՐՏ_107.prototype, {
+        Object.defineProperties(ՐՏ_183.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3184,15 +3016,15 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_107);
-    var Atom = (ՐՏ_108 = function Atom() {
+        })    })(), ՐՏ_183);
+    var Atom = (ՐՏ_184 = function Atom() {
         Constant.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_108, Constant), ՐՏ_108);
-    var Null = (ՐՏ_109 = function Null() {
+    }, ՐՏ_extends(ՐՏ_184, Constant), ՐՏ_184);
+    var Null = (ՐՏ_185 = function Null() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_109, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_185, Atom), (function(){
         var value = null;
-        Object.defineProperties(ՐՏ_109.prototype, {
+        Object.defineProperties(ՐՏ_185.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3207,12 +3039,12 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_109);
-    var NotANumber = (ՐՏ_110 = function NotANumber() {
+        })    })(), ՐՏ_185);
+    var NotANumber = (ՐՏ_186 = function NotANumber() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_110, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_186, Atom), (function(){
         var value = 0 / 0;
-        Object.defineProperties(ՐՏ_110.prototype, {
+        Object.defineProperties(ՐՏ_186.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3227,12 +3059,12 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_110);
-    var Undefined = (ՐՏ_111 = function Undefined() {
+        })    })(), ՐՏ_186);
+    var Undefined = (ՐՏ_187 = function Undefined() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_111, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_187, Atom), (function(){
         var value = void 0;
-        Object.defineProperties(ՐՏ_111.prototype, {
+        Object.defineProperties(ՐՏ_187.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3247,12 +3079,12 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_111);
-    var Hole = (ՐՏ_112 = function Hole() {
+        })    })(), ՐՏ_187);
+    var Hole = (ՐՏ_188 = function Hole() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_112, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_188, Atom), (function(){
         var value = void 0;
-        Object.defineProperties(ՐՏ_112.prototype, {
+        Object.defineProperties(ՐՏ_188.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3267,12 +3099,12 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_112);
-    var Infinity = (ՐՏ_113 = function Infinity() {
+        })    })(), ՐՏ_188);
+    var Infinity = (ՐՏ_189 = function Infinity() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_113, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_189, Atom), (function(){
         var value = 1 / 0;
-        Object.defineProperties(ՐՏ_113.prototype, {
+        Object.defineProperties(ՐՏ_189.prototype, {
             value: {
                 enumerable: true, 
                 writable: true, 
@@ -3287,14 +3119,14 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_113);
-    var Boolean = (ՐՏ_114 = function Boolean() {
+        })    })(), ՐՏ_189);
+    var Boolean = (ՐՏ_190 = function Boolean() {
         Atom.prototype.__init__.apply(this, arguments);
-    }, ՐՏ_extends(ՐՏ_114, Atom), (function(){
+    }, ՐՏ_extends(ՐՏ_190, Atom), (function(){
         var properties = {
             value: "[boolean] value"
         };
-        Object.defineProperties(ՐՏ_114.prototype, {
+        Object.defineProperties(ՐՏ_190.prototype, {
             properties: {
                 enumerable: true, 
                 writable: true, 
@@ -3309,10 +3141,10 @@ var ՐՏ_modules = {};
                 })
 
             }
-        })    })(), ՐՏ_114);
-    var TreeWalker = (ՐՏ_115 = function TreeWalker() {
+        })    })(), ՐՏ_190);
+    var TreeWalker = (ՐՏ_191 = function TreeWalker() {
         TreeWalker.prototype.__init__.apply(this, arguments);
-    }, Object.defineProperties(ՐՏ_115.prototype, {
+    }, Object.defineProperties(ՐՏ_191.prototype, {
         __init__: {
             enumerable: true, 
             writable: true, 
@@ -3345,8 +3177,9 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function parent(n){
+                var ՐՏ_192;
                 var self = this;
-                return self.stack[self.stack.length - 2 - (n || 0)];
+                return (ՐՏ_192 = self.stack)[self.stack.length - 2 - (n || 0)];
             }
 
         },
@@ -3372,8 +3205,9 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function self(){
+                var ՐՏ_193;
                 var self = this;
-                return self.stack[self.stack.length - 1];
+                return (ՐՏ_193 = self.stack)[self.stack.length - 1];
             }
 
         },
@@ -3381,14 +3215,14 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function find_parent(type){
-                var ՐՏitr33, ՐՏidx33;
+                var ՐՏitr33, ՐՏidx33, ՐՏ_194;
                 var self = this;
                 var stack, i, x;
                 stack = self.stack;
                 ՐՏitr33 = ՐՏ_Iterable(range(stack.length - 1, -1, -1));
                 for (ՐՏidx33 = 0; ՐՏidx33 < ՐՏitr33.length; ՐՏidx33++) {
                     i = ՐՏitr33[ՐՏidx33];
-                    x = stack[i];
+                    x = (ՐՏ_194 = stack)[i];
                     if (x instanceof type) {
                         return x;
                     }
@@ -3400,13 +3234,14 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function in_boolean_context(){
+                var ՐՏ_195, ՐՏ_196;
                 var self = this;
                 var stack, i, p;
                 stack = self.stack;
                 i = stack.length;
-                self = stack[--i];
+                self = (ՐՏ_195 = stack)[--i];
                 while (i > 0) {
-                    p = stack[--i];
+                    p = (ՐՏ_196 = stack)[--i];
                     if (p instanceof If && p.condition === self || p instanceof Conditional && p.condition === self || p instanceof DWLoop && p.condition === self || p instanceof UnaryPrefix && p.operator === "!" && p.expression === self) {
                         return true;
                     }
@@ -3422,7 +3257,7 @@ var ՐՏ_modules = {};
             enumerable: true, 
             writable: true, 
             value: function loopcontrol_target(label){
-                var ՐՏitr34, ՐՏidx34, ՐՏitr35, ՐՏidx35;
+                var ՐՏitr34, ՐՏidx34, ՐՏ_197, ՐՏitr35, ՐՏidx35, ՐՏ_198;
                 var self = this;
                 var stack, i, x;
                 stack = self.stack;
@@ -3430,7 +3265,7 @@ var ՐՏ_modules = {};
                     ՐՏitr34 = ՐՏ_Iterable(range(stack.length - 1, -1, -1));
                     for (ՐՏidx34 = 0; ՐՏidx34 < ՐՏitr34.length; ՐՏidx34++) {
                         i = ՐՏitr34[ՐՏidx34];
-                        x = stack[i];
+                        x = (ՐՏ_197 = stack)[i];
                         if (x instanceof LabeledStatement && x.label.name === label.name) {
                             return x.body;
                         }
@@ -3439,7 +3274,7 @@ var ՐՏ_modules = {};
                     ՐՏitr35 = ՐՏ_Iterable(range(stack.length - 1, -1, -1));
                     for (ՐՏidx35 = 0; ՐՏidx35 < ՐՏitr35.length; ՐՏidx35++) {
                         i = ՐՏitr35[ՐՏidx35];
-                        x = stack[i];
+                        x = (ՐՏ_198 = stack)[i];
                         if (x instanceof Switch || x instanceof ForIn || x instanceof DWLoop) {
                             return x;
                         }
@@ -3448,131 +3283,131 @@ var ՐՏ_modules = {};
             }
 
         }
-    }), ՐՏ_115);
-    ՐՏ_modules["ast"]["memoized"] = memoized;
-    ՐՏ_modules["ast"]["AST"] = AST;
-    ՐՏ_modules["ast"]["Token"] = Token;
-    ՐՏ_modules["ast"]["Node"] = Node;
-    ՐՏ_modules["ast"]["Statement"] = Statement;
-    ՐՏ_modules["ast"]["Debugger"] = Debugger;
-    ՐՏ_modules["ast"]["Directive"] = Directive;
-    ՐՏ_modules["ast"]["SimpleStatement"] = SimpleStatement;
-    ՐՏ_modules["ast"]["walk_body"] = walk_body;
-    ՐՏ_modules["ast"]["Block"] = Block;
-    ՐՏ_modules["ast"]["BlockStatement"] = BlockStatement;
-    ՐՏ_modules["ast"]["EmptyStatement"] = EmptyStatement;
-    ՐՏ_modules["ast"]["StatementWithBody"] = StatementWithBody;
-    ՐՏ_modules["ast"]["LabeledStatement"] = LabeledStatement;
-    ՐՏ_modules["ast"]["DWLoop"] = DWLoop;
-    ՐՏ_modules["ast"]["Do"] = Do;
-    ՐՏ_modules["ast"]["While"] = While;
-    ՐՏ_modules["ast"]["ForIn"] = ForIn;
-    ՐՏ_modules["ast"]["ForJS"] = ForJS;
-    ՐՏ_modules["ast"]["ListComprehension"] = ListComprehension;
-    ՐՏ_modules["ast"]["DictComprehension"] = DictComprehension;
-    ՐՏ_modules["ast"]["With"] = With;
-    ՐՏ_modules["ast"]["Scope"] = Scope;
-    ՐՏ_modules["ast"]["TopLevel"] = TopLevel;
-    ՐՏ_modules["ast"]["Splat"] = Splat;
-    ՐՏ_modules["ast"]["Import"] = Import;
-    ՐՏ_modules["ast"]["Imports"] = Imports;
-    ՐՏ_modules["ast"]["Decorator"] = Decorator;
-    ՐՏ_modules["ast"]["Annotation"] = Annotation;
-    ՐՏ_modules["ast"]["Lambda"] = Lambda;
-    ՐՏ_modules["ast"]["Accessor"] = Accessor;
-    ՐՏ_modules["ast"]["Function"] = Function;
-    ՐՏ_modules["ast"]["Class"] = Class;
-    ՐՏ_modules["ast"]["Module"] = Module;
-    ՐՏ_modules["ast"]["Method"] = Method;
-    ՐՏ_modules["ast"]["Constructor"] = Constructor;
-    ՐՏ_modules["ast"]["Jump"] = Jump;
-    ՐՏ_modules["ast"]["Exit"] = Exit;
-    ՐՏ_modules["ast"]["Return"] = Return;
-    ՐՏ_modules["ast"]["Yield"] = Yield;
-    ՐՏ_modules["ast"]["Throw"] = Throw;
-    ՐՏ_modules["ast"]["LoopControl"] = LoopControl;
-    ՐՏ_modules["ast"]["Break"] = Break;
-    ՐՏ_modules["ast"]["Continue"] = Continue;
-    ՐՏ_modules["ast"]["If"] = If;
-    ՐՏ_modules["ast"]["Switch"] = Switch;
-    ՐՏ_modules["ast"]["SwitchBranch"] = SwitchBranch;
-    ՐՏ_modules["ast"]["Default"] = Default;
-    ՐՏ_modules["ast"]["Case"] = Case;
-    ՐՏ_modules["ast"]["Try"] = Try;
-    ՐՏ_modules["ast"]["Catch"] = Catch;
-    ՐՏ_modules["ast"]["Except"] = Except;
-    ՐՏ_modules["ast"]["Finally"] = Finally;
-    ՐՏ_modules["ast"]["Definitions"] = Definitions;
-    ՐՏ_modules["ast"]["Var"] = Var;
-    ՐՏ_modules["ast"]["Const"] = Const;
-    ՐՏ_modules["ast"]["VarDef"] = VarDef;
-    ՐՏ_modules["ast"]["BaseCall"] = BaseCall;
-    ՐՏ_modules["ast"]["Call"] = Call;
-    ՐՏ_modules["ast"]["ClassCall"] = ClassCall;
-    ՐՏ_modules["ast"]["New"] = New;
-    ՐՏ_modules["ast"]["Seq"] = Seq;
-    ՐՏ_modules["ast"]["PropAccess"] = PropAccess;
-    ՐՏ_modules["ast"]["Dot"] = Dot;
-    ՐՏ_modules["ast"]["Sub"] = Sub;
-    ՐՏ_modules["ast"]["Slice"] = Slice;
-    ՐՏ_modules["ast"]["Unary"] = Unary;
-    ՐՏ_modules["ast"]["UnaryPrefix"] = UnaryPrefix;
-    ՐՏ_modules["ast"]["UnaryPostfix"] = UnaryPostfix;
-    ՐՏ_modules["ast"]["Binary"] = Binary;
-    ՐՏ_modules["ast"]["Range"] = Range;
-    ՐՏ_modules["ast"]["DeepEquality"] = DeepEquality;
-    ՐՏ_modules["ast"]["Conditional"] = Conditional;
-    ՐՏ_modules["ast"]["Assign"] = Assign;
-    ՐՏ_modules["ast"]["Array"] = Array;
-    ՐՏ_modules["ast"]["TupleUnpack"] = TupleUnpack;
-    ՐՏ_modules["ast"]["ObjectLiteral"] = ObjectLiteral;
-    ՐՏ_modules["ast"]["ObjectProperty"] = ObjectProperty;
-    ՐՏ_modules["ast"]["ObjectKeyVal"] = ObjectKeyVal;
-    ՐՏ_modules["ast"]["ObjectSetter"] = ObjectSetter;
-    ՐՏ_modules["ast"]["ObjectGetter"] = ObjectGetter;
-    ՐՏ_modules["ast"]["Symbol"] = Symbol;
-    ՐՏ_modules["ast"]["SymbolAlias"] = SymbolAlias;
-    ՐՏ_modules["ast"]["SymbolDeclaration"] = SymbolDeclaration;
-    ՐՏ_modules["ast"]["SymbolVar"] = SymbolVar;
-    ՐՏ_modules["ast"]["SymbolNonlocal"] = SymbolNonlocal;
-    ՐՏ_modules["ast"]["ImportedVar"] = ImportedVar;
-    ՐՏ_modules["ast"]["SymbolConst"] = SymbolConst;
-    ՐՏ_modules["ast"]["SymbolFunarg"] = SymbolFunarg;
-    ՐՏ_modules["ast"]["SymbolClass"] = SymbolClass;
-    ՐՏ_modules["ast"]["SymbolDefun"] = SymbolDefun;
-    ՐՏ_modules["ast"]["SymbolAccessor"] = SymbolAccessor;
-    ՐՏ_modules["ast"]["SymbolLambda"] = SymbolLambda;
-    ՐՏ_modules["ast"]["SymbolCatch"] = SymbolCatch;
-    ՐՏ_modules["ast"]["Label"] = Label;
-    ՐՏ_modules["ast"]["SymbolRef"] = SymbolRef;
-    ՐՏ_modules["ast"]["SymbolClassRef"] = SymbolClassRef;
-    ՐՏ_modules["ast"]["LabelRef"] = LabelRef;
-    ՐՏ_modules["ast"]["This"] = This;
-    ՐՏ_modules["ast"]["Constant"] = Constant;
-    ՐՏ_modules["ast"]["String"] = String;
-    ՐՏ_modules["ast"]["Verbatim"] = Verbatim;
-    ՐՏ_modules["ast"]["Number"] = Number;
-    ՐՏ_modules["ast"]["Identifier"] = Identifier;
-    ՐՏ_modules["ast"]["RegExp"] = RegExp;
-    ՐՏ_modules["ast"]["Atom"] = Atom;
-    ՐՏ_modules["ast"]["Null"] = Null;
-    ՐՏ_modules["ast"]["NotANumber"] = NotANumber;
-    ՐՏ_modules["ast"]["Undefined"] = Undefined;
-    ՐՏ_modules["ast"]["Hole"] = Hole;
-    ՐՏ_modules["ast"]["Infinity"] = Infinity;
-    ՐՏ_modules["ast"]["Boolean"] = Boolean;
-    ՐՏ_modules["ast"]["TreeWalker"] = TreeWalker;
-})();
+    }), ՐՏ_191);
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:ast"];
+    ՐՏ_mod.export("memoized", function(){return memoized;}, function(ՐՏ_v){if (typeof memoized !== "undefined") {memoized = ՐՏ_v;};});
+    ՐՏ_mod.export("AST", function(){return AST;}, function(ՐՏ_v){if (typeof AST !== "undefined") {AST = ՐՏ_v;};});
+    ՐՏ_mod.export("Token", function(){return Token;}, function(ՐՏ_v){if (typeof Token !== "undefined") {Token = ՐՏ_v;};});
+    ՐՏ_mod.export("Node", function(){return Node;}, function(ՐՏ_v){if (typeof Node !== "undefined") {Node = ՐՏ_v;};});
+    ՐՏ_mod.export("Statement", function(){return Statement;}, function(ՐՏ_v){if (typeof Statement !== "undefined") {Statement = ՐՏ_v;};});
+    ՐՏ_mod.export("Debugger", function(){return Debugger;}, function(ՐՏ_v){if (typeof Debugger !== "undefined") {Debugger = ՐՏ_v;};});
+    ՐՏ_mod.export("Directive", function(){return Directive;}, function(ՐՏ_v){if (typeof Directive !== "undefined") {Directive = ՐՏ_v;};});
+    ՐՏ_mod.export("SimpleStatement", function(){return SimpleStatement;}, function(ՐՏ_v){if (typeof SimpleStatement !== "undefined") {SimpleStatement = ՐՏ_v;};});
+    ՐՏ_mod.export("walk_body", function(){return walk_body;}, function(ՐՏ_v){if (typeof walk_body !== "undefined") {walk_body = ՐՏ_v;};});
+    ՐՏ_mod.export("Block", function(){return Block;}, function(ՐՏ_v){if (typeof Block !== "undefined") {Block = ՐՏ_v;};});
+    ՐՏ_mod.export("BlockStatement", function(){return BlockStatement;}, function(ՐՏ_v){if (typeof BlockStatement !== "undefined") {BlockStatement = ՐՏ_v;};});
+    ՐՏ_mod.export("EmptyStatement", function(){return EmptyStatement;}, function(ՐՏ_v){if (typeof EmptyStatement !== "undefined") {EmptyStatement = ՐՏ_v;};});
+    ՐՏ_mod.export("StatementWithBody", function(){return StatementWithBody;}, function(ՐՏ_v){if (typeof StatementWithBody !== "undefined") {StatementWithBody = ՐՏ_v;};});
+    ՐՏ_mod.export("LabeledStatement", function(){return LabeledStatement;}, function(ՐՏ_v){if (typeof LabeledStatement !== "undefined") {LabeledStatement = ՐՏ_v;};});
+    ՐՏ_mod.export("DWLoop", function(){return DWLoop;}, function(ՐՏ_v){if (typeof DWLoop !== "undefined") {DWLoop = ՐՏ_v;};});
+    ՐՏ_mod.export("Do", function(){return Do;}, function(ՐՏ_v){if (typeof Do !== "undefined") {Do = ՐՏ_v;};});
+    ՐՏ_mod.export("While", function(){return While;}, function(ՐՏ_v){if (typeof While !== "undefined") {While = ՐՏ_v;};});
+    ՐՏ_mod.export("ForIn", function(){return ForIn;}, function(ՐՏ_v){if (typeof ForIn !== "undefined") {ForIn = ՐՏ_v;};});
+    ՐՏ_mod.export("ForJS", function(){return ForJS;}, function(ՐՏ_v){if (typeof ForJS !== "undefined") {ForJS = ՐՏ_v;};});
+    ՐՏ_mod.export("ListComprehension", function(){return ListComprehension;}, function(ՐՏ_v){if (typeof ListComprehension !== "undefined") {ListComprehension = ՐՏ_v;};});
+    ՐՏ_mod.export("DictComprehension", function(){return DictComprehension;}, function(ՐՏ_v){if (typeof DictComprehension !== "undefined") {DictComprehension = ՐՏ_v;};});
+    ՐՏ_mod.export("With", function(){return With;}, function(ՐՏ_v){if (typeof With !== "undefined") {With = ՐՏ_v;};});
+    ՐՏ_mod.export("Scope", function(){return Scope;}, function(ՐՏ_v){if (typeof Scope !== "undefined") {Scope = ՐՏ_v;};});
+    ՐՏ_mod.export("TopLevel", function(){return TopLevel;}, function(ՐՏ_v){if (typeof TopLevel !== "undefined") {TopLevel = ՐՏ_v;};});
+    ՐՏ_mod.export("Splat", function(){return Splat;}, function(ՐՏ_v){if (typeof Splat !== "undefined") {Splat = ՐՏ_v;};});
+    ՐՏ_mod.export("Import", function(){return Import;}, function(ՐՏ_v){if (typeof Import !== "undefined") {Import = ՐՏ_v;};});
+    ՐՏ_mod.export("Imports", function(){return Imports;}, function(ՐՏ_v){if (typeof Imports !== "undefined") {Imports = ՐՏ_v;};});
+    ՐՏ_mod.export("Decorator", function(){return Decorator;}, function(ՐՏ_v){if (typeof Decorator !== "undefined") {Decorator = ՐՏ_v;};});
+    ՐՏ_mod.export("Annotation", function(){return Annotation;}, function(ՐՏ_v){if (typeof Annotation !== "undefined") {Annotation = ՐՏ_v;};});
+    ՐՏ_mod.export("Lambda", function(){return Lambda;}, function(ՐՏ_v){if (typeof Lambda !== "undefined") {Lambda = ՐՏ_v;};});
+    ՐՏ_mod.export("Accessor", function(){return Accessor;}, function(ՐՏ_v){if (typeof Accessor !== "undefined") {Accessor = ՐՏ_v;};});
+    ՐՏ_mod.export("Function", function(){return Function;}, function(ՐՏ_v){if (typeof Function !== "undefined") {Function = ՐՏ_v;};});
+    ՐՏ_mod.export("Class", function(){return Class;}, function(ՐՏ_v){if (typeof Class !== "undefined") {Class = ՐՏ_v;};});
+    ՐՏ_mod.export("Module", function(){return Module;}, function(ՐՏ_v){if (typeof Module !== "undefined") {Module = ՐՏ_v;};});
+    ՐՏ_mod.export("Method", function(){return Method;}, function(ՐՏ_v){if (typeof Method !== "undefined") {Method = ՐՏ_v;};});
+    ՐՏ_mod.export("Constructor", function(){return Constructor;}, function(ՐՏ_v){if (typeof Constructor !== "undefined") {Constructor = ՐՏ_v;};});
+    ՐՏ_mod.export("Jump", function(){return Jump;}, function(ՐՏ_v){if (typeof Jump !== "undefined") {Jump = ՐՏ_v;};});
+    ՐՏ_mod.export("Exit", function(){return Exit;}, function(ՐՏ_v){if (typeof Exit !== "undefined") {Exit = ՐՏ_v;};});
+    ՐՏ_mod.export("Return", function(){return Return;}, function(ՐՏ_v){if (typeof Return !== "undefined") {Return = ՐՏ_v;};});
+    ՐՏ_mod.export("Yield", function(){return Yield;}, function(ՐՏ_v){if (typeof Yield !== "undefined") {Yield = ՐՏ_v;};});
+    ՐՏ_mod.export("Throw", function(){return Throw;}, function(ՐՏ_v){if (typeof Throw !== "undefined") {Throw = ՐՏ_v;};});
+    ՐՏ_mod.export("LoopControl", function(){return LoopControl;}, function(ՐՏ_v){if (typeof LoopControl !== "undefined") {LoopControl = ՐՏ_v;};});
+    ՐՏ_mod.export("Break", function(){return Break;}, function(ՐՏ_v){if (typeof Break !== "undefined") {Break = ՐՏ_v;};});
+    ՐՏ_mod.export("Continue", function(){return Continue;}, function(ՐՏ_v){if (typeof Continue !== "undefined") {Continue = ՐՏ_v;};});
+    ՐՏ_mod.export("If", function(){return If;}, function(ՐՏ_v){if (typeof If !== "undefined") {If = ՐՏ_v;};});
+    ՐՏ_mod.export("Switch", function(){return Switch;}, function(ՐՏ_v){if (typeof Switch !== "undefined") {Switch = ՐՏ_v;};});
+    ՐՏ_mod.export("SwitchBranch", function(){return SwitchBranch;}, function(ՐՏ_v){if (typeof SwitchBranch !== "undefined") {SwitchBranch = ՐՏ_v;};});
+    ՐՏ_mod.export("Default", function(){return Default;}, function(ՐՏ_v){if (typeof Default !== "undefined") {Default = ՐՏ_v;};});
+    ՐՏ_mod.export("Case", function(){return Case;}, function(ՐՏ_v){if (typeof Case !== "undefined") {Case = ՐՏ_v;};});
+    ՐՏ_mod.export("Try", function(){return Try;}, function(ՐՏ_v){if (typeof Try !== "undefined") {Try = ՐՏ_v;};});
+    ՐՏ_mod.export("Catch", function(){return Catch;}, function(ՐՏ_v){if (typeof Catch !== "undefined") {Catch = ՐՏ_v;};});
+    ՐՏ_mod.export("Except", function(){return Except;}, function(ՐՏ_v){if (typeof Except !== "undefined") {Except = ՐՏ_v;};});
+    ՐՏ_mod.export("Finally", function(){return Finally;}, function(ՐՏ_v){if (typeof Finally !== "undefined") {Finally = ՐՏ_v;};});
+    ՐՏ_mod.export("Definitions", function(){return Definitions;}, function(ՐՏ_v){if (typeof Definitions !== "undefined") {Definitions = ՐՏ_v;};});
+    ՐՏ_mod.export("Var", function(){return Var;}, function(ՐՏ_v){if (typeof Var !== "undefined") {Var = ՐՏ_v;};});
+    ՐՏ_mod.export("Const", function(){return Const;}, function(ՐՏ_v){if (typeof Const !== "undefined") {Const = ՐՏ_v;};});
+    ՐՏ_mod.export("VarDef", function(){return VarDef;}, function(ՐՏ_v){if (typeof VarDef !== "undefined") {VarDef = ՐՏ_v;};});
+    ՐՏ_mod.export("BaseCall", function(){return BaseCall;}, function(ՐՏ_v){if (typeof BaseCall !== "undefined") {BaseCall = ՐՏ_v;};});
+    ՐՏ_mod.export("Call", function(){return Call;}, function(ՐՏ_v){if (typeof Call !== "undefined") {Call = ՐՏ_v;};});
+    ՐՏ_mod.export("ClassCall", function(){return ClassCall;}, function(ՐՏ_v){if (typeof ClassCall !== "undefined") {ClassCall = ՐՏ_v;};});
+    ՐՏ_mod.export("New", function(){return New;}, function(ՐՏ_v){if (typeof New !== "undefined") {New = ՐՏ_v;};});
+    ՐՏ_mod.export("Seq", function(){return Seq;}, function(ՐՏ_v){if (typeof Seq !== "undefined") {Seq = ՐՏ_v;};});
+    ՐՏ_mod.export("PropAccess", function(){return PropAccess;}, function(ՐՏ_v){if (typeof PropAccess !== "undefined") {PropAccess = ՐՏ_v;};});
+    ՐՏ_mod.export("Dot", function(){return Dot;}, function(ՐՏ_v){if (typeof Dot !== "undefined") {Dot = ՐՏ_v;};});
+    ՐՏ_mod.export("Sub", function(){return Sub;}, function(ՐՏ_v){if (typeof Sub !== "undefined") {Sub = ՐՏ_v;};});
+    ՐՏ_mod.export("Slice", function(){return Slice;}, function(ՐՏ_v){if (typeof Slice !== "undefined") {Slice = ՐՏ_v;};});
+    ՐՏ_mod.export("Unary", function(){return Unary;}, function(ՐՏ_v){if (typeof Unary !== "undefined") {Unary = ՐՏ_v;};});
+    ՐՏ_mod.export("UnaryPrefix", function(){return UnaryPrefix;}, function(ՐՏ_v){if (typeof UnaryPrefix !== "undefined") {UnaryPrefix = ՐՏ_v;};});
+    ՐՏ_mod.export("UnaryPostfix", function(){return UnaryPostfix;}, function(ՐՏ_v){if (typeof UnaryPostfix !== "undefined") {UnaryPostfix = ՐՏ_v;};});
+    ՐՏ_mod.export("Binary", function(){return Binary;}, function(ՐՏ_v){if (typeof Binary !== "undefined") {Binary = ՐՏ_v;};});
+    ՐՏ_mod.export("Range", function(){return Range;}, function(ՐՏ_v){if (typeof Range !== "undefined") {Range = ՐՏ_v;};});
+    ՐՏ_mod.export("DeepEquality", function(){return DeepEquality;}, function(ՐՏ_v){if (typeof DeepEquality !== "undefined") {DeepEquality = ՐՏ_v;};});
+    ՐՏ_mod.export("Conditional", function(){return Conditional;}, function(ՐՏ_v){if (typeof Conditional !== "undefined") {Conditional = ՐՏ_v;};});
+    ՐՏ_mod.export("Assign", function(){return Assign;}, function(ՐՏ_v){if (typeof Assign !== "undefined") {Assign = ՐՏ_v;};});
+    ՐՏ_mod.export("Array", function(){return Array;}, function(ՐՏ_v){if (typeof Array !== "undefined") {Array = ՐՏ_v;};});
+    ՐՏ_mod.export("TupleUnpack", function(){return TupleUnpack;}, function(ՐՏ_v){if (typeof TupleUnpack !== "undefined") {TupleUnpack = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectLiteral", function(){return ObjectLiteral;}, function(ՐՏ_v){if (typeof ObjectLiteral !== "undefined") {ObjectLiteral = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectProperty", function(){return ObjectProperty;}, function(ՐՏ_v){if (typeof ObjectProperty !== "undefined") {ObjectProperty = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectKeyVal", function(){return ObjectKeyVal;}, function(ՐՏ_v){if (typeof ObjectKeyVal !== "undefined") {ObjectKeyVal = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectSetter", function(){return ObjectSetter;}, function(ՐՏ_v){if (typeof ObjectSetter !== "undefined") {ObjectSetter = ՐՏ_v;};});
+    ՐՏ_mod.export("ObjectGetter", function(){return ObjectGetter;}, function(ՐՏ_v){if (typeof ObjectGetter !== "undefined") {ObjectGetter = ՐՏ_v;};});
+    ՐՏ_mod.export("Symbol", function(){return Symbol;}, function(ՐՏ_v){if (typeof Symbol !== "undefined") {Symbol = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolAlias", function(){return SymbolAlias;}, function(ՐՏ_v){if (typeof SymbolAlias !== "undefined") {SymbolAlias = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolDeclaration", function(){return SymbolDeclaration;}, function(ՐՏ_v){if (typeof SymbolDeclaration !== "undefined") {SymbolDeclaration = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolVar", function(){return SymbolVar;}, function(ՐՏ_v){if (typeof SymbolVar !== "undefined") {SymbolVar = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolNonlocal", function(){return SymbolNonlocal;}, function(ՐՏ_v){if (typeof SymbolNonlocal !== "undefined") {SymbolNonlocal = ՐՏ_v;};});
+    ՐՏ_mod.export("ImportedVar", function(){return ImportedVar;}, function(ՐՏ_v){if (typeof ImportedVar !== "undefined") {ImportedVar = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolConst", function(){return SymbolConst;}, function(ՐՏ_v){if (typeof SymbolConst !== "undefined") {SymbolConst = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolFunarg", function(){return SymbolFunarg;}, function(ՐՏ_v){if (typeof SymbolFunarg !== "undefined") {SymbolFunarg = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolClass", function(){return SymbolClass;}, function(ՐՏ_v){if (typeof SymbolClass !== "undefined") {SymbolClass = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolDefun", function(){return SymbolDefun;}, function(ՐՏ_v){if (typeof SymbolDefun !== "undefined") {SymbolDefun = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolAccessor", function(){return SymbolAccessor;}, function(ՐՏ_v){if (typeof SymbolAccessor !== "undefined") {SymbolAccessor = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolLambda", function(){return SymbolLambda;}, function(ՐՏ_v){if (typeof SymbolLambda !== "undefined") {SymbolLambda = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolCatch", function(){return SymbolCatch;}, function(ՐՏ_v){if (typeof SymbolCatch !== "undefined") {SymbolCatch = ՐՏ_v;};});
+    ՐՏ_mod.export("Label", function(){return Label;}, function(ՐՏ_v){if (typeof Label !== "undefined") {Label = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolRef", function(){return SymbolRef;}, function(ՐՏ_v){if (typeof SymbolRef !== "undefined") {SymbolRef = ՐՏ_v;};});
+    ՐՏ_mod.export("SymbolClassRef", function(){return SymbolClassRef;}, function(ՐՏ_v){if (typeof SymbolClassRef !== "undefined") {SymbolClassRef = ՐՏ_v;};});
+    ՐՏ_mod.export("LabelRef", function(){return LabelRef;}, function(ՐՏ_v){if (typeof LabelRef !== "undefined") {LabelRef = ՐՏ_v;};});
+    ՐՏ_mod.export("This", function(){return This;}, function(ՐՏ_v){if (typeof This !== "undefined") {This = ՐՏ_v;};});
+    ՐՏ_mod.export("Constant", function(){return Constant;}, function(ՐՏ_v){if (typeof Constant !== "undefined") {Constant = ՐՏ_v;};});
+    ՐՏ_mod.export("String", function(){return String;}, function(ՐՏ_v){if (typeof String !== "undefined") {String = ՐՏ_v;};});
+    ՐՏ_mod.export("Verbatim", function(){return Verbatim;}, function(ՐՏ_v){if (typeof Verbatim !== "undefined") {Verbatim = ՐՏ_v;};});
+    ՐՏ_mod.export("Number", function(){return Number;}, function(ՐՏ_v){if (typeof Number !== "undefined") {Number = ՐՏ_v;};});
+    ՐՏ_mod.export("Identifier", function(){return Identifier;}, function(ՐՏ_v){if (typeof Identifier !== "undefined") {Identifier = ՐՏ_v;};});
+    ՐՏ_mod.export("RegExp", function(){return RegExp;}, function(ՐՏ_v){if (typeof RegExp !== "undefined") {RegExp = ՐՏ_v;};});
+    ՐՏ_mod.export("Atom", function(){return Atom;}, function(ՐՏ_v){if (typeof Atom !== "undefined") {Atom = ՐՏ_v;};});
+    ՐՏ_mod.export("Null", function(){return Null;}, function(ՐՏ_v){if (typeof Null !== "undefined") {Null = ՐՏ_v;};});
+    ՐՏ_mod.export("NotANumber", function(){return NotANumber;}, function(ՐՏ_v){if (typeof NotANumber !== "undefined") {NotANumber = ՐՏ_v;};});
+    ՐՏ_mod.export("Undefined", function(){return Undefined;}, function(ՐՏ_v){if (typeof Undefined !== "undefined") {Undefined = ՐՏ_v;};});
+    ՐՏ_mod.export("Hole", function(){return Hole;}, function(ՐՏ_v){if (typeof Hole !== "undefined") {Hole = ՐՏ_v;};});
+    ՐՏ_mod.export("Infinity", function(){return Infinity;}, function(ՐՏ_v){if (typeof Infinity !== "undefined") {Infinity = ՐՏ_v;};});
+    ՐՏ_mod.export("Boolean", function(){return Boolean;}, function(ՐՏ_v){if (typeof Boolean !== "undefined") {Boolean = ՐՏ_v;};});
+    ՐՏ_mod.export("TreeWalker", function(){return TreeWalker;}, function(ՐՏ_v){if (typeof TreeWalker !== "undefined") {TreeWalker = ՐՏ_v;};});
+    ՐՏ_mod.export("colored", function(){return colored;}, function(ՐՏ_v){if (typeof colored !== "undefined") {colored = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:tokenizer"].body = function(){
     var __name__ = "tokenizer";
 
     var ES6_KEYWORDS, COMMON_KEYWORDS, JS_KEYWORDS, JS_KEYWORDS_AUTOFIX, RS_KEYWORDS, KEYWORDS, KEYWORDS_ATOM, RESERVED_WORDS, KEYWORDS_BEFORE_EXPRESSION, ALL_KEYWORDS, ALL_JS_KEYWORDS, IS_ANY_KEYWORD, OPERATOR_CHARS, RE_HEX_NUMBER, RE_OCT_NUMBER, RE_DEC_NUMBER, OPERATORS, OP_MAP, WHITESPACE_CHARS, PUNC_BEFORE_EXPRESSION, PUNC_CHARS, REGEXP_MODIFIERS, UNICODE, IDENTIFIER_PAT, STRING_MODIFIERS, UNARY_POSTFIX, PRECEDENCE, EX_EOF;
-    var makePredicate = ՐՏ_modules["utils"].makePredicate;
-    var ParseError = ՐՏ_modules["utils"].ParseError;
-    
+    var makePredicate = ՐՏ_modules["utils"].makePredicate;var ParseError = ՐՏ_modules["utils"].ParseError;
     var ast = ՐՏ_modules["ast"];
-    
     function characters(str_) {
         return str_.split("");
     }
@@ -3622,11 +3457,12 @@ var ՐՏ_modules = {};
     STRING_MODIFIERS = "urfvURFV";
     UNARY_POSTFIX = makePredicate([ "--", "++" ]);
     PRECEDENCE = function(a, ret) {
+        var ՐՏ_199, ՐՏ_200, ՐՏ_201;
         var i, b, j;
         for (i = 0; i < a.length; i++) {
-            b = a[i];
+            b = (ՐՏ_199 = a)[i];
             for (j = 0; j < b.length; j++) {
-                ret[b[j]] = i + 1;
+                (ՐՏ_200 = ret)[(ՐՏ_201 = b)[j]] = i + 1;
             }
         }
         return ret;
@@ -3679,10 +3515,11 @@ var ՐՏ_modules = {};
         }
     }
     function is_token(token, type, val) {
+        var ՐՏ_202, ՐՏ_203;
         var type_subtype, subtype;
         type_subtype = type.split(":");
-        type = type_subtype[0];
-        subtype = type_subtype[1];
+        type = (ՐՏ_202 = type_subtype)[0];
+        subtype = (ՐՏ_203 = type_subtype)[1];
         return token.type === type && (subtype ? token.subtype === subtype : true) && (val === null || val === void 0 || Array.isArray(val) && val.indexOf(token.value) >= 0 || token.value === val);
     }
     function js_error(message, filename, line, col, pos, is_eof) {
@@ -3696,7 +3533,7 @@ var ՐՏ_modules = {};
     }
     EX_EOF = {};
     function tokenizer($TEXT, filename) {
-        var ՐՏ_116, ՐՏ_117, ՐՏ_118;
+        var ՐՏ_218, ՐՏ_222, ՐՏ_225;
         var S;
         S = {
             text: $TEXT.replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/\uFEFF/g, ""),
@@ -3755,19 +3592,20 @@ var ՐՏ_modules = {};
             S.tokpos = S.pos;
         }
         function token(full_type, value, is_comment, keep_newline) {
+            var ՐՏ_204, ՐՏ_205, ՐՏ_206, ՐՏ_207, ՐՏ_208, ՐՏ_209, ՐՏ_210, ՐՏ_211, ՐՏ_212, ՐՏ_213, ՐՏ_214, ՐՏ_215;
             var _full_type, type, subtype, _value, ret, block_expect, i, top_scope;
             _full_type = full_type.split(":");
-            type = _full_type[0];
-            subtype = _full_type[1];
+            type = (ՐՏ_204 = _full_type)[0];
+            subtype = (ՐՏ_205 = _full_type)[1];
             _value = null;
-            S.regex_allowed = type === "operator" && !UNARY_POSTFIX[value] || type === "keyword" && KEYWORDS_BEFORE_EXPRESSION(value) || type === "punc" && PUNC_BEFORE_EXPRESSION(value);
+            S.regex_allowed = type === "operator" && !(ՐՏ_206 = UNARY_POSTFIX)[value] || type === "keyword" && KEYWORDS_BEFORE_EXPRESSION(value) || type === "punc" && PUNC_BEFORE_EXPRESSION(value);
             if (type === "operator" && value === "is" && S.text.substr(S.pos).trimLeft().substr(0, 4).trimRight() === "not") {
                 next_token();
                 value = "!==";
             }
-            if (type === "operator" && OP_MAP[value]) {
+            if (type === "operator" && (ՐՏ_207 = OP_MAP)[value]) {
                 _value = value;
-                value = OP_MAP[value];
+                value = (ՐՏ_208 = OP_MAP)[value];
             }
             ret = {
                 type: type,
@@ -3784,7 +3622,7 @@ var ՐՏ_modules = {};
             };
             S.comma_expect = false;
             if (!S.block_expect) {
-                S.block_expect = S.in_scope[S.in_scope.length-1] === "{}" && (S.prev.type === "keyword" && S.prev.value === "def" && (value === "(" || ՐՏ_in(type, [ "name", "string", "num" ]) || full_type === "operator:keyword") || S.prev.type === "name" && ՐՏ_in(S.prev.value, [ "get", "set" ]) && (ՐՏ_in(type, [ "name", "string", "num" ]) || full_type === "operator:keyword")) || S.in_scope[S.in_scope.length-1] === "()" && S.prev.type === "keyword" && S.prev.value === "def" && (value === "(" || type === "name");
+                S.block_expect = (ՐՏ_209 = S.in_scope)[ՐՏ_209.length-1] === "{}" && (S.prev.type === "keyword" && S.prev.value === "def" && (value === "(" || ՐՏ_in(type, [ "name", "string", "num" ]) || full_type === "operator:keyword") || S.prev.type === "name" && ՐՏ_in(S.prev.value, [ "get", "set" ]) && (ՐՏ_in(type, [ "name", "string", "num" ]) || full_type === "operator:keyword")) || (ՐՏ_210 = S.in_scope)[ՐՏ_210.length-1] === "()" && S.prev.type === "keyword" && S.prev.value === "def" && (value === "(" || type === "name");
             } else {
                 block_expect = true;
                 S.block_expect = false;
@@ -3793,13 +3631,13 @@ var ՐՏ_modules = {};
                 ret.comments_before = S.comments_before;
                 S.comments_before = [];
                 for (i = 0; i < len(ret.comments_before); i++) {
-                    ret.newline_before = ret.newline_before || ret.comments_before[i].newline_before;
+                    ret.newline_before = ret.newline_before || (ՐՏ_211 = ret.comments_before)[i].newline_before;
                 }
             }
             if (!keep_newline) {
                 S.newline_before = false;
             }
-            top_scope = S.in_scope[S.in_scope.length-1];
+            top_scope = (ՐՏ_212 = S.in_scope)[ՐՏ_212.length-1];
             if (type === "punc") {
                 if (value === ":") {
                     if (ՐՏ_in(top_scope, [ "block", "def", "[]" ])) {
@@ -3826,20 +3664,20 @@ var ՐՏ_modules = {};
                 } else if (value === "{") {
                     S.in_scope.push("{}");
                 } else if (ՐՏ_in(value, [ "]", ")", "}" ])) {
-                    if (top_scope[top_scope.length-1] === value) {
+                    if ((ՐՏ_213 = top_scope)[ՐՏ_213.length-1] === value) {
                         S.in_scope.pop();
                     } else {
                         console.log("mismatch: " + value);
                     }
                 } else if (value === "endblock") {
                     ret.value = "}";
-                    if (ret.comments_before.length && ret.comments_before[ret.comments_before.length-1].col <= S.col) {
+                    if (ret.comments_before.length && (ՐՏ_214 = ret.comments_before)[ՐՏ_214.length-1].col <= S.col) {
                         S.comments_before = ret.comments_before;
                         ret.comments_before = [];
                     }
                     if (top_scope === "block") {
                         S.in_scope.pop();
-                        if (ՐՏ_in(S.in_scope[S.in_scope.length-1], [ "[]", "{}", "()" ])) {
+                        if (ՐՏ_in((ՐՏ_215 = S.in_scope)[ՐՏ_215.length-1], [ "[]", "{}", "()" ])) {
                             S.comma_expect = true;
                         }
                     } else {
@@ -3875,10 +3713,11 @@ var ՐՏ_modules = {};
             }
         }
         function test_indent_token(leading_whitespace) {
+            var ՐՏ_216, ՐՏ_217;
             var most_recent;
-            most_recent = S.whitespace_before[S.whitespace_before.length-1] || "";
+            most_recent = (ՐՏ_216 = S.whitespace_before)[ՐՏ_216.length-1] || "";
             S.endblock = false;
-            if (S.in_scope[S.in_scope.length-1] === "block" && leading_whitespace !== most_recent) {
+            if ((ՐՏ_217 = S.in_scope)[ՐՏ_217.length-1] === "block" && leading_whitespace !== most_recent) {
                 if (S.newblock && leading_whitespace && leading_whitespace.indexOf(most_recent) === 0) {
                     S.newblock = false;
                     S.whitespace_before.push(leading_whitespace);
@@ -3985,7 +3824,8 @@ var ՐՏ_modules = {};
             return num;
         }
         
-        var read_string = (ՐՏ_116 = function read_string(modifier) {
+        var read_string = (ՐՏ_218 = function read_string(modifier) {
+            var ՐՏ_219, ՐՏ_221;
             var token_type, quote, ret, i, tmp, find_newlines, ch;
             token_type = "string";
             if (modifier) {
@@ -4002,16 +3842,17 @@ var ՐՏ_modules = {};
                         tmp = S.text.substring(S.pos, i);
                         S.pos = i + 3;
                         while (tmp.length) {
-                            if (tmp[0] === "\\") {
+                            if ((ՐՏ_219 = tmp)[0] === "\\") {
                                 tmp = tmp.slice(1);
                                 ret += read_escaped_char(true, function() {
+                                    var ՐՏ_220;
                                     var ch;
-                                    ch = tmp[0];
+                                    ch = (ՐՏ_220 = tmp)[0];
                                     tmp = tmp.slice(1);
                                     return ch;
                                 });
                             } else {
-                                ret += tmp[0];
+                                ret += (ՐՏ_221 = tmp)[0];
                                 tmp = tmp.slice(1);
                             }
                         }
@@ -4043,7 +3884,7 @@ var ՐՏ_modules = {};
                 ret += ch;
             }
             return token(token_type, ret);
-        }, ՐՏ_116 = with_eof_error("Unterminated string constant")(ՐՏ_116), ՐՏ_116);
+        }, ՐՏ_218 = with_eof_error("Unterminated string constant")(ՐՏ_218), ՐՏ_218);
         function read_line_comment(shebang) {
             shebang = shebang === void 0 ? false : shebang;
             var i, ret;
@@ -4061,7 +3902,8 @@ var ՐՏ_modules = {};
             return token(shebang ? "shebang" : "comment:line", ret, true);
         }
         
-        var read_multiline_comment = (ՐՏ_117 = function read_multiline_comment() {
+        var read_multiline_comment = (ՐՏ_222 = function read_multiline_comment() {
+            var ՐՏ_223, ՐՏ_224;
             var i, text, a, n;
             next();
             i = find("*/", true);
@@ -4071,14 +3913,14 @@ var ՐՏ_modules = {};
             S.pos = i + 2;
             S.line += n - 1;
             if (n > 1) {
-                S.col = a[n - 1].length;
+                S.col = (ՐՏ_223 = a)[n - 1].length;
             } else {
-                S.col += a[n - 1].length;
+                S.col += (ՐՏ_224 = a)[n - 1].length;
             }
             S.col += 2;
             S.newline_before = S.newline_before || ՐՏ_in("\n", text);
             return token("comment:multiline", text, true);
-        }, ՐՏ_117 = with_eof_error("Unterminated multiline comment")(ՐՏ_117), ՐՏ_117);
+        }, ՐՏ_222 = with_eof_error("Unterminated multiline comment")(ՐՏ_222), ՐՏ_222);
         function read_name() {
             var backslash, name, escaped, ch, hex;
             backslash = false;
@@ -4118,7 +3960,7 @@ var ՐՏ_modules = {};
             return name;
         }
         
-        var read_regexp = (ՐՏ_118 = function read_regexp(regexp) {
+        var read_regexp = (ՐՏ_225 = function read_regexp(regexp) {
             var prev_backslash, in_class, verbose_regexp, in_comment, mods, ch;
             prev_backslash = false;
             in_class = false;
@@ -4175,7 +4017,7 @@ var ՐՏ_modules = {};
             }
             mods = read_name();
             return token("regexp", new RegExp(regexp, mods));
-        }, ՐՏ_118 = with_eof_error("Unterminated regular expression")(ՐՏ_118), ՐՏ_118);
+        }, ՐՏ_225 = with_eof_error("Unterminated regular expression")(ՐՏ_225), ՐՏ_225);
         function read_operator(prefix) {
             var op;
             function grow(op) {
@@ -4296,75 +4138,72 @@ var ՐՏ_modules = {};
         };
         return next_token;
     }
-    ՐՏ_modules["tokenizer"]["ES6_KEYWORDS"] = ES6_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["COMMON_KEYWORDS"] = COMMON_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["JS_KEYWORDS"] = JS_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["JS_KEYWORDS_AUTOFIX"] = JS_KEYWORDS_AUTOFIX;
-    ՐՏ_modules["tokenizer"]["RS_KEYWORDS"] = RS_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["KEYWORDS"] = KEYWORDS;
-    ՐՏ_modules["tokenizer"]["KEYWORDS_ATOM"] = KEYWORDS_ATOM;
-    ՐՏ_modules["tokenizer"]["RESERVED_WORDS"] = RESERVED_WORDS;
-    ՐՏ_modules["tokenizer"]["KEYWORDS_BEFORE_EXPRESSION"] = KEYWORDS_BEFORE_EXPRESSION;
-    ՐՏ_modules["tokenizer"]["ALL_KEYWORDS"] = ALL_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["ALL_JS_KEYWORDS"] = ALL_JS_KEYWORDS;
-    ՐՏ_modules["tokenizer"]["IS_ANY_KEYWORD"] = IS_ANY_KEYWORD;
-    ՐՏ_modules["tokenizer"]["OPERATOR_CHARS"] = OPERATOR_CHARS;
-    ՐՏ_modules["tokenizer"]["RE_HEX_NUMBER"] = RE_HEX_NUMBER;
-    ՐՏ_modules["tokenizer"]["RE_OCT_NUMBER"] = RE_OCT_NUMBER;
-    ՐՏ_modules["tokenizer"]["RE_DEC_NUMBER"] = RE_DEC_NUMBER;
-    ՐՏ_modules["tokenizer"]["OPERATORS"] = OPERATORS;
-    ՐՏ_modules["tokenizer"]["OP_MAP"] = OP_MAP;
-    ՐՏ_modules["tokenizer"]["WHITESPACE_CHARS"] = WHITESPACE_CHARS;
-    ՐՏ_modules["tokenizer"]["PUNC_BEFORE_EXPRESSION"] = PUNC_BEFORE_EXPRESSION;
-    ՐՏ_modules["tokenizer"]["PUNC_CHARS"] = PUNC_CHARS;
-    ՐՏ_modules["tokenizer"]["REGEXP_MODIFIERS"] = REGEXP_MODIFIERS;
-    ՐՏ_modules["tokenizer"]["UNICODE"] = UNICODE;
-    ՐՏ_modules["tokenizer"]["IDENTIFIER_PAT"] = IDENTIFIER_PAT;
-    ՐՏ_modules["tokenizer"]["STRING_MODIFIERS"] = STRING_MODIFIERS;
-    ՐՏ_modules["tokenizer"]["UNARY_POSTFIX"] = UNARY_POSTFIX;
-    ՐՏ_modules["tokenizer"]["PRECEDENCE"] = PRECEDENCE;
-    ՐՏ_modules["tokenizer"]["EX_EOF"] = EX_EOF;
-    ՐՏ_modules["tokenizer"]["characters"] = characters;
-    ՐՏ_modules["tokenizer"]["is_letter"] = is_letter;
-    ՐՏ_modules["tokenizer"]["is_digit"] = is_digit;
-    ՐՏ_modules["tokenizer"]["is_alphanumeric_char"] = is_alphanumeric_char;
-    ՐՏ_modules["tokenizer"]["is_unicode_combining_mark"] = is_unicode_combining_mark;
-    ՐՏ_modules["tokenizer"]["is_unicode_connector_punctuation"] = is_unicode_connector_punctuation;
-    ՐՏ_modules["tokenizer"]["is_string_modifier"] = is_string_modifier;
-    ՐՏ_modules["tokenizer"]["is_identifier"] = is_identifier;
-    ՐՏ_modules["tokenizer"]["is_identifier_start"] = is_identifier_start;
-    ՐՏ_modules["tokenizer"]["is_identifier_char"] = is_identifier_char;
-    ՐՏ_modules["tokenizer"]["parse_js_number"] = parse_js_number;
-    ՐՏ_modules["tokenizer"]["is_token"] = is_token;
-    ՐՏ_modules["tokenizer"]["js_error"] = js_error;
-    ՐՏ_modules["tokenizer"]["tokenizer"] = tokenizer;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:tokenizer"];
+    ՐՏ_mod.export("ES6_KEYWORDS", function(){return ES6_KEYWORDS;}, function(ՐՏ_v){if (typeof ES6_KEYWORDS !== "undefined") {ES6_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("COMMON_KEYWORDS", function(){return COMMON_KEYWORDS;}, function(ՐՏ_v){if (typeof COMMON_KEYWORDS !== "undefined") {COMMON_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("JS_KEYWORDS", function(){return JS_KEYWORDS;}, function(ՐՏ_v){if (typeof JS_KEYWORDS !== "undefined") {JS_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("JS_KEYWORDS_AUTOFIX", function(){return JS_KEYWORDS_AUTOFIX;}, function(ՐՏ_v){if (typeof JS_KEYWORDS_AUTOFIX !== "undefined") {JS_KEYWORDS_AUTOFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("RS_KEYWORDS", function(){return RS_KEYWORDS;}, function(ՐՏ_v){if (typeof RS_KEYWORDS !== "undefined") {RS_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("KEYWORDS", function(){return KEYWORDS;}, function(ՐՏ_v){if (typeof KEYWORDS !== "undefined") {KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("KEYWORDS_ATOM", function(){return KEYWORDS_ATOM;}, function(ՐՏ_v){if (typeof KEYWORDS_ATOM !== "undefined") {KEYWORDS_ATOM = ՐՏ_v;};});
+    ՐՏ_mod.export("RESERVED_WORDS", function(){return RESERVED_WORDS;}, function(ՐՏ_v){if (typeof RESERVED_WORDS !== "undefined") {RESERVED_WORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("KEYWORDS_BEFORE_EXPRESSION", function(){return KEYWORDS_BEFORE_EXPRESSION;}, function(ՐՏ_v){if (typeof KEYWORDS_BEFORE_EXPRESSION !== "undefined") {KEYWORDS_BEFORE_EXPRESSION = ՐՏ_v;};});
+    ՐՏ_mod.export("ALL_KEYWORDS", function(){return ALL_KEYWORDS;}, function(ՐՏ_v){if (typeof ALL_KEYWORDS !== "undefined") {ALL_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("ALL_JS_KEYWORDS", function(){return ALL_JS_KEYWORDS;}, function(ՐՏ_v){if (typeof ALL_JS_KEYWORDS !== "undefined") {ALL_JS_KEYWORDS = ՐՏ_v;};});
+    ՐՏ_mod.export("IS_ANY_KEYWORD", function(){return IS_ANY_KEYWORD;}, function(ՐՏ_v){if (typeof IS_ANY_KEYWORD !== "undefined") {IS_ANY_KEYWORD = ՐՏ_v;};});
+    ՐՏ_mod.export("OPERATOR_CHARS", function(){return OPERATOR_CHARS;}, function(ՐՏ_v){if (typeof OPERATOR_CHARS !== "undefined") {OPERATOR_CHARS = ՐՏ_v;};});
+    ՐՏ_mod.export("RE_HEX_NUMBER", function(){return RE_HEX_NUMBER;}, function(ՐՏ_v){if (typeof RE_HEX_NUMBER !== "undefined") {RE_HEX_NUMBER = ՐՏ_v;};});
+    ՐՏ_mod.export("RE_OCT_NUMBER", function(){return RE_OCT_NUMBER;}, function(ՐՏ_v){if (typeof RE_OCT_NUMBER !== "undefined") {RE_OCT_NUMBER = ՐՏ_v;};});
+    ՐՏ_mod.export("RE_DEC_NUMBER", function(){return RE_DEC_NUMBER;}, function(ՐՏ_v){if (typeof RE_DEC_NUMBER !== "undefined") {RE_DEC_NUMBER = ՐՏ_v;};});
+    ՐՏ_mod.export("OPERATORS", function(){return OPERATORS;}, function(ՐՏ_v){if (typeof OPERATORS !== "undefined") {OPERATORS = ՐՏ_v;};});
+    ՐՏ_mod.export("OP_MAP", function(){return OP_MAP;}, function(ՐՏ_v){if (typeof OP_MAP !== "undefined") {OP_MAP = ՐՏ_v;};});
+    ՐՏ_mod.export("WHITESPACE_CHARS", function(){return WHITESPACE_CHARS;}, function(ՐՏ_v){if (typeof WHITESPACE_CHARS !== "undefined") {WHITESPACE_CHARS = ՐՏ_v;};});
+    ՐՏ_mod.export("PUNC_BEFORE_EXPRESSION", function(){return PUNC_BEFORE_EXPRESSION;}, function(ՐՏ_v){if (typeof PUNC_BEFORE_EXPRESSION !== "undefined") {PUNC_BEFORE_EXPRESSION = ՐՏ_v;};});
+    ՐՏ_mod.export("PUNC_CHARS", function(){return PUNC_CHARS;}, function(ՐՏ_v){if (typeof PUNC_CHARS !== "undefined") {PUNC_CHARS = ՐՏ_v;};});
+    ՐՏ_mod.export("REGEXP_MODIFIERS", function(){return REGEXP_MODIFIERS;}, function(ՐՏ_v){if (typeof REGEXP_MODIFIERS !== "undefined") {REGEXP_MODIFIERS = ՐՏ_v;};});
+    ՐՏ_mod.export("UNICODE", function(){return UNICODE;}, function(ՐՏ_v){if (typeof UNICODE !== "undefined") {UNICODE = ՐՏ_v;};});
+    ՐՏ_mod.export("IDENTIFIER_PAT", function(){return IDENTIFIER_PAT;}, function(ՐՏ_v){if (typeof IDENTIFIER_PAT !== "undefined") {IDENTIFIER_PAT = ՐՏ_v;};});
+    ՐՏ_mod.export("STRING_MODIFIERS", function(){return STRING_MODIFIERS;}, function(ՐՏ_v){if (typeof STRING_MODIFIERS !== "undefined") {STRING_MODIFIERS = ՐՏ_v;};});
+    ՐՏ_mod.export("UNARY_POSTFIX", function(){return UNARY_POSTFIX;}, function(ՐՏ_v){if (typeof UNARY_POSTFIX !== "undefined") {UNARY_POSTFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("PRECEDENCE", function(){return PRECEDENCE;}, function(ՐՏ_v){if (typeof PRECEDENCE !== "undefined") {PRECEDENCE = ՐՏ_v;};});
+    ՐՏ_mod.export("EX_EOF", function(){return EX_EOF;}, function(ՐՏ_v){if (typeof EX_EOF !== "undefined") {EX_EOF = ՐՏ_v;};});
+    ՐՏ_mod.export("characters", function(){return characters;}, function(ՐՏ_v){if (typeof characters !== "undefined") {characters = ՐՏ_v;};});
+    ՐՏ_mod.export("is_letter", function(){return is_letter;}, function(ՐՏ_v){if (typeof is_letter !== "undefined") {is_letter = ՐՏ_v;};});
+    ՐՏ_mod.export("is_digit", function(){return is_digit;}, function(ՐՏ_v){if (typeof is_digit !== "undefined") {is_digit = ՐՏ_v;};});
+    ՐՏ_mod.export("is_alphanumeric_char", function(){return is_alphanumeric_char;}, function(ՐՏ_v){if (typeof is_alphanumeric_char !== "undefined") {is_alphanumeric_char = ՐՏ_v;};});
+    ՐՏ_mod.export("is_unicode_combining_mark", function(){return is_unicode_combining_mark;}, function(ՐՏ_v){if (typeof is_unicode_combining_mark !== "undefined") {is_unicode_combining_mark = ՐՏ_v;};});
+    ՐՏ_mod.export("is_unicode_connector_punctuation", function(){return is_unicode_connector_punctuation;}, function(ՐՏ_v){if (typeof is_unicode_connector_punctuation !== "undefined") {is_unicode_connector_punctuation = ՐՏ_v;};});
+    ՐՏ_mod.export("is_string_modifier", function(){return is_string_modifier;}, function(ՐՏ_v){if (typeof is_string_modifier !== "undefined") {is_string_modifier = ՐՏ_v;};});
+    ՐՏ_mod.export("is_identifier", function(){return is_identifier;}, function(ՐՏ_v){if (typeof is_identifier !== "undefined") {is_identifier = ՐՏ_v;};});
+    ՐՏ_mod.export("is_identifier_start", function(){return is_identifier_start;}, function(ՐՏ_v){if (typeof is_identifier_start !== "undefined") {is_identifier_start = ՐՏ_v;};});
+    ՐՏ_mod.export("is_identifier_char", function(){return is_identifier_char;}, function(ՐՏ_v){if (typeof is_identifier_char !== "undefined") {is_identifier_char = ՐՏ_v;};});
+    ՐՏ_mod.export("parse_js_number", function(){return parse_js_number;}, function(ՐՏ_v){if (typeof parse_js_number !== "undefined") {parse_js_number = ՐՏ_v;};});
+    ՐՏ_mod.export("is_token", function(){return is_token;}, function(ՐՏ_v){if (typeof is_token !== "undefined") {is_token = ՐՏ_v;};});
+    ՐՏ_mod.export("js_error", function(){return js_error;}, function(ՐՏ_v){if (typeof js_error !== "undefined") {js_error = ՐՏ_v;};});
+    ՐՏ_mod.export("tokenizer", function(){return tokenizer;}, function(ՐՏ_v){if (typeof tokenizer !== "undefined") {tokenizer = ՐՏ_v;};});
+    ՐՏ_mod.export("ParseError", function(){return ParseError;}, function(ՐՏ_v){if (typeof ParseError !== "undefined") {ParseError = ՐՏ_v;};});
+    ՐՏ_mod.export("ast", function(){return ast;}, function(ՐՏ_v){if (typeof ast !== "undefined") {ast = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:parser"].body = function(){
     var __name__ = "parser";
 
     var NATIVE_CLASSES, COMMON_STATIC, CLASS_MAP, BASELIB, STDLIB, UNARY_PREFIX, ASSIGNMENT, STATEMENTS_WITH_LABELS, ATOMIC_START_TOKEN;
-    var makePredicate = ՐՏ_modules["utils"].makePredicate;
-    var defaults = ՐՏ_modules["utils"].defaults;
-    var ImportError = ՐՏ_modules["utils"].ImportError;
-    var js_error = ՐՏ_modules["utils"].js_error;
-    var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
-    var find_if = ՐՏ_modules["utils"].find_if;
-    
+    var makePredicate = ՐՏ_modules["utils"].makePredicate;var defaults = ՐՏ_modules["utils"].defaults;var ImportError = ՐՏ_modules["utils"].ImportError;var js_error = ՐՏ_modules["utils"].js_error;var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;var find_if = ՐՏ_modules["utils"].find_if;
     var ast = ՐՏ_modules["ast"];
-    
     var tokenizer = ՐՏ_modules["tokenizer"];
-    
     NATIVE_CLASSES = null;
     COMMON_STATIC = null;
     CLASS_MAP = null;
     BASELIB = null;
     STDLIB = null;
     function array_to_hash(a) {
+        var ՐՏ_226, ՐՏ_227;
         var ret, i;
         ret = {};
         for (i = 0; i < len(a); i++) {
-            ret[a[i]] = true;
+            (ՐՏ_226 = ret)[(ՐՏ_227 = a)[i]] = true;
         }
         return ret;
     }
@@ -4420,7 +4259,7 @@ var ՐՏ_modules = {};
         COMMON_STATIC = [ "call", "apply", "bind", "toString" ];
         CLASS_MAP = {};
         BASELIB = (function() {
-            var ՐՏidx37, ՐՏitr37 = ՐՏ_Iterable([ "abs", "all", "any", "bin", "bind", "rebind_all", "with__name__", "cmp", "chr", "dir", "enumerate", "eslice", "extends", "filter", "hex", "in", "iterable", "len", "map", "max", "min", "merge", "mixin", "print", "range", "reduce", "reversed", "sorted", "sum", "type", "zip", "getattr", "setattr", "hasattr", "eq", "kwargs", "AssertionError", "IndexError", "KeyError", "TypeError", "ValueError" ]), ՐՏres = {}, key;
+            var ՐՏidx37, ՐՏitr37 = ՐՏ_Iterable([ "abs", "all", "any", "bin", "bind", "rebind_all", "with__name__", "def_modules", "cmp", "chr", "dir", "enumerate", "eslice", "extends", "filter", "hex", "in", "iterable", "len", "map", "max", "min", "merge", "mixin", "print", "range", "reduce", "reversed", "sorted", "sum", "type", "zip", "getattr", "setattr", "hasattr", "eq", "kwargs", "AssertionError", "IndexError", "KeyError", "TypeError", "ValueError" ]), ՐՏres = {}, key;
             for (ՐՏidx37 = 0; ՐՏidx37 < ՐՏitr37.length; ՐՏidx37++) {
                 key = ՐՏitr37[ՐՏidx37];
                 ՐՏres[key] = 0;
@@ -4430,10 +4269,11 @@ var ՐՏ_modules = {};
         STDLIB = [ "abs", "bin", "cmp", "chr", "dir", "hex", "max", "min", "merge", "mixin", "print", "range", "reduce", "getattr", "setattr", "hasattr", "eq", "bind", "rebind_all", "type", "all", "any", "enumerate", "filter", "len", "map", "reversed", "sum", "zip", "AssertionError", "IndexError", "KeyError", "TypeError", "ValueError" ];
     }
     function has_simple_decorator(decorators, name) {
+        var ՐՏ_228, ՐՏ_229;
         var remove, s;
         remove = [];
         for (var i = 0; i < decorators.length; i++) {
-            s = decorators[i];
+            s = (ՐՏ_228 = decorators)[i];
             if (s instanceof ast.SymbolRef && !s.parens && s.name === name) {
                 remove.push(i);
             }
@@ -4441,7 +4281,7 @@ var ՐՏ_modules = {};
         if (remove.length) {
             remove.reverse();
             for (var i = 0; i < remove.length; i++) {
-                decorators.splice(remove[i], 1);
+                decorators.splice((ՐՏ_229 = remove)[i], 1);
             }
             return true;
         }
@@ -4452,7 +4292,7 @@ var ՐՏ_modules = {};
     STATEMENTS_WITH_LABELS = array_to_hash([ "for", "do", "while", "switch" ]);
     ATOMIC_START_TOKEN = array_to_hash([ "atom", "num", "string", "regexp", "name" ]);
     function parse($TEXT, options) {
-        var ՐՏitr38, ՐՏidx38, ՐՏ_119, ՐՏ_120, ՐՏ_121;
+        var ՐՏ_230, ՐՏitr38, ՐՏidx38, ՐՏ_231, ՐՏ_232, ՐՏ_233, ՐՏ_239, ՐՏ_331, ՐՏ_339;
         var class_map, module_id, import_dirs, depends_on, PRE_IMPORTED, IMPORTED, IMPORTING, S, cname, obj;
         if (!STDLIB) {
             init_mod();
@@ -4485,7 +4325,7 @@ var ՐՏ_modules = {};
         PRE_IMPORTED = options.PRE_IMPORTED || {};
         IMPORTED = options.IMPORTED || {};
         IMPORTING = options.IMPORTING || {};
-        IMPORTING[module_id] = true;
+        (ՐՏ_230 = IMPORTING)[module_id] = true;
         S = {
             input: typeof $TEXT === "string" ? tokenizer.tokenizer($TEXT, options.filename) : $TEXT,
             token: null,
@@ -4509,8 +4349,8 @@ var ՐՏ_modules = {};
             ՐՏitr38 = ՐՏ_Iterable(options.classes);
             for (ՐՏidx38 = 0; ՐՏidx38 < ՐՏitr38.length; ՐՏidx38++) {
                 cname = ՐՏitr38[ՐՏidx38];
-                obj = options.classes[cname];
-                S.in_scope[0].classes[cname] = {
+                obj = (ՐՏ_231 = options.classes)[cname];
+                (ՐՏ_232 = (ՐՏ_233 = S.in_scope)[0].classes)[cname] = {
                     "static": obj.static,
                     "bound": obj.bound
                 };
@@ -4625,13 +4465,58 @@ var ՐՏ_modules = {};
                 return false;
             }
         }
+        function scan_for_top_level_imports(body) {
+            var ՐՏ_234, ՐՏitr39, ՐՏidx39, ՐՏitr40, ՐՏidx40, ՐՏ_235, ՐՏitr41, ՐՏidx41, ՐՏ_236;
+            var self_fun, ans, name, obj, imp, argname, imp_sym, x, opt;
+            self_fun = scan_for_top_level_imports;
+            ans = [];
+            if (Array.isArray(body)) {
+                for (name in body) {
+                    obj = (ՐՏ_234 = body)[name];
+                    if (obj instanceof ast.Imports) {
+                        ՐՏitr39 = ՐՏ_Iterable(obj.imports);
+                        for (ՐՏidx39 = 0; ՐՏidx39 < ՐՏitr39.length; ՐՏidx39++) {
+                            imp = ՐՏitr39[ՐՏidx39];
+                            if (imp.argnames) {
+                                ՐՏitr40 = ՐՏ_Iterable(imp.argnames);
+                                for (ՐՏidx40 = 0; ՐՏidx40 < ՐՏitr40.length; ՐՏidx40++) {
+                                    argname = ՐՏitr40[ՐՏidx40];
+                                    imp_sym = argname.alias || argname;
+                                }
+                            } else {
+                                imp_sym = imp.alias || new_symbol(ast.SymbolVar, (ՐՏ_235 = imp.key.split(".", 1))[0]);
+                            }
+                            ans.push(imp_sym);
+                        }
+                    } else {
+                        if (obj instanceof ast.Scope) {
+                            continue;
+                        }
+                        ՐՏitr41 = ՐՏ_Iterable([ "body", "alternative" ]);
+                        for (ՐՏidx41 = 0; ՐՏidx41 < ՐՏitr41.length; ՐՏidx41++) {
+                            x = ՐՏitr41[ՐՏidx41];
+                            opt = (ՐՏ_236 = obj)[x];
+                            if (opt) {
+                                ans = ans.concat(self_fun(opt));
+                            }
+                        }
+                    }
+                }
+            } else if (body.body) {
+                ans = ans.concat(self_fun(body.body));
+                if (body.alternative) {
+                    ans = ans.concat(self_fun(body.alternative));
+                }
+            }
+            return ans;
+        }
         function scan_for_top_level_callables(body) {
-            var ՐՏitr39, ՐՏidx39;
+            var ՐՏ_237, ՐՏitr42, ՐՏidx42, ՐՏ_238;
             var ans, name, obj, x, opt;
             ans = [];
             if (Array.isArray(body)) {
                 for (name in body) {
-                    obj = body[name];
+                    obj = (ՐՏ_237 = body)[name];
                     if (obj instanceof ast.Function || obj instanceof ast.Class) {
                         if (obj.name) {
                             ans.push(obj.name);
@@ -4642,10 +4527,10 @@ var ՐՏ_modules = {};
                         if (obj instanceof ast.Scope) {
                             continue;
                         }
-                        ՐՏitr39 = ՐՏ_Iterable([ "body", "alternative" ]);
-                        for (ՐՏidx39 = 0; ՐՏidx39 < ՐՏitr39.length; ՐՏidx39++) {
-                            x = ՐՏitr39[ՐՏidx39];
-                            opt = obj[x];
+                        ՐՏitr42 = ՐՏ_Iterable([ "body", "alternative" ]);
+                        for (ՐՏidx42 = 0; ՐՏidx42 < ՐՏitr42.length; ՐՏidx42++) {
+                            x = ՐՏitr42[ՐՏidx42];
+                            opt = (ՐՏ_238 = obj)[x];
                             if (opt) {
                                 ans = ans.concat(scan_for_top_level_callables(opt));
                             }
@@ -4667,8 +4552,9 @@ var ՐՏ_modules = {};
             return statement(true);
         }
         
-        var statement = (ՐՏ_119 = function statement(expect_block) {
-            var tmp_, dir, stat, type, start, func, chain, result, ctor, expectedType, actualType, tmp;
+        var statement = (ՐՏ_239 = function statement(expect_block) {
+            var ՐՏ_240, ՐՏ_241, ՐՏ_242, ՐՏ_243, ՐՏ_244, ՐՏ_245, ՐՏ_246, ՐՏ_247, ՐՏ_248, ՐՏ_249;
+            var tmp_, dir, stat, type, start, func, chain, is_from, result, ctor, expectedType, actualType, tmp;
             if (is_("operator", "/") || is_("operator", "/=")) {
                 S.peeked = null;
                 S.token = S.input(S.token.value.slice(1));
@@ -4720,10 +4606,10 @@ var ՐՏ_modules = {};
                     type = S.token.value;
                     start = S.token.start;
                     next();
-                    if (!(S.in_scope[S.in_scope.length-1].type === "class")) {
+                    if (!((ՐՏ_240 = S.in_scope)[ՐՏ_240.length-1].type === "class")) {
                         croak("Getter/setter outside of class");
                     }
-                    return accessor_(type, start, S.in_scope[S.in_scope.length-1].name || true);
+                    return accessor_(type, start, (ՐՏ_241 = S.in_scope)[ՐՏ_241.length-1].name || true);
                 }
                 return tokenizer.is_token(peek(), "punc", ":") ? labeled_statement() : simple_statement();
             } else if (tmp_ === "keyword") {
@@ -4766,17 +4652,17 @@ var ՐՏ_modules = {};
                 } else if (tmp_ === "import") {
                     return import_(false);
                 } else if (tmp_ === "class") {
-                    ++BASELIB["extends"];
+                    ++(ՐՏ_242 = BASELIB)["extends"];
                     if (options.auto_bind) {
-                        ++BASELIB["rebind_all"];
+                        ++(ՐՏ_243 = BASELIB)["rebind_all"];
                     }
                     if (!options.es6) {
-                        ++BASELIB["with__name__"];
+                        ++(ՐՏ_244 = BASELIB)["with__name__"];
                     }
                     return class_();
                 } else if (tmp_ === "def") {
                     start = prev();
-                    func = function_(S.in_scope[S.in_scope.length-1].type === "class" ? S.in_scope[S.in_scope.length-1].name : false);
+                    func = function_((ՐՏ_245 = S.in_scope)[ՐՏ_245.length-1].type === "class" ? (ՐՏ_246 = S.in_scope)[ՐՏ_246.length-1].name : false);
                     func.start = start;
                     func.end = prev();
                     chain = subscripts(func, true);
@@ -4794,8 +4680,15 @@ var ՐՏ_modules = {};
                 } else if (tmp_ === "pass") {
                     semicolon();
                     return new ast.EmptyStatement();
+                } else if (tmp_ === "async") {
+                    is_from = false;
+                    if (S.token.type === "keyword" && (S.token.value === "import" || (is_from = S.token.value === "from"))) {
+                        next();
+                        return import_(is_from, true);
+                    }
+                    unexpected();
                 } else if (tmp_ === "return" || tmp_ === "yield") {
-                    if (S.in_scope[S.in_scope.length-1].type !== "function") {
+                    if ((ՐՏ_247 = S.in_scope)[ՐՏ_247.length-1].type !== "function") {
                         croak("'return' outside of function");
                     }
                     if (tmp_ === "yield") {
@@ -4814,8 +4707,8 @@ var ՐՏ_modules = {};
                             }()
                         });
                     }
-                    if (S.in_scope[S.in_scope.length-1].return_annotation) {
-                        expectedType = S.in_scope[S.in_scope.length-1].return_annotation.resolveType(S.in_scope);
+                    if ((ՐՏ_248 = S.in_scope)[ՐՏ_248.length-1].return_annotation) {
+                        expectedType = (ՐՏ_249 = S.in_scope)[ՐՏ_249.length-1].return_annotation.resolveType(S.in_scope);
                         actualType = result.resolveType(S.in_scope);
                         if (!(ՐՏ_in(actualType, [ expectedType, "?" ]))) {
                             croak("Type annotation states that function returns " + expectedType + ", actual returned type is " + actualType + "");
@@ -4859,7 +4752,7 @@ var ՐՏ_modules = {};
                     unexpected();
                 }
             }
-        }, ՐՏ_119 = embed_tokens(ՐՏ_119), ՐՏ_119);
+        }, ՐՏ_239 = embed_tokens(ՐՏ_239), ՐՏ_239);
         function labeled_statement() {
             var label, stat;
             label = as_symbol(ast.Label);
@@ -4930,14 +4823,14 @@ var ՐՏ_modules = {};
             unexpected();
         }
         function for_in(init, list_comp) {
-            var ՐՏitr40, ՐՏidx40, ՐՏupk1;
+            var ՐՏ_250, ՐՏitr43, ՐՏidx43, ՐՏupk1, ՐՏ_251;
             var lhs, obj, i, element, value;
-            lhs = init instanceof ast.Var ? init.definitions[0].name : null;
+            lhs = init instanceof ast.Var ? (ՐՏ_250 = init.definitions)[0].name : null;
             obj = expression(true);
             if (init instanceof ast.Array) {
-                ՐՏitr40 = ՐՏ_Iterable(enumerate(init.elements));
-                for (ՐՏidx40 = 0; ՐՏidx40 < ՐՏitr40.length; ՐՏidx40++) {
-                    ՐՏupk1 = ՐՏitr40[ՐՏidx40];
+                ՐՏitr43 = ՐՏ_Iterable(enumerate(init.elements));
+                for (ՐՏidx43 = 0; ՐՏidx43 < ՐՏitr43.length; ՐՏidx43++) {
+                    ՐՏupk1 = ՐՏitr43[ՐՏidx43];
                     i = ՐՏupk1[0];
                     element = ՐՏupk1[1];
                     value = null;
@@ -4955,7 +4848,7 @@ var ՐՏ_modules = {};
                 }
                 mark_local_assignment(init, value);
             }
-            ++BASELIB["iterable"];
+            ++(ՐՏ_251 = BASELIB)["iterable"];
             if (list_comp) {
                 return {
                     init: init,
@@ -4979,17 +4872,17 @@ var ՐՏ_modules = {};
             });
         }
         function get_class_in_scope(expr) {
-            var ՐՏitr41, ՐՏidx41, ՐՏitr42, ՐՏidx42;
+            var ՐՏ_252, ՐՏitr44, ՐՏidx44, ՐՏ_253, ՐՏ_254, ՐՏ_255, ՐՏitr45, ՐՏidx45, ՐՏ_256, ՐՏ_257, ՐՏ_258;
             var s, referenced_path, class_name;
             if (expr instanceof ast.SymbolRef) {
                 if (ՐՏ_in(expr.name, NATIVE_CLASSES)) {
-                    return NATIVE_CLASSES[expr.name];
+                    return (ՐՏ_252 = NATIVE_CLASSES)[expr.name];
                 }
-                ՐՏitr41 = ՐՏ_Iterable(range(S.in_scope.length - 1, -1, -1));
-                for (ՐՏidx41 = 0; ՐՏidx41 < ՐՏitr41.length; ՐՏidx41++) {
-                    s = ՐՏitr41[ՐՏidx41];
-                    if (ՐՏ_in(expr.name, S.in_scope[s].classes)) {
-                        return S.in_scope[s].classes[expr.name];
+                ՐՏitr44 = ՐՏ_Iterable(range(S.in_scope.length - 1, -1, -1));
+                for (ՐՏidx44 = 0; ՐՏidx44 < ՐՏitr44.length; ՐՏidx44++) {
+                    s = ՐՏitr44[ՐՏidx44];
+                    if (ՐՏ_in(expr.name, (ՐՏ_253 = S.in_scope)[s].classes)) {
+                        return (ՐՏ_254 = (ՐՏ_255 = S.in_scope)[s].classes)[expr.name];
                     }
                 }
             } else if (expr instanceof ast.Dot) {
@@ -5002,11 +4895,11 @@ var ՐՏ_modules = {};
                     referenced_path.unshift(expr.name);
                     if (len(referenced_path) > 1) {
                         class_name = referenced_path.join(".");
-                        ՐՏitr42 = ՐՏ_Iterable(range(S.in_scope.length - 1, -1, -1));
-                        for (ՐՏidx42 = 0; ՐՏidx42 < ՐՏitr42.length; ՐՏidx42++) {
-                            s = ՐՏitr42[ՐՏidx42];
-                            if (ՐՏ_in(class_name, S.in_scope[s].classes)) {
-                                return S.in_scope[s].classes[class_name];
+                        ՐՏitr45 = ՐՏ_Iterable(range(S.in_scope.length - 1, -1, -1));
+                        for (ՐՏidx45 = 0; ՐՏidx45 < ՐՏitr45.length; ՐՏidx45++) {
+                            s = ՐՏitr45[ՐՏidx45];
+                            if (ՐՏ_in(class_name, (ՐՏ_256 = S.in_scope)[s].classes)) {
+                                return (ՐՏ_257 = (ՐՏ_258 = S.in_scope)[s].classes)[class_name];
                             }
                         }
                     }
@@ -5015,27 +4908,27 @@ var ՐՏ_modules = {};
             return false;
         }
         function do_import(key) {
-            var ՐՏitr44, ՐՏidx44, ՐՏupk3;
+            var ՐՏ_259, ՐՏ_260, ՐՏitr47, ՐՏidx47, ՐՏupk3, ՐՏ_261, ՐՏ_262, ՐՏ_263;
             var package_module_id, filename, src_code, modpath, location, data, msg, contents, subs;
             if (ՐՏ_in(key, IMPORTED)) {
                 return;
             }
-            if (IMPORTING[key]) {
+            if ((ՐՏ_259 = IMPORTING)[key]) {
                 throw new ImportError("Detected a recursive import of: " + key + " while importing: " + module_id, options.filename);
             }
             package_module_id = key.split(".").slice(0, -1).join(".");
-            if (len(package_module_id) > 0 && !IMPORTING[package_module_id]) {
+            if (len(package_module_id) > 0 && !(ՐՏ_260 = IMPORTING)[package_module_id]) {
                 do_import(package_module_id);
                 if (ՐՏ_in(key, IMPORTED)) {
                     return;
                 }
             }
             function safe_read(base_path) {
-                var ՐՏitr43, ՐՏidx43, ՐՏupk2;
+                var ՐՏitr46, ՐՏidx46, ՐՏupk2;
                 var i, path;
-                ՐՏitr43 = ՐՏ_Iterable(enumerate([ base_path + ".pyj", base_path + "/__init__.pyj" ]));
-                for (ՐՏidx43 = 0; ՐՏidx43 < ՐՏitr43.length; ՐՏidx43++) {
-                    ՐՏupk2 = ՐՏitr43[ՐՏidx43];
+                ՐՏitr46 = ՐՏ_Iterable(enumerate([ base_path + ".pyj", base_path + "/__init__.pyj" ]));
+                for (ՐՏidx46 = 0; ՐՏidx46 < ՐՏitr46.length; ՐՏidx46++) {
+                    ՐՏupk2 = ՐՏitr46[ՐՏidx46];
                     i = ՐՏupk2[0];
                     path = ՐՏupk2[1];
                     try {
@@ -5054,9 +4947,9 @@ var ՐՏ_modules = {};
             }
             src_code = filename = null;
             modpath = key.replace(/\./g, "/");
-            ՐՏitr44 = ՐՏ_Iterable(import_dirs);
-            for (ՐՏidx44 = 0; ՐՏidx44 < ՐՏitr44.length; ՐՏidx44++) {
-                location = ՐՏitr44[ՐՏidx44];
+            ՐՏitr47 = ՐՏ_Iterable(import_dirs);
+            for (ՐՏidx47 = 0; ՐՏidx47 < ՐՏitr47.length; ՐՏidx47++) {
+                location = ՐՏitr47[ՐՏidx47];
                 if (location) {
                     try {
                         ՐՏupk3 = safe_read(location + "/" + modpath);
@@ -5097,36 +4990,39 @@ var ՐՏ_modules = {};
                 dropDocstrings: options.dropDocstrings
             });
             if (len(package_module_id) > 0) {
-                subs = !IMPORTING[package_module_id] ? IMPORTED[package_module_id].submodules : PRE_IMPORTED[package_module_id].submodules;
+                subs = !(ՐՏ_261 = IMPORTING)[package_module_id] ? (ՐՏ_262 = IMPORTED)[package_module_id].submodules : (ՐՏ_263 = PRE_IMPORTED)[package_module_id].submodules;
                 if (!(ՐՏ_in(key, subs))) {
                     subs.push(key);
                 }
             }
         }
-        function import_(from_import) {
-            var ՐՏitr45, ՐՏidx45, ՐՏitr46, ՐՏidx46, ՐՏitr47, ՐՏidx47;
+        function import_(from_import, async_import) {
+            var ՐՏ_264, ՐՏ_265, ՐՏ_266, ՐՏitr48, ՐՏ_268, ՐՏidx48, ՐՏ_269, ՐՏ_270, ՐՏ_271, ՐՏ_272, ՐՏ_273, ՐՏitr49, ՐՏidx49, ՐՏ_275, ՐՏ_276, ՐՏ_277, ՐՏitr50, ՐՏidx50, ՐՏ_278, ՐՏ_279, ՐՏ_280;
             var ans, imp_with, package_pref, name, tmp, key, alias, imp, from_pack_imp, cur_imported, argnames, from_pack_module_names, aname, classes, argvar, obj, mod_name;
             ans = new ast.Imports({
-                "imports": []
+                "imports": [],
+                "async": async_import
             });
             imp_with = null;
             while (true) {
                 package_pref = "";
-                if ((options.filename || "").endsWith("/__init__.pyj")) {
-                    package_pref = options.module_id + ".";
-                    if (!PRE_IMPORTED[options.module_id]) {
-                        PRE_IMPORTED[options.module_id] = {
-                            submodules: []
-                        };
+                if (!async_import) {
+                    if (!async_import && (options.filename || "").endsWith("/__init__.pyj")) {
+                        package_pref = options.module_id + ".";
+                        if (!(ՐՏ_264 = PRE_IMPORTED)[options.module_id]) {
+                            (ՐՏ_265 = PRE_IMPORTED)[options.module_id] = {
+                                submodules: []
+                            };
+                        }
                     }
-                }
-                if (is_("punc", ".")) {
-                    if (!package_pref) {
-                        package_pref = (/^(.+?\.)[^\.]+$/.exec(options.module_id || "") || [ "", "" ])[1];
+                    if (is_("punc", ".")) {
+                        if (!package_pref) {
+                            package_pref = (ՐՏ_266 = (/^(.+?\.)[^\.]+$/.exec(options.module_id || "") || [ "", "" ]))[1];
+                        }
+                        next();
+                    } else {
+                        package_pref = "";
                     }
-                    next();
-                } else {
-                    package_pref = "";
                 }
                 tmp = name = expression(false);
                 key = "";
@@ -5166,9 +5062,12 @@ var ՐՏ_modules = {};
                     "key": key,
                     "alias": alias,
                     "argnames": null,
-                    "body": function() {
-                        return IMPORTED[key];
-                    }
+                    "body": function(_) {
+                        return function() {
+                            var ՐՏ_267;
+                            return (ՐՏ_267 = IMPORTED)[_];
+                        };
+                    }(key)
                 });
                 ans.imports.push(imp);
                 if (from_import) {
@@ -5181,12 +5080,27 @@ var ՐՏ_modules = {};
                 }
             }
             from_pack_imp = [];
-            ՐՏitr45 = ՐՏ_Iterable(ans["imports"]);
-            for (ՐՏidx45 = 0; ՐՏidx45 < ՐՏitr45.length; ՐՏidx45++) {
-                imp = ՐՏitr45[ՐՏidx45];
-                do_import(imp.key);
-                depends_on[imp.key] = true;
-                cur_imported = IMPORTED[imp.key];
+            ՐՏitr48 = ՐՏ_Iterable((ՐՏ_268 = ans)["imports"]);
+            for (ՐՏidx48 = 0; ՐՏidx48 < ՐՏitr48.length; ՐՏidx48++) {
+                imp = ՐՏitr48[ՐՏidx48];
+                if (!async_import) {
+                    do_import(imp.key);
+                } else {
+                    (ՐՏ_269 = IMPORTED)[imp.key] = new ast.TopLevel({
+                        imports: {},
+                        nonlocalvars: [],
+                        module_id: imp.key,
+                        exports: [],
+                        submodules: [],
+                        classes: [],
+                        filename: null,
+                        async: true
+                    });
+                    (ՐՏ_270 = IMPORTED)[imp.key].localvars = [];
+                    (ՐՏ_271 = IMPORTED)[imp.key].body = [];
+                }
+                (ՐՏ_272 = depends_on)[imp.key] = true;
+                cur_imported = async_import ? null : (ՐՏ_273 = IMPORTED)[imp.key];
                 argnames = [];
                 if (from_import) {
                     expect_token("keyword", "import");
@@ -5197,7 +5111,7 @@ var ՐՏ_modules = {};
                             unexpected();
                         }
                         name = S.token.value;
-                        if (cur_imported.is_package && !cur_imported.exports.find(function(it) {
+                        if (cur_imported && cur_imported.is_package && !cur_imported.exports.find(function(it) {
                             return it.name === name;
                         })) {
                             key = imp.key + "." + name;
@@ -5207,7 +5121,8 @@ var ՐՏ_modules = {};
                                 "alias": new_symbol(ast.SymbolAlias, name),
                                 "argnames": null,
                                 "body": function() {
-                                    return IMPORTED[key];
+                                    var ՐՏ_274;
+                                    return (ՐՏ_274 = IMPORTED)[key];
                                 }
                             });
                             from_pack_imp.push(aname);
@@ -5227,34 +5142,38 @@ var ՐՏ_modules = {};
                             break;
                         }
                     }
-                    classes = cur_imported.classes;
-                    ՐՏitr46 = ՐՏ_Iterable(argnames);
-                    for (ՐՏidx46 = 0; ՐՏidx46 < ՐՏitr46.length; ՐՏidx46++) {
-                        argvar = ՐՏitr46[ՐՏidx46];
-                        obj = classes[argvar.name];
-                        if (obj) {
-                            key = argvar.alias ? argvar.alias.name : argvar.name;
-                            S.in_scope[S.in_scope.length-1].classes[key] = {
-                                "static": obj.static,
-                                "bound": obj.bound
-                            };
+                    if (cur_imported) {
+                        classes = cur_imported.classes;
+                        ՐՏitr49 = ՐՏ_Iterable(argnames);
+                        for (ՐՏidx49 = 0; ՐՏidx49 < ՐՏitr49.length; ՐՏidx49++) {
+                            argvar = ՐՏitr49[ՐՏidx49];
+                            obj = (ՐՏ_275 = classes)[argvar.name];
+                            if (obj) {
+                                key = argvar.alias ? argvar.alias.name : argvar.name;
+                                (ՐՏ_276 = (ՐՏ_277 = S.in_scope)[ՐՏ_277.length-1].classes)[key] = {
+                                    "static": obj.static,
+                                    "bound": obj.bound
+                                };
+                            }
                         }
                     }
-                    ՐՏitr47 = ՐՏ_Iterable(from_pack_module_names);
-                    for (ՐՏidx47 = 0; ՐՏidx47 < ՐՏitr47.length; ՐՏidx47++) {
-                        mod_name = ՐՏitr47[ՐՏidx47];
-                        Object.assign(S.in_scope[S.in_scope.length - 1].classes, IMPORTED[mod_name.key].top_classes(mod_name.alias.name));
+                    ՐՏitr50 = ՐՏ_Iterable(from_pack_module_names);
+                    for (ՐՏidx50 = 0; ՐՏidx50 < ՐՏitr50.length; ՐՏidx50++) {
+                        mod_name = ՐՏitr50[ՐՏidx50];
+                        Object.assign((ՐՏ_278 = S.in_scope)[S.in_scope.length - 1].classes, (ՐՏ_279 = IMPORTED)[mod_name.key].top_classes(mod_name.alias.name));
                     }
                 } else {
                     key = imp.alias ? imp.alias.name : imp.key;
-                    Object.assign(S.in_scope[S.in_scope.length - 1].classes, cur_imported.top_classes(key));
+                    if (cur_imported) {
+                        Object.assign((ՐՏ_280 = S.in_scope)[S.in_scope.length - 1].classes, cur_imported.top_classes(key));
+                    }
                 }
             }
             [].push.apply(ans.imports, from_pack_imp);
             return ans;
         }
         function class_() {
-            var ՐՏitr50, ՐՏidx50;
+            var ՐՏ_287, ՐՏitr53, ՐՏidx53, ՐՏ_294, ՐՏ_295;
             var start, name, externaldecorator, class_details, parent, docstring, definition, i, stmt, class_vars_names, visitor;
             start = prev();
             name = as_symbol(ast.SymbolClass);
@@ -5293,6 +5212,7 @@ var ՐՏ_modules = {};
                 name: name,
                 module_id: module_id,
                 parent: function() {
+                    var ՐՏ_281, ՐՏ_282;
                     var atom, parent_details;
                     if (is_("punc", "(")) {
                         next();
@@ -5304,7 +5224,7 @@ var ՐՏ_modules = {};
                         atom = expr_atom(false);
                         expect(")");
                         parent = stringifyName(atom);
-                        if (parent && (parent_details = S.in_scope[S.in_scope.length-1].classes[parent])) {
+                        if (parent && (parent_details = (ՐՏ_281 = (ՐՏ_282 = S.in_scope)[ՐՏ_282.length-1].classes)[parent])) {
                             [].push.apply(class_details.static, parent_details.static);
                         }
                         return atom;
@@ -5318,14 +5238,14 @@ var ՐՏ_modules = {};
                 bound: class_details.bound,
                 statements: [],
                 decorators: function() {
-                    var ՐՏitr48, ՐՏidx48;
+                    var ՐՏitr51, ՐՏidx51, ՐՏ_283;
                     var d, decorator;
                     d = [];
-                    ՐՏitr48 = ՐՏ_Iterable(S.decorators);
-                    for (ՐՏidx48 = 0; ՐՏidx48 < ՐՏitr48.length; ՐՏidx48++) {
-                        decorator = ՐՏitr48[ՐՏidx48];
+                    ՐՏitr51 = ՐՏ_Iterable(S.decorators);
+                    for (ՐՏidx51 = 0; ՐՏidx51 < ՐՏitr51.length; ՐՏidx51++) {
+                        decorator = ՐՏitr51[ՐՏidx51];
                         if (decorator === "kwargs") {
-                            ++BASELIB["kwargs"];
+                            ++(ՐՏ_283 = BASELIB)["kwargs"];
                         }
                         d.push(new ast.Decorator({
                             expression: decorator
@@ -5335,8 +5255,9 @@ var ՐՏ_modules = {};
                     return d;
                 }(),
                 body: function(loop, labels) {
+                    var ՐՏ_284, ՐՏ_285, ՐՏ_286;
                     var a;
-                    S.in_scope[S.in_scope.length-1].classes[name.name] = class_details;
+                    (ՐՏ_284 = (ՐՏ_285 = S.in_scope)[ՐՏ_285.length-1].classes)[name.name] = class_details;
                     S.in_scope.push({
                         type: "class",
                         name: name.name,
@@ -5350,7 +5271,7 @@ var ՐՏ_modules = {};
                     S.in_loop = 0;
                     S.labels = [];
                     a = block_();
-                    docstring = S.in_scope[S.in_scope.length-1].docstring;
+                    docstring = (ՐՏ_286 = S.in_scope)[ՐՏ_286.length-1].docstring;
                     S.in_scope.pop();
                     S.in_loop = loop;
                     S.labels = labels;
@@ -5360,7 +5281,7 @@ var ՐՏ_modules = {};
                 end: prev()
             });
             for (i in definition.body) {
-                stmt = definition.body[i];
+                stmt = (ՐՏ_287 = definition.body)[i];
                 if (stmt instanceof ast.Method && stmt.name.name === "__init__") {
                     definition.init = stmt;
                     break;
@@ -5369,21 +5290,21 @@ var ՐՏ_modules = {};
             class_vars_names = {};
             function walker() {
                 this._visit = function(node, descend) {
-                    var ՐՏitr49, ՐՏidx49;
+                    var ՐՏ_288, ՐՏ_289, ՐՏitr52, ՐՏidx52, ՐՏ_290, ՐՏ_291, ՐՏ_292, ՐՏ_293;
                     var child;
                     if (node instanceof ast.Method) {
-                        class_vars_names[node.name.name] = true;
+                        (ՐՏ_288 = class_vars_names)[node.name.name] = true;
                         return;
                     } else if (node instanceof ast.Assign && node.left instanceof ast.SymbolRef) {
-                        class_vars_names[node.left.name] = true;
+                        (ՐՏ_289 = class_vars_names)[node.left.name] = true;
                     }
-                    ՐՏitr49 = ՐՏ_Iterable(node);
-                    for (ՐՏidx49 = 0; ՐՏidx49 < ՐՏitr49.length; ՐՏidx49++) {
-                        child = ՐՏitr49[ՐՏidx49];
-                        if (node[child] instanceof ast.SymbolRef && Object.prototype.hasOwnProperty.call(class_vars_names, node[child].name)) {
-                            node[child] = new ast.SymbolClassRef({
+                    ՐՏitr52 = ՐՏ_Iterable(node);
+                    for (ՐՏidx52 = 0; ՐՏidx52 < ՐՏitr52.length; ՐՏidx52++) {
+                        child = ՐՏitr52[ՐՏidx52];
+                        if ((ՐՏ_290 = node)[child] instanceof ast.SymbolRef && Object.prototype.hasOwnProperty.call(class_vars_names, (ՐՏ_291 = node)[child].name)) {
+                            (ՐՏ_292 = node)[child] = new ast.SymbolClassRef({
                                 "class": name,
-                                "name": node[child].name
+                                "name": (ՐՏ_293 = node)[child].name
                             });
                         }
                     }
@@ -5393,21 +5314,22 @@ var ՐՏ_modules = {};
                 };
             }
             visitor = new walker();
-            ՐՏitr50 = ՐՏ_Iterable(definition.body);
-            for (ՐՏidx50 = 0; ՐՏidx50 < ՐՏitr50.length; ՐՏidx50++) {
-                stmt = ՐՏitr50[ՐՏidx50];
+            ՐՏitr53 = ՐՏ_Iterable(definition.body);
+            for (ՐՏidx53 = 0; ՐՏidx53 < ՐՏitr53.length; ՐՏidx53++) {
+                stmt = ՐՏitr53[ՐՏidx53];
                 if (!(stmt instanceof ast.Class) && !(stmt instanceof ast.Method)) {
                     stmt.walk(visitor);
                     definition.statements.push(stmt);
                 }
             }
             if (S.in_scope.length === 1) {
-                class_map[definition.name.name] = definition;
-                CLASS_MAP[definition.name.name] = definition;
+                (ՐՏ_294 = class_map)[definition.name.name] = definition;
+                (ՐՏ_295 = CLASS_MAP)[definition.name.name] = definition;
             }
             return definition;
         }
         function function_(in_class_or_xobject, ctor) {
+            var ՐՏ_296, ՐՏ_297, ՐՏ_298, ՐՏ_299, ՐՏ_300, ՐՏ_301, ՐՏ_311, ՐՏ_312, ՐՏ_313, ՐՏ_314;
             var in_xobject, in_class, start, is_accessor, name, generator, localvars, staticmethod, function_args, return_annotation, has_special_decorator, cls_details, docstring, callsSuper, superCall_expr, definition, arg, args;
             in_class = in_xobject = false;
             if (in_class_or_xobject) {
@@ -5433,7 +5355,7 @@ var ՐՏ_modules = {};
                     return has_simple_decorator(S.decorators, name);
                 };
                 if (in_class) {
-                    cls_details = S.in_scope[S.in_scope.length-2].classes[in_class];
+                    cls_details = (ՐՏ_296 = (ՐՏ_297 = S.in_scope)[ՐՏ_297.length-2].classes)[in_class];
                     if (has_special_decorator("staticmethod")) {
                         staticmethod = true;
                         if (!(ՐՏ_in(name.name, cls_details.static))) {
@@ -5443,8 +5365,8 @@ var ՐՏ_modules = {};
                         cls_details.pop_static(name.name);
                     }
                     if (has_special_decorator("bind") || name.name !== "__init__" && options.auto_bind) {
-                        ++BASELIB["bind"];
-                        S.in_scope[S.in_scope.length-2].classes[in_class].bound[name.name] = true;
+                        ++(ՐՏ_298 = BASELIB)["bind"];
+                        (ՐՏ_299 = (ՐՏ_300 = (ՐՏ_301 = S.in_scope)[ՐՏ_301.length-2].classes)[in_class].bound)[name.name] = true;
                     }
                 }
             }
@@ -5463,11 +5385,13 @@ var ՐՏ_modules = {};
                 start: start,
                 name: name,
                 argnames: function(a) {
+                    var ՐՏ_304;
                     var defaults, first, seen_names, val, expr;
                     defaults = {};
                     first = true;
                     seen_names = {};
                     function get_arg() {
+                        var ՐՏ_302, ՐՏ_303;
                         var name_token, name, ntok, annotation, sym;
                         if (Object.prototype.hasOwnProperty.call(seen_names, S.token.value)) {
                             token_error(prev(), "Can't repeat parameter names");
@@ -5480,7 +5404,7 @@ var ՐՏ_modules = {};
                             return null;
                         }
                         name_token = S.token;
-                        seen_names[name_token.value] = true;
+                        (ՐՏ_302 = seen_names)[name_token.value] = true;
                         name = maybe_keyword(name_token.value);
                         ntok = peek();
                         if (ntok.type === "punc" && ntok.value === ":") {
@@ -5506,7 +5430,7 @@ var ՐՏ_modules = {};
                             });
                             next();
                         }
-                        function_args[sym.name] = sym.annotation ? sym.annotation.resolveType(S.in_scope) : "?";
+                        (ՐՏ_303 = function_args)[sym.name] = sym.annotation ? sym.annotation.resolveType(S.in_scope) : "?";
                         return sym;
                     }
                     while (!is_("punc", ")")) {
@@ -5542,7 +5466,7 @@ var ՐՏ_modules = {};
                                 }
                                 val = prev().value;
                                 next();
-                                defaults[val] = expression(false);
+                                (ՐՏ_304 = defaults)[val] = expression(false);
                                 a.has_defaults = true;
                             } else {
                                 if (a.has_defaults) {
@@ -5565,12 +5489,12 @@ var ՐՏ_modules = {};
                     return a;
                 }([]),
                 decorators: S.in_decorator ? [] : function() {
-                    var ՐՏitr51, ՐՏidx51;
+                    var ՐՏitr54, ՐՏidx54;
                     var d, decorator;
                     d = [];
-                    ՐՏitr51 = ՐՏ_Iterable(S.decorators);
-                    for (ՐՏidx51 = 0; ՐՏidx51 < ՐՏitr51.length; ՐՏidx51++) {
-                        decorator = ՐՏitr51[ՐՏidx51];
+                    ՐՏitr54 = ՐՏ_Iterable(S.decorators);
+                    for (ՐՏidx54 = 0; ՐՏidx54 < ՐՏitr54.length; ՐՏidx54++) {
+                        decorator = ՐՏitr54[ՐՏidx54];
                         d.push(new ast.Decorator({
                             expression: decorator
                         }));
@@ -5580,6 +5504,7 @@ var ՐՏ_modules = {};
                 }(),
                 return_annotation: return_annotation,
                 body: function(loop, labels) {
+                    var ՐՏ_305, ՐՏ_306, ՐՏ_307, ՐՏ_308, ՐՏ_309, ՐՏ_310;
                     var a, variable;
                     S.in_scope.push({
                         type: "function",
@@ -5595,15 +5520,15 @@ var ՐՏ_modules = {};
                     S.in_loop = 0;
                     S.labels = [];
                     a = block_();
-                    generator = S.in_scope[S.in_scope.length-1].generator;
-                    docstring = S.in_scope[S.in_scope.length-1].docstring;
-                    callsSuper = S.in_scope[S.in_scope.length-1].callsSuper;
-                    superCall_expr = S.in_scope[S.in_scope.length-1].superCall_expr;
+                    generator = (ՐՏ_305 = S.in_scope)[ՐՏ_305.length-1].generator;
+                    docstring = (ՐՏ_306 = S.in_scope)[ՐՏ_306.length-1].docstring;
+                    callsSuper = (ՐՏ_307 = S.in_scope)[ՐՏ_307.length-1].callsSuper;
+                    superCall_expr = (ՐՏ_308 = S.in_scope)[ՐՏ_308.length-1].superCall_expr;
                     localvars = (function() {
-                        var ՐՏidx52, ՐՏitr52 = ՐՏ_Iterable(Object.keys(S.in_scope[S.in_scope.length-1].vars)), ՐՏres = [], variable;
-                        for (ՐՏidx52 = 0; ՐՏidx52 < ՐՏitr52.length; ՐՏidx52++) {
-                            variable = ՐՏitr52[ՐՏidx52];
-                            if (!(ՐՏ_in(variable, S.in_scope[S.in_scope.length-1].nonlocal))) {
+                        var ՐՏidx55, ՐՏitr55 = ՐՏ_Iterable(Object.keys((ՐՏ_309 = S.in_scope)[ՐՏ_309.length-1].vars)), ՐՏres = [], variable;
+                        for (ՐՏidx55 = 0; ՐՏidx55 < ՐՏitr55.length; ՐՏidx55++) {
+                            variable = ՐՏitr55[ՐՏidx55];
+                            if (!(ՐՏ_in(variable, (ՐՏ_310 = S.in_scope)[ՐՏ_310.length-1].nonlocal))) {
                                 ՐՏres.push(new_symbol(ast.SymbolVar, variable));
                             }
                         }
@@ -5621,12 +5546,12 @@ var ՐՏ_modules = {};
                 static: in_class && staticmethod
             });
             if (name) {
-                S.in_scope[S.in_scope.length-1].functions[name.name] = definition.resolveType(S.in_scope);
+                (ՐՏ_311 = (ՐՏ_312 = S.in_scope)[ՐՏ_312.length-1].functions)[name.name] = definition.resolveType(S.in_scope);
             }
             args = (function() {
-                var ՐՏidx53, ՐՏitr53 = ՐՏ_Iterable(definition.argnames), ՐՏres = [], arg;
-                for (ՐՏidx53 = 0; ՐՏidx53 < ՐՏitr53.length; ՐՏidx53++) {
-                    arg = ՐՏitr53[ՐՏidx53];
+                var ՐՏidx56, ՐՏitr56 = ՐՏ_Iterable(definition.argnames), ՐՏres = [], arg;
+                for (ՐՏidx56 = 0; ՐՏidx56 < ՐՏitr56.length; ՐՏidx56++) {
+                    arg = ՐՏitr56[ՐՏidx56];
                     ՐՏres.push(arg.name);
                 }
                 return ՐՏres;
@@ -5637,10 +5562,10 @@ var ՐՏ_modules = {};
             if (in_class_or_xobject && !staticmethod) {
                 if (in_class) {
                     if (ctor === ast.Constructor) {
-                        definition.parent = S.in_scope[S.in_scope.length-1].parent;
+                        definition.parent = (ՐՏ_313 = S.in_scope)[ՐՏ_313.length-1].parent;
                         definition.callsSuper = callsSuper;
                         if (superCall_expr) {
-                            superCall_expr.selfArg = definition.argnames[0];
+                            superCall_expr.selfArg = (ՐՏ_314 = definition.argnames)[0];
                         }
                     }
                 }
@@ -5689,41 +5614,43 @@ var ՐՏ_modules = {};
             });
         }
         function is_docstring(stmt) {
-            if (stmt instanceof ast.Directive && !S.in_scope[S.in_scope.length-1].docstring) {
+            var ՐՏ_315;
+            if (stmt instanceof ast.Directive && !(ՐՏ_315 = S.in_scope)[ՐՏ_315.length-1].docstring) {
                 return true;
             }
             return false;
         }
         function format_docstring(string) {
-            var ՐՏitr54, ՐՏidx54, ՐՏitr55, ՐՏidx55;
+            var ՐՏitr57, ՐՏidx57, ՐՏ_316, ՐՏ_317, ՐՏitr58, ՐՏidx58, ՐՏ_318, ՐՏ_319;
             var lines, indent, line, pad, trimmed;
             lines = string.split(/\n/g);
             indent = 1e6;
-            ՐՏitr54 = ՐՏ_Iterable(lines.slice(1));
-            for (ՐՏidx54 = 0; ՐՏidx54 < ՐՏitr54.length; ՐՏidx54++) {
-                line = ՐՏitr54[ՐՏidx54];
+            ՐՏitr57 = ՐՏ_Iterable(lines.slice(1));
+            for (ՐՏidx57 = 0; ՐՏidx57 < ՐՏitr57.length; ՐՏidx57++) {
+                line = ՐՏitr57[ՐՏidx57];
                 if (line.trim().length) {
-                    pad = line.match(/^\s*/)[0];
+                    pad = (ՐՏ_316 = line.match(/^\s*/))[0];
                     indent = Math.min(indent, pad.length);
                 }
             }
-            trimmed = [ lines[0].trim() ];
+            trimmed = [ (ՐՏ_317 = lines)[0].trim() ];
             if (indent < 1e6) {
-                ՐՏitr55 = ՐՏ_Iterable(lines.slice(1));
-                for (ՐՏidx55 = 0; ՐՏidx55 < ՐՏitr55.length; ՐՏidx55++) {
-                    line = ՐՏitr55[ՐՏidx55];
+                ՐՏitr58 = ՐՏ_Iterable(lines.slice(1));
+                for (ՐՏidx58 = 0; ՐՏidx58 < ՐՏitr58.length; ՐՏidx58++) {
+                    line = ՐՏitr58[ՐՏidx58];
                     trimmed.push(line.slice(indent).replace(/\s+$/));
                 }
             }
-            while (trimmed && !trimmed[trimmed.length-1]) {
+            while (trimmed && !(ՐՏ_318 = trimmed)[ՐՏ_318.length-1]) {
                 trimmed.pop();
             }
-            while (trimmed && !trimmed[0]) {
+            while (trimmed && !(ՐՏ_319 = trimmed)[0]) {
                 trimmed.shift();
             }
             return trimmed.join("\n");
         }
         function block_() {
+            var ՐՏ_320, ՐՏ_321;
             var a, stmt;
             expect(":");
             a = [];
@@ -5735,7 +5662,7 @@ var ՐՏ_modules = {};
                     stmt = statement();
                     if (!a.length && is_docstring(stmt)) {
                         if (!options.dropDocstrings) {
-                            S.in_scope[S.in_scope.length-1].docstring = format_docstring(stmt.value);
+                            (ՐՏ_320 = S.in_scope)[ՐՏ_320.length-1].docstring = format_docstring(stmt.value);
                         }
                     } else {
                         a.push(stmt);
@@ -5749,7 +5676,7 @@ var ՐՏ_modules = {};
                     stmt = statement();
                     if (!a.length && is_docstring(stmt)) {
                         if (!options.dropDocstrings) {
-                            S.in_scope[S.in_scope.length-1].docstring = format_docstring(stmt.value);
+                            (ՐՏ_321 = S.in_scope)[ՐՏ_321.length-1].docstring = format_docstring(stmt.value);
                         }
                     } else {
                         a.push(stmt);
@@ -5865,6 +5792,7 @@ var ՐՏ_modules = {};
             });
         }
         function vardefs(no_in, type) {
+            var ՐՏ_322, ՐՏ_323;
             var a, symbol;
             a = [];
             while (true) {
@@ -5874,7 +5802,7 @@ var ՐՏ_modules = {};
                     end: prev()
                 });
                 if (type === "nonlocal") {
-                    S.in_scope[S.in_scope.length-1].nonlocal[symbol.name.name] = true;
+                    (ՐՏ_322 = (ՐՏ_323 = S.in_scope)[ՐՏ_323.length-1].nonlocal)[symbol.name.name] = true;
                 }
                 a.push(symbol);
                 if (!is_("punc", ",")) {
@@ -5899,11 +5827,12 @@ var ՐՏ_modules = {};
             });
         }
         function yield_() {
+            var ՐՏ_324, ՐՏ_325;
             var value, yield_from, ret;
-            if (S.in_scope[S.in_scope.length-1].type !== "function") {
+            if ((ՐՏ_324 = S.in_scope)[ՐՏ_324.length-1].type !== "function") {
                 croak("'yield' outside of function");
             }
-            S.in_scope[S.in_scope.length-1].generator = true;
+            (ՐՏ_325 = S.in_scope)[ՐՏ_325.length-1].generator = true;
             value = null;
             yield_from = false;
             if (is_("punc", ";")) {
@@ -6020,6 +5949,7 @@ var ՐՏ_modules = {};
             return ret;
         }
         function expr_atom(allow_calls) {
+            var ՐՏ_326;
             var start, tmp_, ex, cls, func;
             if (is_("operator", "new")) {
                 return new_();
@@ -6061,13 +5991,13 @@ var ՐՏ_modules = {};
             if (is_("keyword", "yield")) {
                 return yield_request();
             }
-            if (ATOMIC_START_TOKEN[S.token.type]) {
+            if ((ՐՏ_326 = ATOMIC_START_TOKEN)[S.token.type]) {
                 return subscripts(as_atom_node(), allow_calls);
             }
             unexpected();
         }
         function expr_list(closing, allow_trailing_comma, allow_empty, func_call) {
-            var ՐՏitr56, ՐՏidx56, ՐՏupk4;
+            var ՐՏitr59, ՐՏidx59, ՐՏupk4, ՐՏ_327;
             var first, a, saw_starargs, tmp, i, arg;
             first = true;
             a = [];
@@ -6100,13 +6030,13 @@ var ՐՏ_modules = {};
             if (func_call) {
                 tmp = [];
                 tmp.kwargs = [];
-                ՐՏitr56 = ՐՏ_Iterable(enumerate(a));
-                for (ՐՏidx56 = 0; ՐՏidx56 < ՐՏitr56.length; ՐՏidx56++) {
-                    ՐՏupk4 = ՐՏitr56[ՐՏidx56];
+                ՐՏitr59 = ՐՏ_Iterable(enumerate(a));
+                for (ՐՏidx59 = 0; ՐՏidx59 < ՐՏitr59.length; ՐՏidx59++) {
+                    ՐՏupk4 = ՐՏitr59[ՐՏidx59];
                     i = ՐՏupk4[0];
                     arg = ՐՏupk4[1];
                     if (arg instanceof ast.Assign) {
-                        ++BASELIB["kwargs"];
+                        ++(ՐՏ_327 = BASELIB)["kwargs"];
                         tmp.kwargs.push([ arg.left, arg.right ]);
                     } else {
                         tmp.push(arg);
@@ -6121,6 +6051,7 @@ var ՐՏ_modules = {};
             return a;
         }
         function func_call_list() {
+            var ՐՏ_328, ՐՏ_329;
             var a, first, kwargs, arg;
             a = [];
             first = true;
@@ -6140,13 +6071,13 @@ var ՐՏ_modules = {};
                     a.push(arg);
                     a.starargs = true;
                 } else if (is_("operator", "**")) {
-                    ++BASELIB["kwargs"];
+                    ++(ՐՏ_328 = BASELIB)["kwargs"];
                     next();
                     kwargs.push(as_symbol(ast.SymbolVar, false));
                 } else {
                     arg = expression(false);
                     if (arg instanceof ast.Assign) {
-                        ++BASELIB["kwargs"];
+                        ++(ՐՏ_329 = BASELIB)["kwargs"];
                         a.kwargs.push([ arg.left, arg.right ]);
                     } else {
                         a.push(arg);
@@ -6157,11 +6088,12 @@ var ՐՏ_modules = {};
             return a;
         }
         function read_comprehension(object) {
+            var ՐՏ_330;
             var terminator, forloop;
             terminator = object instanceof ast.DictComprehension ? "}" : "]";
             expect_token("keyword", "for");
             forloop = for_(true);
-            ++BASELIB["iterable"];
+            ++(ՐՏ_330 = BASELIB)["iterable"];
             object.init = forloop.init;
             object.name = forloop.name;
             object.object = forloop.object;
@@ -6171,7 +6103,8 @@ var ՐՏ_modules = {};
             return object;
         }
         
-        var array_ = (ՐՏ_120 = function array_() {
+        var array_ = (ՐՏ_331 = function array_() {
+            var ՐՏ_332, ՐՏ_333, ՐՏ_334, ՐՏ_335, ՐՏ_336, ՐՏ_337, ՐՏ_338;
             var expr, ret;
             expect("[");
             expr = [];
@@ -6179,31 +6112,31 @@ var ՐՏ_modules = {};
                 expr.push(expression(false));
                 if (is_("keyword", "for")) {
                     return read_comprehension(new ast.ListComprehension({
-                        statement: expr[0]
+                        statement: (ՐՏ_332 = expr)[0]
                     }));
                 }
                 if (is_("operator", "til")) {
-                    ++BASELIB["range"];
+                    ++(ՐՏ_333 = BASELIB)["range"];
                     next();
                     expr.push(expression(false));
                     ret = new ast.Range({
                         start: S.token,
-                        left: expr[0],
+                        left: (ՐՏ_334 = expr)[0],
                         operator: "til",
-                        right: expr[1],
+                        right: (ՐՏ_335 = expr)[1],
                         end: prev()
                     });
                     expect("]");
                     return ret;
                 } else if (is_("operator", "to")) {
-                    ++BASELIB["range"];
+                    ++(ՐՏ_336 = BASELIB)["range"];
                     next();
                     expr.push(expression(false));
                     ret = new ast.Range({
                         start: S.token,
-                        left: expr[0],
+                        left: (ՐՏ_337 = expr)[0],
                         operator: "to",
-                        right: expr[1],
+                        right: (ՐՏ_338 = expr)[1],
                         end: prev()
                     });
                     expect("]");
@@ -6215,9 +6148,10 @@ var ՐՏ_modules = {};
             return new ast.Array({
                 elements: expr.concat(expr_list("]", !options.strict, true))
             });
-        }, ՐՏ_120 = embed_tokens(ՐՏ_120), ՐՏ_120);
+        }, ՐՏ_331 = embed_tokens(ՐՏ_331), ՐՏ_331);
         
-        var object_ = (ՐՏ_121 = function object_() {
+        var object_ = (ՐՏ_339 = function object_() {
+            var ՐՏ_340, ՐՏ_341;
             var maybe_dict_comprehension, must_be_comprehension, first, a, start, type, fun_type, value, key, name, key_;
             maybe_dict_comprehension = false;
             must_be_comprehension = false;
@@ -6326,8 +6260,8 @@ var ՐՏ_modules = {};
                 }));
                 if (first && is_("keyword", "for")) {
                     return read_comprehension(new ast.DictComprehension({
-                        statement: maybe_dict_comprehension ? key : as_atom_node(a[0].start),
-                        value_statement: a[0].value
+                        statement: maybe_dict_comprehension ? key : as_atom_node((ՐՏ_340 = a)[0].start),
+                        value_statement: (ՐՏ_341 = a)[0].value
                     }));
                 } else if (must_be_comprehension) {
                     unexpected();
@@ -6338,7 +6272,7 @@ var ՐՏ_modules = {};
             return new ast.ObjectLiteral({
                 properties: a
             });
-        }, ՐՏ_121 = embed_tokens(ՐՏ_121), ՐՏ_121);
+        }, ՐՏ_339 = embed_tokens(ՐՏ_339), ՐՏ_339);
         function as_property_name() {
             var tmp, tmp_;
             tmp = S.token;
@@ -6418,6 +6352,7 @@ var ՐՏ_modules = {};
             }
         }
         function mark_local_assignment(element, value) {
+            var ՐՏ_342, ՐՏ_343, ՐՏ_344, ՐՏ_345, ՐՏ_346;
             var computedType, name;
             if (value) {
                 computedType = typeof value === "string" ? value : value.resolveType(S.in_scope);
@@ -6426,14 +6361,15 @@ var ՐՏ_modules = {};
             }
             name = typeof element === "string" ? element : element.name;
             if (name) {
-                if (ՐՏ_in(name, S.in_scope[S.in_scope.length-1].vars)) {
-                    S.in_scope[S.in_scope.length-1].vars[name].push(computedType);
+                if (ՐՏ_in(name, (ՐՏ_342 = S.in_scope)[ՐՏ_342.length-1].vars)) {
+                    (ՐՏ_343 = (ՐՏ_344 = S.in_scope)[ՐՏ_344.length-1].vars)[name].push(computedType);
                 } else {
-                    S.in_scope[S.in_scope.length-1].vars[name] = [ computedType ];
+                    (ՐՏ_345 = (ՐՏ_346 = S.in_scope)[ՐՏ_346.length-1].vars)[name] = [ computedType ];
                 }
             }
         }
         function subscripts(expr, allow_calls) {
+            var ՐՏ_347, ՐՏ_348, ՐՏ_349, ՐՏ_350, ՐՏ_351, ՐՏ_352, ՐՏ_353, ՐՏ_354, ՐՏ_355, ՐՏ_356, ՐՏ_357, ՐՏ_358, ՐՏ_359, ՐՏ_360, ՐՏ_361, ՐՏ_362, ՐՏ_363, ՐՏ_364, ՐՏ_365;
             var start, slice_bounds, is_slice, i, str_, ret, className, funcname, is_super, ast_ClassCall, tmp_, args;
             start = expr.start;
             if (is_("punc", ".")) {
@@ -6464,7 +6400,7 @@ var ՐՏ_modules = {};
                     }
                 }
                 if (is_("punc", ":")) {
-                    ++BASELIB["eslice"];
+                    ++(ՐՏ_347 = BASELIB)["eslice"];
                     next();
                     if (is_("punc", "]")) {
                         unexpected();
@@ -6479,22 +6415,22 @@ var ՐՏ_modules = {};
                         return subscripts(new ast.Slice({
                             start: start,
                             expression: expr,
-                            property: slice_bounds[0] || new ast.Number({
+                            property: (ՐՏ_348 = slice_bounds)[0] || new ast.Number({
                                 value: 0
                             }),
-                            property2: slice_bounds[1],
+                            property2: (ՐՏ_349 = slice_bounds)[1],
                             assignment: expression(true),
                             end: prev()
                         }), allow_calls);
                     } else if (slice_bounds.length === 3) {
                         slice_bounds.unshift(slice_bounds.pop());
-                        if (!slice_bounds[slice_bounds.length-1]) {
+                        if (!(ՐՏ_350 = slice_bounds)[ՐՏ_350.length-1]) {
                             slice_bounds.pop();
-                            if (!slice_bounds[slice_bounds.length-1]) {
+                            if (!(ՐՏ_351 = slice_bounds)[ՐՏ_351.length-1]) {
                                 slice_bounds.pop();
                             }
-                        } else if (!slice_bounds[slice_bounds.length-2]) {
-                            slice_bounds[slice_bounds.length-2] = new ast.Undefined();
+                        } else if (!(ՐՏ_352 = slice_bounds)[ՐՏ_352.length-2]) {
+                            (ՐՏ_353 = slice_bounds)[ՐՏ_353.length-2] = new ast.Undefined();
                         }
                         return subscripts(new ast.Call({
                             start: start,
@@ -6506,9 +6442,9 @@ var ՐՏ_modules = {};
                         }), allow_calls);
                     } else {
                         slice_bounds = (function() {
-                            var ՐՏidx57, ՐՏitr57 = ՐՏ_Iterable(slice_bounds), ՐՏres = [], i;
-                            for (ՐՏidx57 = 0; ՐՏidx57 < ՐՏitr57.length; ՐՏidx57++) {
-                                i = ՐՏitr57[ՐՏidx57];
+                            var ՐՏidx60, ՐՏitr60 = ՐՏ_Iterable(slice_bounds), ՐՏres = [], i;
+                            for (ՐՏidx60 = 0; ՐՏidx60 < ՐՏitr60.length; ՐՏidx60++) {
+                                i = ՐՏitr60[ՐՏidx60];
                                 ՐՏres.push(i === null ? new ast.Number({
                                     value: 0
                                 }) : i);
@@ -6531,7 +6467,7 @@ var ՐՏ_modules = {};
                     return subscripts(new ast.Sub({
                         start: start,
                         expression: expr,
-                        property: slice_bounds[0] || new ast.Number({
+                        property: (ՐՏ_354 = slice_bounds)[0] || new ast.Number({
                             value: 0
                         }),
                         end: prev()
@@ -6554,9 +6490,9 @@ var ՐՏ_modules = {};
                     return subscripts(ret, true);
                 } else if (!expr.parens && get_class_in_scope(expr)) {
                     if (ՐՏ_in(expr.name, STDLIB)) {
-                        ++BASELIB[expr.name];
+                        ++(ՐՏ_355 = BASELIB)[expr.name];
                         if (/Error$/.test(expr.name)) {
-                            ++BASELIB["extends"];
+                            ++(ՐՏ_356 = BASELIB)["extends"];
                         }
                     }
                     return subscripts(new ast.New({
@@ -6574,8 +6510,8 @@ var ՐՏ_modules = {};
                         if (funcname.property === "__init__") {
                             funcname.property = "constructor";
                         }
-                        is_super = S.in_scope.length > 1 && S.in_scope[S.in_scope.length-2].type === "class" && stringifyName(expr.expression) === S.in_scope[S.in_scope.length-2].parent;
-                        S.in_scope[S.in_scope.length-1].callsSuper = S.in_scope[S.in_scope.length-1].callsSuper || is_super;
+                        is_super = S.in_scope.length > 1 && (ՐՏ_357 = S.in_scope)[ՐՏ_357.length-2].type === "class" && stringifyName(expr.expression) === (ՐՏ_358 = S.in_scope)[ՐՏ_358.length-2].parent;
+                        (ՐՏ_359 = S.in_scope)[ՐՏ_359.length-1].callsSuper = (ՐՏ_360 = S.in_scope)[ՐՏ_360.length-1].callsSuper || is_super;
                         ast_ClassCall = new ast.ClassCall({
                             start: start,
                             class: expr.expression,
@@ -6596,7 +6532,7 @@ var ՐՏ_modules = {};
                     } else if (expr instanceof ast.SymbolRef) {
                         tmp_ = expr.name;
                         if (ՐՏ_in(tmp_, STDLIB)) {
-                            ++BASELIB[tmp_];
+                            ++(ՐՏ_361 = BASELIB)[tmp_];
                         } else if (tmp_ === "isinstance") {
                             args = func_call_list();
                             if (args.length !== 2) {
@@ -6605,13 +6541,13 @@ var ՐՏ_modules = {};
                             return new ast.Binary({
                                 start: start,
                                 operator: "instanceof",
-                                left: args[0],
-                                right: args[1],
+                                left: (ՐՏ_362 = args)[0],
+                                right: (ՐՏ_363 = args)[1],
                                 end: prev()
                             });
                         } else if (tmp_ === "super") {
-                            S.in_scope[S.in_scope.length-1].callsSuper = true;
-                            S.in_scope[S.in_scope.length-1].superCall_expr = expr;
+                            (ՐՏ_364 = S.in_scope)[ՐՏ_364.length-1].callsSuper = true;
+                            (ՐՏ_365 = S.in_scope)[ՐՏ_365.length-1].superCall_expr = expr;
                         } else {
                             expr.name = maybe_keyword(expr.name);
                         }
@@ -6705,22 +6641,23 @@ var ՐՏ_modules = {};
             }));
         }
         function validateBinary(astElement) {
+            var ՐՏ_366, ՐՏ_367, ՐՏ_368, ՐՏ_369;
             var left, right, op;
             left = astElement.left.resolveType(S.in_scope);
             right = astElement.right.resolveType(S.in_scope);
             op = astElement.operator;
             if (!(ՐՏ_in(op, [ "in", "instanceof", "==", "!=", "===", "!==", "||", "&&", "=" ])) && (!(ՐՏ_in(left, [ "Number", "String", "Boolean", "?" ])) || !(ՐՏ_in(right, [ "Number", "String", "Boolean", "?" ])) || (left === "String" || right === "String") && (left === right ? !(ՐՏ_in(op, [ "+", "+=", "<", "<=", ">", ">=" ])) : !(ՐՏ_in(op, [ "+", "+=" ]))))) {
                 if (left) {
-                    if (left[0] === "[") {
+                    if ((ՐՏ_366 = left)[0] === "[") {
                         left = "Array";
-                    } else if (left[0] === "{") {
+                    } else if ((ՐՏ_367 = left)[0] === "{") {
                         left = "Object";
                     }
                 }
                 if (right) {
-                    if (right[0] === "[") {
+                    if ((ՐՏ_368 = right)[0] === "[") {
                         right = "Array";
-                    } else if (right[0] === "{") {
+                    } else if ((ՐՏ_369 = right)[0] === "{") {
                         right = "Object";
                     }
                 }
@@ -6729,6 +6666,7 @@ var ՐՏ_modules = {};
             return astElement;
         }
         function validateUnary(astElement) {
+            var ՐՏ_370, ՐՏ_371, ՐՏ_372;
             var element, op;
             element = astElement.expression.resolveType(S.in_scope);
             op = astElement.operator;
@@ -6736,10 +6674,10 @@ var ՐՏ_modules = {};
                 if (op !== "!") {
                     throw croak("cannot perform unary '" + op + "' operation on incompatible element of type " + element);
                 }
-            } else if (!(ՐՏ_in(element, [ "Number", "?" ])) && ՐՏ_in(op, [ "+", "-" ]) || !(ՐՏ_in(element[0], [ "[", "{", "?" ])) && op === "*") {
-                if (element[0] === "[") {
+            } else if (!(ՐՏ_in(element, [ "Number", "?" ])) && ՐՏ_in(op, [ "+", "-" ]) || !(ՐՏ_in((ՐՏ_370 = element)[0], [ "[", "{", "?" ])) && op === "*") {
+                if ((ՐՏ_371 = element)[0] === "[") {
                     element = "Array";
-                } else if (element[0] === "{") {
+                } else if ((ՐՏ_372 = element)[0] === "{") {
                     element = "Object";
                 }
                 throw croak("cannot perform unary '" + op + "' operation on incompatible element of type " + element);
@@ -6747,28 +6685,28 @@ var ՐՏ_modules = {};
             return astElement;
         }
         function validateCallArgs(astElement) {
-            var ՐՏitr58, ՐՏidx58, ՐՏitr59, ՐՏidx59, ՐՏitr60, ՐՏidx60, ՐՏitr61, ՐՏidx61, ՐՏupk5;
+            var ՐՏitr61, ՐՏidx61, ՐՏitr62, ՐՏidx62, ՐՏ_373, ՐՏitr63, ՐՏidx63, ՐՏ_374, ՐՏ_375, ՐՏ_376, ՐՏitr64, ՐՏidx64, ՐՏupk5, ՐՏ_377;
             var name, found, scope, func, signature, variable, args, i, arg, expected, actual;
             if (astElement.expression instanceof ast.SymbolRef) {
                 name = astElement.expression.name;
                 found = false;
-                ՐՏitr58 = ՐՏ_Iterable(reversed(S.in_scope));
-                for (ՐՏidx58 = 0; ՐՏidx58 < ՐՏitr58.length; ՐՏidx58++) {
-                    scope = ՐՏitr58[ՐՏidx58];
-                    ՐՏitr59 = ՐՏ_Iterable(scope.functions);
-                    for (ՐՏidx59 = 0; ՐՏidx59 < ՐՏitr59.length; ՐՏidx59++) {
-                        func = ՐՏitr59[ՐՏidx59];
+                ՐՏitr61 = ՐՏ_Iterable(reversed(S.in_scope));
+                for (ՐՏidx61 = 0; ՐՏidx61 < ՐՏitr61.length; ՐՏidx61++) {
+                    scope = ՐՏitr61[ՐՏidx61];
+                    ՐՏitr62 = ՐՏ_Iterable(scope.functions);
+                    for (ՐՏidx62 = 0; ՐՏidx62 < ՐՏitr62.length; ՐՏidx62++) {
+                        func = ՐՏitr62[ՐՏidx62];
                         if (func === name) {
-                            signature = scope.functions[func];
+                            signature = (ՐՏ_373 = scope.functions)[func];
                             found = true;
                             break;
                         }
                     }
-                    ՐՏitr60 = ՐՏ_Iterable(scope.vars);
-                    for (ՐՏidx60 = 0; ՐՏidx60 < ՐՏitr60.length; ՐՏidx60++) {
-                        variable = ՐՏitr60[ՐՏidx60];
+                    ՐՏitr63 = ՐՏ_Iterable(scope.vars);
+                    for (ՐՏidx63 = 0; ՐՏidx63 < ՐՏitr63.length; ՐՏidx63++) {
+                        variable = ՐՏitr63[ՐՏidx63];
                         if (variable === name) {
-                            signature = scope.vars[func];
+                            signature = (ՐՏ_374 = scope.vars)[func];
                             found = true;
                             break;
                         }
@@ -6778,19 +6716,19 @@ var ՐՏ_modules = {};
                     }
                 }
                 if (signature && signature.slice(0, 9) === "Function(") {
-                    args = /\((.*)\)/.exec(signature)[1].split(",");
-                    if (args.length === 1 && !args[0].length) {
+                    args = (ՐՏ_375 = /\((.*)\)/.exec(signature))[1].split(",");
+                    if (args.length === 1 && !(ՐՏ_376 = args)[0].length) {
                         args.pop();
                     }
                     if (args.length < astElement.args.length) {
                         croak("Function '" + name + "' takes " + args.length + " arguments, yet your call contains " + astElement.args.length + "");
                     }
-                    ՐՏitr61 = ՐՏ_Iterable(enumerate(astElement.args));
-                    for (ՐՏidx61 = 0; ՐՏidx61 < ՐՏitr61.length; ՐՏidx61++) {
-                        ՐՏupk5 = ՐՏitr61[ՐՏidx61];
+                    ՐՏitr64 = ՐՏ_Iterable(enumerate(astElement.args));
+                    for (ՐՏidx64 = 0; ՐՏidx64 < ՐՏitr64.length; ՐՏidx64++) {
+                        ՐՏupk5 = ՐՏitr64[ՐՏidx64];
                         i = ՐՏupk5[0];
                         arg = ՐՏupk5[1];
-                        expected = args[i].trim();
+                        expected = (ՐՏ_377 = args)[i].trim();
                         actual = arg.resolveType(S.in_scope);
                         if (expected !== "?" && !(ՐՏ_in(actual, [ expected, "?" ]))) {
                             croak("Function '" + name + "' expects argument " + i + " type of " + expected + ", but you're passing " + actual + "");
@@ -6801,6 +6739,7 @@ var ՐՏ_modules = {};
             return astElement;
         }
         function expr_op(left, min_prec, no_in) {
+            var ՐՏ_378, ՐՏ_379, ՐՏ_380;
             var op, not_in, prec, right, ret;
             op = is_("operator") ? S.token.value : null;
             not_in = false;
@@ -6813,15 +6752,15 @@ var ՐՏ_modules = {};
                 if (no_in) {
                     op = null;
                 } else {
-                    ++BASELIB[op];
+                    ++(ՐՏ_378 = BASELIB)[op];
                 }
             }
-            prec = op !== null ? tokenizer.PRECEDENCE[op] : null;
+            prec = op !== null ? (ՐՏ_379 = tokenizer.PRECEDENCE)[op] : null;
             if (prec !== null && prec > min_prec) {
                 next();
                 right = expr_op(maybe_unary(true), prec, no_in);
                 if (ՐՏ_in(op, [ "==", "!=" ])) {
-                    ++BASELIB["eq"];
+                    ++(ՐՏ_380 = BASELIB)["eq"];
                     ret = new ast.DeepEquality({
                         start: left.start,
                         left: left,
@@ -6873,7 +6812,7 @@ var ՐՏ_modules = {};
             return expr;
         }
         function isAssignable(expr) {
-            var ՐՏitr62, ՐՏidx62;
+            var ՐՏitr65, ՐՏidx65;
             var element;
             if (expr instanceof ast.PropAccess) {
                 return true;
@@ -6885,9 +6824,9 @@ var ՐՏ_modules = {};
                 return true;
             }
             if (expr instanceof ast.Array) {
-                ՐՏitr62 = ՐՏ_Iterable(expr.elements);
-                for (ՐՏidx62 = 0; ՐՏidx62 < ՐՏitr62.length; ՐՏidx62++) {
-                    element = ՐՏitr62[ՐՏidx62];
+                ՐՏitr65 = ՐՏ_Iterable(expr.elements);
+                for (ՐՏidx65 = 0; ՐՏidx65 < ՐՏitr65.length; ՐՏidx65++) {
+                    element = ՐՏitr65[ՐՏidx65];
                     if (!isAssignable(element)) {
                         return false;
                     }
@@ -6902,13 +6841,14 @@ var ՐՏ_modules = {};
             return false;
         }
         function maybe_assign(no_in) {
+            var ՐՏ_381, ՐՏ_382, ՐՏ_383, ՐՏ_384;
             var start, left, val, right;
             start = S.token;
             left = maybe_conditional(no_in);
             val = S.token.value;
             if (is_("operator") && ASSIGNMENT(val)) {
                 if (isAssignable(left)) {
-                    if (left instanceof ast.SymbolRef && val !== "=" && !(ՐՏ_in(left.name, S.in_scope[S.in_scope.length-1].vars)) && (!S.in_scope[S.in_scope.length-1].args || !(ՐՏ_in(left.name, S.in_scope[S.in_scope.length-1].args))) && !(ՐՏ_in(left.name, S.in_scope[S.in_scope.length-1].nonlocal))) {
+                    if (left instanceof ast.SymbolRef && val !== "=" && !(ՐՏ_in(left.name, (ՐՏ_381 = S.in_scope)[ՐՏ_381.length-1].vars)) && (!(ՐՏ_382 = S.in_scope)[ՐՏ_382.length-1].args || !(ՐՏ_in(left.name, (ՐՏ_383 = S.in_scope)[ՐՏ_383.length-1].args))) && !(ՐՏ_in(left.name, (ՐՏ_384 = S.in_scope)[ՐՏ_384.length-1].nonlocal))) {
                         croak("Attempting to increment/modify uninitialized variable '" + left.name + "', this can also occur if you're trying to shadow without initializing the variable in local scope.");
                     }
                     next();
@@ -6929,7 +6869,7 @@ var ՐՏ_modules = {};
             return left;
         }
         function expression(commas, no_in) {
-            var ՐՏitr63, ՐՏidx63, ՐՏupk6, ՐՏitr64, ՐՏidx64, ՐՏupk7;
+            var ՐՏ_385, ՐՏ_386, ՐՏ_387, ՐՏ_388, ՐՏ_389, ՐՏitr66, ՐՏidx66, ՐՏupk6, ՐՏ_390, ՐՏ_391, ՐՏ_392, ՐՏ_393, ՐՏitr67, ՐՏidx67, ՐՏupk7, ՐՏ_394;
             var start, expr, left, leftAst, right, index, element, seq;
             start = S.token;
             expr = maybe_assign(no_in);
@@ -6939,12 +6879,12 @@ var ՐՏ_modules = {};
                     S.in_seq = true;
                     next();
                     if (expr instanceof ast.Assign) {
-                        left[left.length-1] = left[left.length-1].left;
+                        (ՐՏ_385 = left)[ՐՏ_385.length-1] = (ՐՏ_386 = left)[ՐՏ_386.length-1].left;
                         if (left.length === 1) {
-                            if (left[0] instanceof ast.Seq) {
-                                leftAst = seq_to_array(left[0]);
+                            if ((ՐՏ_387 = left)[0] instanceof ast.Seq) {
+                                leftAst = seq_to_array((ՐՏ_388 = left)[0]);
                             } else {
-                                leftAst = left[0];
+                                leftAst = (ՐՏ_389 = left)[0];
                             }
                         } else {
                             leftAst = new ast.Array({
@@ -6955,12 +6895,12 @@ var ՐՏ_modules = {};
                             car: expr.right,
                             cdr: expression(true, no_in)
                         }));
-                        ՐՏitr63 = ՐՏ_Iterable(enumerate(leftAst.elements));
-                        for (ՐՏidx63 = 0; ՐՏidx63 < ՐՏitr63.length; ՐՏidx63++) {
-                            ՐՏupk6 = ՐՏitr63[ՐՏidx63];
+                        ՐՏitr66 = ՐՏ_Iterable(enumerate(leftAst.elements));
+                        for (ՐՏidx66 = 0; ՐՏidx66 < ՐՏitr66.length; ՐՏidx66++) {
+                            ՐՏupk6 = ՐՏitr66[ՐՏidx66];
                             index = ՐՏupk6[0];
                             element = ՐՏupk6[1];
-                            mark_local_assignment(element, right.elements[index]);
+                            mark_local_assignment(element, (ՐՏ_390 = right.elements)[index]);
                         }
                         return new ast.Assign({
                             start: start,
@@ -6977,14 +6917,14 @@ var ՐՏ_modules = {};
                 if (expr instanceof ast.Assign && expr.left instanceof ast.Seq) {
                     expr.left = seq_to_array(expr.left);
                 }
-                if (left.length > 1 && left[left.length-1] instanceof ast.Assign) {
-                    left[left.length-1] = left[left.length-1].left;
-                    ՐՏitr64 = ՐՏ_Iterable(enumerate(left));
-                    for (ՐՏidx64 = 0; ՐՏidx64 < ՐՏitr64.length; ՐՏidx64++) {
-                        ՐՏupk7 = ՐՏitr64[ՐՏidx64];
+                if (left.length > 1 && (ՐՏ_391 = left)[ՐՏ_391.length-1] instanceof ast.Assign) {
+                    (ՐՏ_392 = left)[ՐՏ_392.length-1] = (ՐՏ_393 = left)[ՐՏ_393.length-1].left;
+                    ՐՏitr67 = ՐՏ_Iterable(enumerate(left));
+                    for (ՐՏidx67 = 0; ՐՏidx67 < ՐՏitr67.length; ՐՏidx67++) {
+                        ՐՏupk7 = ՐՏitr67[ՐՏidx67];
                         index = ՐՏupk7[0];
                         element = ՐՏupk7[1];
-                        mark_local_assignment(element, expr.right instanceof ast.Array ? expr.right.elements[index] : null);
+                        mark_local_assignment(element, expr.right instanceof ast.Array ? (ՐՏ_394 = expr.right.elements)[index] : null);
                     }
                     return new ast.Assign({
                         start: start,
@@ -6997,17 +6937,17 @@ var ՐՏ_modules = {};
                     });
                 }
                 seq = function build_seq(a) {
-                    var ՐՏitr65, ՐՏidx65, ՐՏupk8;
+                    var ՐՏitr68, ՐՏidx68, ՐՏupk8, ՐՏ_395;
                     var first, index, element;
                     first = a.shift();
                     if (first instanceof ast.Assign) {
                         if (first.left instanceof ast.Array) {
-                            ՐՏitr65 = ՐՏ_Iterable(enumerate(first.left.elements));
-                            for (ՐՏidx65 = 0; ՐՏidx65 < ՐՏitr65.length; ՐՏidx65++) {
-                                ՐՏupk8 = ՐՏitr65[ՐՏidx65];
+                            ՐՏitr68 = ՐՏ_Iterable(enumerate(first.left.elements));
+                            for (ՐՏidx68 = 0; ՐՏidx68 < ՐՏitr68.length; ՐՏidx68++) {
+                                ՐՏupk8 = ՐՏitr68[ՐՏidx68];
                                 index = ՐՏupk8[0];
                                 element = ՐՏupk8[1];
-                                mark_local_assignment(element, first.right instanceof ast.Array ? first.right.elements[index] : null);
+                                mark_local_assignment(element, first.right instanceof ast.Array ? (ՐՏ_395 = first.right.elements)[index] : null);
                             }
                         }
                     }
@@ -7033,8 +6973,8 @@ var ՐՏ_modules = {};
             return ret;
         }
         return function() {
-            var ՐՏitr66, ՐՏidx66;
-            var start, body, docstring, first_token, element, shebang, end, toplevel, assignments, callables, item;
+            var ՐՏ_396, ՐՏ_397, ՐՏitr69, ՐՏidx69, ՐՏ_401, ՐՏ_402, ՐՏ_403, ՐՏ_404, ՐՏ_405, ՐՏ_406;
+            var start, body, docstring, first_token, element, shebang, end, toplevel, assignments, callables, imports, item;
             start = S.token;
             body = [];
             docstring = null;
@@ -7071,39 +7011,40 @@ var ՐՏ_modules = {};
                 return arr.lastIndexOf(element) === index;
             }
             toplevel.filename = options.filename;
-            toplevel.nonlocalvars = Object.keys(S.in_scope[S.in_scope.length-1].nonlocal);
-            assignments = Object.keys(S.in_scope[S.in_scope.length-1].vars);
+            toplevel.nonlocalvars = Object.keys((ՐՏ_396 = S.in_scope)[ՐՏ_396.length-1].nonlocal);
+            assignments = Object.keys((ՐՏ_397 = S.in_scope)[ՐՏ_397.length-1].vars);
             callables = scan_for_top_level_callables(toplevel.body).filter(uniq);
+            imports = scan_for_top_level_imports(toplevel.body);
             toplevel.localvars = [];
-            ՐՏitr66 = ՐՏ_Iterable(assignments);
-            for (ՐՏidx66 = 0; ՐՏidx66 < ՐՏitr66.length; ՐՏidx66++) {
-                item = ՐՏitr66[ՐՏidx66];
+            ՐՏitr69 = ՐՏ_Iterable(assignments);
+            for (ՐՏidx69 = 0; ՐՏidx69 < ՐՏitr69.length; ՐՏidx69++) {
+                item = ՐՏitr69[ՐՏidx69];
                 if (!(ՐՏ_in(item, toplevel.nonlocalvars))) {
                     toplevel.localvars.push(new_symbol(ast.SymbolVar, item));
                 }
             }
-            toplevel.exports = toplevel.localvars.concat(callables).filter(uniq);
+            toplevel.exports = toplevel.localvars.concat(callables).concat(imports).filter(uniq);
             toplevel.depends_on = depends_on;
             toplevel.submodules = [];
             toplevel.classes = class_map;
             toplevel.top_classes = function(key) {
-                var ՐՏitr67, ՐՏidx67;
+                var ՐՏ_398, ՐՏ_399, ՐՏitr70, ՐՏidx70, ՐՏ_400;
                 var ret, cn, obj, sub_id, sub_key, sub;
                 ret = {};
                 key = key || "";
                 cn = "";
                 for (cn in this.classes) {
-                    obj = this.classes[cn];
-                    ret[key ? key + "." + cn : cn] = {
+                    obj = (ՐՏ_398 = this.classes)[cn];
+                    (ՐՏ_399 = ret)[key ? key + "." + cn : cn] = {
                         "static": obj.static,
                         "bound": obj.bound
                     };
                 }
-                ՐՏitr67 = ՐՏ_Iterable(this.submodules);
-                for (ՐՏidx67 = 0; ՐՏidx67 < ՐՏitr67.length; ՐՏidx67++) {
-                    sub_id = ՐՏitr67[ՐՏidx67];
+                ՐՏitr70 = ՐՏ_Iterable(this.submodules);
+                for (ՐՏidx70 = 0; ՐՏidx70 < ՐՏitr70.length; ՐՏidx70++) {
+                    sub_id = ՐՏitr70[ՐՏidx70];
                     sub_key = sub_id.replace(new RegExp("^" + this.module_id.replace(/\./g, "\\.")), key);
-                    sub = IMPORTED[sub_id];
+                    sub = (ՐՏ_400 = IMPORTED)[sub_id];
                     Object.assign(ret, sub.top_classes(sub_key));
                 }
                 return ret;
@@ -7111,57 +7052,55 @@ var ՐՏ_modules = {};
             toplevel.import_order = Object.keys(IMPORTED).length;
             toplevel.module_id = module_id;
             toplevel.is_package = (toplevel.filename || "").endsWith("/__init__.pyj");
-            IMPORTED[module_id] = toplevel;
+            (ՐՏ_401 = IMPORTED)[module_id] = toplevel;
             toplevel.imports = IMPORTED;
             toplevel.baselib = BASELIB;
-            IMPORTING[module_id] = false;
-            if (PRE_IMPORTED[module_id]) {
-                IMPORTED[module_id].submodules = PRE_IMPORTED[module_id].submodules;
-                delete PRE_IMPORTED[module_id];
+            (ՐՏ_402 = IMPORTING)[module_id] = false;
+            if ((ՐՏ_403 = PRE_IMPORTED)[module_id]) {
+                (ՐՏ_404 = IMPORTED)[module_id].submodules = (ՐՏ_405 = PRE_IMPORTED)[module_id].submodules;
+                delete (ՐՏ_406 = PRE_IMPORTED)[module_id];
             }
             return toplevel;
         }();
     }
-    ՐՏ_modules["parser"]["NATIVE_CLASSES"] = NATIVE_CLASSES;
-    ՐՏ_modules["parser"]["COMMON_STATIC"] = COMMON_STATIC;
-    ՐՏ_modules["parser"]["CLASS_MAP"] = CLASS_MAP;
-    ՐՏ_modules["parser"]["BASELIB"] = BASELIB;
-    ՐՏ_modules["parser"]["STDLIB"] = STDLIB;
-    ՐՏ_modules["parser"]["UNARY_PREFIX"] = UNARY_PREFIX;
-    ՐՏ_modules["parser"]["ASSIGNMENT"] = ASSIGNMENT;
-    ՐՏ_modules["parser"]["STATEMENTS_WITH_LABELS"] = STATEMENTS_WITH_LABELS;
-    ՐՏ_modules["parser"]["ATOMIC_START_TOKEN"] = ATOMIC_START_TOKEN;
-    ՐՏ_modules["parser"]["array_to_hash"] = array_to_hash;
-    ՐՏ_modules["parser"]["init_mod"] = init_mod;
-    ՐՏ_modules["parser"]["has_simple_decorator"] = has_simple_decorator;
-    ՐՏ_modules["parser"]["parse"] = parse;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:parser"];
+    ՐՏ_mod.export("NATIVE_CLASSES", function(){return NATIVE_CLASSES;}, function(ՐՏ_v){if (typeof NATIVE_CLASSES !== "undefined") {NATIVE_CLASSES = ՐՏ_v;};});
+    ՐՏ_mod.export("COMMON_STATIC", function(){return COMMON_STATIC;}, function(ՐՏ_v){if (typeof COMMON_STATIC !== "undefined") {COMMON_STATIC = ՐՏ_v;};});
+    ՐՏ_mod.export("CLASS_MAP", function(){return CLASS_MAP;}, function(ՐՏ_v){if (typeof CLASS_MAP !== "undefined") {CLASS_MAP = ՐՏ_v;};});
+    ՐՏ_mod.export("BASELIB", function(){return BASELIB;}, function(ՐՏ_v){if (typeof BASELIB !== "undefined") {BASELIB = ՐՏ_v;};});
+    ՐՏ_mod.export("STDLIB", function(){return STDLIB;}, function(ՐՏ_v){if (typeof STDLIB !== "undefined") {STDLIB = ՐՏ_v;};});
+    ՐՏ_mod.export("UNARY_PREFIX", function(){return UNARY_PREFIX;}, function(ՐՏ_v){if (typeof UNARY_PREFIX !== "undefined") {UNARY_PREFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("ASSIGNMENT", function(){return ASSIGNMENT;}, function(ՐՏ_v){if (typeof ASSIGNMENT !== "undefined") {ASSIGNMENT = ՐՏ_v;};});
+    ՐՏ_mod.export("STATEMENTS_WITH_LABELS", function(){return STATEMENTS_WITH_LABELS;}, function(ՐՏ_v){if (typeof STATEMENTS_WITH_LABELS !== "undefined") {STATEMENTS_WITH_LABELS = ՐՏ_v;};});
+    ՐՏ_mod.export("ATOMIC_START_TOKEN", function(){return ATOMIC_START_TOKEN;}, function(ՐՏ_v){if (typeof ATOMIC_START_TOKEN !== "undefined") {ATOMIC_START_TOKEN = ՐՏ_v;};});
+    ՐՏ_mod.export("array_to_hash", function(){return array_to_hash;}, function(ՐՏ_v){if (typeof array_to_hash !== "undefined") {array_to_hash = ՐՏ_v;};});
+    ՐՏ_mod.export("init_mod", function(){return init_mod;}, function(ՐՏ_v){if (typeof init_mod !== "undefined") {init_mod = ՐՏ_v;};});
+    ՐՏ_mod.export("has_simple_decorator", function(){return has_simple_decorator;}, function(ՐՏ_v){if (typeof has_simple_decorator !== "undefined") {has_simple_decorator = ՐՏ_v;};});
+    ՐՏ_mod.export("parse", function(){return parse;}, function(ՐՏ_v){if (typeof parse !== "undefined") {parse = ՐՏ_v;};});
+    ՐՏ_mod.export("find_if", function(){return find_if;}, function(ՐՏ_v){if (typeof find_if !== "undefined") {find_if = ՐՏ_v;};});
+    ՐՏ_mod.export("ast", function(){return ast;}, function(ՐՏ_v){if (typeof ast !== "undefined") {ast = ՐՏ_v;};});
+    ՐՏ_mod.export("tokenizer", function(){return tokenizer;}, function(ՐՏ_v){if (typeof tokenizer !== "undefined") {tokenizer = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:_baselib"].body = function(){
     var __name__ = "_baselib";
 
     var BASELIB;
-    BASELIB = '"""\n**********************************************************************\n\n  A RapydScript to JavaScript compiler.\n  https://github.com/atsepkov/RapydScript\n\n  -------------------------------- (C) ---------------------------------\n\n                       Author: Alexander Tsepkov\n                         <atsepkov@pyjeon.com>\n                         http://www.pyjeon.com\n\n  Distributed under BSD license:\n    Copyright 2013 (c) Alexander Tsepkov <atsepkov@pyjeon.com>\n\n **********************************************************************\n"""\n\n\n# for convenience we\'ll use a convention here that will work as follows:\n#\n#   if function is named, assume we\'ll be outputting the function itself\n#   if the given baselib chunk is triggered\n#\n#   if function is unnamed, assume the function is a container for the logic\n#   to be output. We\'re basically ignoring the wrapper and dumping what\'s inside\n\n{\n"abs": def abs(n):\n    return Math.abs(n)\n,\n"all": def all(a):\n    for e in a:\n        if not e: return False\n    return True\n,\n"any": def any(a):\n    for e in a:\n        if e: return True\n    return False\n,\n"bin": def bin(a): return \'0b\' + (a >>> 0).toString(2)\n,\n"bind": def ՐՏ_bind(fn, thisArg):\n    if fn.orig: fn = fn.orig\n    if thisArg is False: return fn\n    ret = def():\n        return fn.apply(thisArg, arguments)\n    ret.orig = fn\n    return ret\n,\n"rebind_all": def ՐՏ_rebindAll(thisArg, rebind):\n    if rebind is undefined: rebind = True\n    for JS(\'var p in thisArg\'):\n        if thisArg[p] and thisArg[p].orig:\n            if rebind: thisArg[p] = bind(thisArg[p], thisArg)\n            else: thisArg[p] = thisArg[p].orig\n,\n"with__name__": def ՐՏ_with__name__(fn, name):\n    fn.__name__ = name\n    return fn\n,\n"cmp": def cmp(a, b): return a < b ? -1 : a > b ? 1 : 0\n,\n"chr": def(): JS(\'var chr = String.fromCharCode\')\n,\n"dir": def dir(item):\n    # TODO: this isn\'t really representative of real Python\'s dir(), nor is it\n    # an intuitive replacement for "for ... in" loop, need to update this logic\n    # and introduce a different way of achieving "for ... in"\n    arr = []\n    for JS(\'var i in item\'): arr.push(i)\n    return arr\n,\n"enumerate": def enumerate(item):\n    arr = []\n    iter = ՐՏ_Iterable(item)\n    for i in range(iter.length):\n        arr[arr.length] = [i, item[i]]\n    return arr\n,\n"eslice": def ՐՏ_eslice(arr, step, start, end):\n    arr = arr[:]\n    if JS(\'typeof arr\') is \'string\' or isinstance(arr, String):\n        isString = True\n        arr = arr.split(\'\')\n\n    if step < 0:\n        step = -step\n        arr.reverse()\n        if JS(\'typeof start\') is not "undefined": start = arr.length - start - 1\n        if JS(\'typeof end\') is not "undefined": end = arr.length - end - 1\n    if JS(\'typeof start\') is "undefined": start = 0\n    if JS(\'typeof end\') is "undefined": end = arr.length\n\n    arr = arr.slice(start, end).filter(def(e, i): return i % step is 0;)\n    return isString ? arr.join(\'\') : arr\n,\n"extends": def ՐՏ_extends(child, parent):\n    child.prototype = Object.create(parent.prototype)\n    child.prototype.__base__ = parent     # since we don\'t support multiple inheritance, __base__ seemed more appropriate than __bases__ array of 1\n    child.prototype.constructor = child\n,\n"filter": def filter(oper, arr):\n    return arr.filter(oper)\n,\n"hex": def hex(a): return \'0x\' + (a >>> 0).toString(16)\n,\n"in": def ՐՏ_in(val, arr):\n    if JS(\'typeof arr.indexOf\') is \'function\': return arr.indexOf(val) is not -1\n    elif JS(\'typeof arr.has\') is \'function\': return arr.has(val)\n    return arr.hasOwnProperty(val)\n,\n"iterable": def ՐՏ_Iterable(iterable):\n    # can\'t use Symbol.iterator yet since it\'s not supported on all platforms until ES6 (i.e. mobile browsers don\'t have it)\n    if iterable.constructor is [].constructor\n    or iterable.constructor is \'\'.constructor\n    or (tmp = Array.prototype.slice.call(iterable)).length:\n        return tmp or iterable\n    if Set and iterable.constructor is Set:\n        return Array.from(iterable)\n    return Object.keys(iterable)    # so we can use \'for ... in\' syntax with hashes\n,\n"len": def len(obj):\n    # can\'t use Symbol.iterator yet since it\'s not supported on all platforms until ES6 (i.e. mobile browsers don\'t have it)\n    if obj.constructor is [].constructor\n    or obj.constructor is \'\'.constructor\n    or (tmp = Array.prototype.slice.call(obj)).length:\n        return (tmp or obj).length\n    if Set and obj.constructor is Set:\n        return obj.size\n    return Object.keys(obj).length\n,\n"map": def map(oper, arr):\n    return arr.map(oper)\n,\n"max": def max(a):\n    return Math.max.apply(None, Array.isArray(a) ? a : arguments)\n,\n"min": def min(a):\n    return Math.min.apply(None, Array.isArray(a) ? a : arguments)\n,\n"merge": def ՐՏ_merge(target, source, overwrite):\n    for JS(\'var i in source\'):\n        # instance variables\n        if source.hasOwnProperty(i) and (overwrite or JS(\'typeof target[i]\') is \'undefined\'): target[i] = source[i]\n    for prop in Object.getOwnPropertyNames(source.prototype):\n        # methods\n        if overwrite or JS(\'typeof target.prototype[prop]\') is \'undefined\':\n            Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop))\n,\n"mixin": def ՐՏ_mixin(*classes):\n    return def(baseClass):\n        for cls in classes:\n            for key in Object.getOwnPropertyNames(cls.prototype):\n                if key not in baseClass.prototype:\n                    Object.defineProperty(baseClass.prototype, key, Object.getOwnPropertyDescriptor(cls.prototype, key))\n        return baseClass\n\n,\n"print": def ՐՏ_print():\n    if JS(\'typeof console\') is \'object\': console.log.apply(console, arguments)\n,\n"range": def range(start, stop, step):\n    if arguments.length <= 1:\n        stop = start or 0\n        start = 0\n    step = arguments[2] or 1\n\n    length = Math.max(Math.ceil((stop - start) / step), 0)\n    idx = 0\n    range = Array(length)\n\n    while idx < length:\n        range[JS(\'idx++\')] = start\n        start += step\n    return range\n,\n"reduce": def reduce(f, a): return Array.reduce(a, f)\n,\n"reversed": def reversed(arr):\n    tmp = arr[:]\n    return tmp.reverse()\n,\n"sorted": def sorted(arr):\n    tmp = arr[:]\n    return tmp.sort()\n,\n"sum": def sum(arr, start=0):\n    return arr.reduce(\n        def(prev, cur): return prev+cur\n        ,\n        start\n    )\n,\n"type": def ՐՏ_type(obj):\n    return obj and obj.constructor and obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1)\n,\n"zip": def zip(a, b):\n    return [[a[i], b[i]] for i in range(Math.min(a.length, b.length))]\n,\n"getattr": def getattr(obj, name):\n    return obj[name]\n,\n"setattr": def setattr(obj, name, value):\n    obj[name] = value\n,\n"hasattr": def hasattr(obj, name):\n    return JS(\'name in obj\')\n,\n"eq": def ՐՏ_eq(a, b):\n    """\n    Equality comparison that works with all data types, returns true if structure and\n    contents of first object equal to those of second object\n\n    Arguments:\n        a: first object\n        b: second object\n    """\n    if a is b:\n        # simple object\n        return True\n\n    if a is undefined or b is undefined or a is None or b is None:\n        return False\n\n    if a.constructor is not b.constructor:\n        # object type mismatch\n        return False\n\n    if Array.isArray(a):\n        # arrays\n        if a.length is not b.length: return False\n        for i in range(a.length):\n            if not ՐՏ_eq(a[i], b[i]):\n                return False\n        return True\n    elif a.constructor is Object:\n        # hashes\n        # compare individual properties (order doesn\'t matter if it\'s a hash)\n        if Object.keys(a).length is not Object.keys(b).length: return False\n        for i in a:\n            # recursively test equality of object children\n            if not ՐՏ_eq(a[i], b[i]):\n                return False\n        return True\n    elif (Set and a.constructor is Set) or (Map and a.constructor is Map):\n        # sets and maps\n        if a.size is not b.size: return False\n        for JS(\'i of a\'):\n            if not b.has(i):\n                return False\n        return True\n    elif (a.constructor is Date):\n        # dates\n        return a.getTime() is b.getTime()\n    elif JS(\'typeof a.__eq__\') is \'function\':\n        # everything else that implements __eq__ method\n        return a.__eq__(b)\n    return False\n,\n"kwargs": def():\n    # WARNING: when using this function decorator, you will not be able to use obfuscators that rename local variables\n    def kwargs(f):\n        argNames = f.toString().match(/\\(([^\\)]+)/)[1]\n        if not kwargs.memo[argNames]:\n            kwargs.memo[argNames] = argNames ? argNames.split(\',\').map(def(s): return s.trim();) : []\n        argNames = kwargs.memo[argNames]\n        return def():\n            args = [].slice.call(arguments)\n            if args.length:\n                kw = args[-1]\n                if JS(\'typeof kw\') is \'object\':\n                    for i in range(argNames.length):\n                        if argNames[i] in kw:\n                            args[i] = kw[argNames[i]]\n                else:\n                    args.push(kw)\n\n            # This logic is very fragile and very subtle, it needs to work both in ES6 and ES5, don\'t try to optimize the\n            # apply away into *args because having it in this format ensures correct \'this\' context, otherwise the function\n            # ends up unbound. Similarly, the fallthrough to except handles class creation in ES6.\n            try:\n                return f.apply(this, args)\n            except as e:\n                if /Class constructor \\w+ cannot be invoked without \'new\'/.test(e):\n                    return new f(*args)\n                raise\n    kwargs.memo = {}\n,\n\n# Errors\n# temporarily implemented via a wrapper pattern since there is no mechanism for assigning\n# classes to dictionary keys yet\n"AssertionError": def():\n    class AssertionError(Error):\n        def __init__(self, message):\n            self.name = "AssertionError"\n            self.message = message\n,\n"IndexError": def():\n    class IndexError(Error):\n        def __init__(self, message):\n            self.name = "IndexError"\n            self.message = message\n,\n"KeyError": def():\n    class KeyError(Error):\n        def __init__(self, message):\n            self.name = "KeyError"\n            self.message = message\n,\n"TypeError": def():\n    class TypeError(Error):\n        def __init__(self, message):\n            self.name = "TypeError"\n            self.message = message\n,\n"ValueError": def():\n    class ValueError(Error):\n        def __init__(self, message):\n            self.name = "ValueError"\n            self.message = message\n,\n}\n';
-    ՐՏ_modules["_baselib"]["BASELIB"] = BASELIB;
-})();
+    BASELIB = '"""\n**********************************************************************\n\n  A RapydScript to JavaScript compiler.\n  https://github.com/atsepkov/RapydScript\n\n  -------------------------------- (C) ---------------------------------\n\n                       Author: Alexander Tsepkov\n                         <atsepkov@pyjeon.com>\n                         http://www.pyjeon.com\n\n  Distributed under BSD license:\n    Copyright 2013 (c) Alexander Tsepkov <atsepkov@pyjeon.com>\n\n **********************************************************************\n"""\n\n\n# for convenience we\'ll use a convention here that will work as follows:\n#\n#   if function is named, assume we\'ll be outputting the function itself\n#   if the given baselib chunk is triggered\n#\n#   if function is unnamed, assume the function is a container for the logic\n#   to be output. We\'re basically ignoring the wrapper and dumping what\'s inside\n\n{\n"abs": def abs(n):\n    return Math.abs(n)\n,\n"all": def all(a):\n    for e in a:\n        if not e: return False\n    return True\n,\n"any": def any(a):\n    for e in a:\n        if e: return True\n    return False\n,\n"bin": def bin(a): return \'0b\' + (a >>> 0).toString(2)\n,\n"bind": def ՐՏ_bind(fn, thisArg):\n    if fn.orig: fn = fn.orig\n    if thisArg is False: return fn\n    ret = def():\n        return fn.apply(thisArg, arguments)\n    ret.orig = fn\n    return ret\n,\n"rebind_all": def ՐՏ_rebindAll(thisArg, rebind):\n    if rebind is undefined: rebind = True\n    for v\'var p in thisArg\':\n        if thisArg[p] and thisArg[p].orig:\n            if rebind: thisArg[p] = bind(thisArg[p], thisArg)\n            else: thisArg[p] = thisArg[p].orig\n,\n"with__name__": def ՐՏ_with__name__(fn, name):\n    fn.__name__ = name\n    return fn\n,\n"def_modules": def ՐՏ_def_modules():\n    modules = {}\n    def mounter(mod_id):\n        rs_mod_id = "ՐՏ:"+ mod_id\n        rs_mod = modules[rs_mod_id] = {\n            "body": None,\n            "exports":None,\n        }\n        rs_mod["export"] = def(prop, get, set):\n            if not rs_mod["exports"]: rs_mod["exports"] = {}\n            Object.defineProperty( rs_mod["exports"], prop, {\n                configurable: True,\n                enumerable: True,\n                get: get,\n                set: set,\n            })\n        Object.defineProperty( modules,  mod_id, {\n            enumerable: True,\n            get: def():\n                return (mod = modules[rs_mod_id])["exports"] or mod["body"]()\n            , set: def(v):\n                modules[rs_mod_id]["exports"] = v\n        })\n        return rs_mod\n\n    Object.defineProperty( modules, \'ՐՏ_def\', {\n        configurable: False,\n        enumerable: False,\n        value: mounter\n    })\n    return modules\n,\n"cmp": def cmp(a, b): return a < b ? -1 : a > b ? 1 : 0\n,\n"chr": def(): v\'var chr = String.fromCharCode\'\n,\n"dir": def dir(item):\n    # TODO: this isn\'t really representative of real Python\'s dir(), nor is it\n    # an intuitive replacement for "for ... in" loop, need to update this logic\n    # and introduce a different way of achieving "for ... in"\n    arr = []\n    for v\'var i in item\': arr.push(i)\n    return arr\n,\n"enumerate": def enumerate(item):\n    arr = []\n    iter = ՐՏ_Iterable(item)\n    for i in range(iter.length):\n        arr[arr.length] = [i, item[i]]\n    return arr\n,\n"eslice": def ՐՏ_eslice(arr, step, start, end):\n    arr = arr[:]\n    if v\'typeof arr\' is \'string\' or isinstance(arr, String):\n        isString = True\n        arr = arr.split(\'\')\n\n    if step < 0:\n        step = -step\n        arr.reverse()\n        if v\'typeof start\' is not "undefined": start = arr.length - start - 1\n        if v\'typeof end\' is not "undefined": end = arr.length - end - 1\n    if v\'typeof start\' is "undefined": start = 0\n    if v\'typeof end\' is "undefined": end = arr.length\n\n    arr = arr.slice(start, end).filter(def(e, i): return i % step is 0;)\n    return isString ? arr.join(\'\') : arr\n,\n"extends": def ՐՏ_extends(child, parent):\n    child.prototype = Object.create(parent.prototype)\n    child.prototype.__base__ = parent     # since we don\'t support multiple inheritance, __base__ seemed more appropriate than __bases__ array of 1\n    child.prototype.constructor = child\n,\n"filter": def filter(oper, arr):\n    return arr.filter(oper)\n,\n"hex": def hex(a): return \'0x\' + (a >>> 0).toString(16)\n,\n"in": def ՐՏ_in(val, arr):\n    if v\'typeof arr.indexOf\' is \'function\': return arr.indexOf(val) is not -1\n    elif v\'typeof arr.has\' is \'function\': return arr.has(val)\n    return arr.hasOwnProperty(val)\n,\n"iterable": def ՐՏ_Iterable(iterable):\n    # can\'t use Symbol.iterator yet since it\'s not supported on all platforms until ES6 (i.e. mobile browsers don\'t have it)\n    if iterable.constructor is [].constructor\n    or iterable.constructor is \'\'.constructor\n    or (tmp = Array.prototype.slice.call(iterable)).length:\n        return tmp or iterable\n    if Set and iterable.constructor is Set:\n        return Array.from(iterable)\n    return Object.keys(iterable)    # so we can use \'for ... in\' syntax with hashes\n,\n"len": def len(obj):\n    # can\'t use Symbol.iterator yet since it\'s not supported on all platforms until ES6 (i.e. mobile browsers don\'t have it)\n    if obj.constructor is [].constructor\n    or obj.constructor is \'\'.constructor\n    or (tmp = Array.prototype.slice.call(obj)).length:\n        return (tmp or obj).length\n    if Set and obj.constructor is Set:\n        return obj.size\n    return Object.keys(obj).length\n,\n"map": def map(oper, arr):\n    return arr.map(oper)\n,\n"max": def max(a):\n    return Math.max.apply(None, Array.isArray(a) ? a : arguments)\n,\n"min": def min(a):\n    return Math.min.apply(None, Array.isArray(a) ? a : arguments)\n,\n"merge": def ՐՏ_merge(target, source, overwrite):\n    for v\'var i in source\':\n        # instance variables\n        if source.hasOwnProperty(i) and (overwrite or v\'typeof target[i]\' is \'undefined\'): target[i] = source[i]\n    for prop in Object.getOwnPropertyNames(source.prototype):\n        # methods\n        if overwrite or v\'typeof target.prototype[prop]\' is \'undefined\':\n            Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop))\n,\n"mixin": def ՐՏ_mixin(*classes):\n    return def(baseClass):\n        for cls in classes:\n            for key in Object.getOwnPropertyNames(cls.prototype):\n                if key not in baseClass.prototype:\n                    Object.defineProperty(baseClass.prototype, key, Object.getOwnPropertyDescriptor(cls.prototype, key))\n        return baseClass\n\n,\n"print": def ՐՏ_print():\n    if v\'typeof console\' is \'object\': console.log.apply(console, arguments)\n,\n"range": def range(start, stop, step):\n    if arguments.length <= 1:\n        stop = start or 0\n        start = 0\n    step = arguments[2] or 1\n\n    length = Math.max(Math.ceil((stop - start) / step), 0)\n    idx = 0\n    range = Array(length)\n\n    while idx < length:\n        range[v\'idx++\'] = start\n        start += step\n    return range\n,\n"reduce": def reduce(f, a): return Array.reduce(a, f)\n,\n"reversed": def reversed(arr):\n    tmp = arr[:]\n    return tmp.reverse()\n,\n"sorted": def sorted(arr):\n    tmp = arr[:]\n    return tmp.sort()\n,\n"sum": def sum(arr, start=0):\n    return arr.reduce(\n        def(prev, cur): return prev+cur\n        ,\n        start\n    )\n,\n"type": def ՐՏ_type(obj):\n    return obj and obj.constructor and obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1)\n,\n"zip": def zip(a, b):\n    return [[a[i], b[i]] for i in range(Math.min(a.length, b.length))]\n,\n"getattr": def getattr(obj, name):\n    return obj[name]\n,\n"setattr": def setattr(obj, name, value):\n    obj[name] = value\n,\n"hasattr": def hasattr(obj, name):\n    return v\'name in obj\'\n,\n"eq": def ՐՏ_eq(a, b):\n    """\n    Equality comparison that works with all data types, returns true if structure and\n    contents of first object equal to those of second object\n\n    Arguments:\n        a: first object\n        b: second object\n    """\n    if a is b:\n        # simple object\n        return True\n\n    if a is undefined or b is undefined or a is None or b is None:\n        return False\n\n    if a.constructor is not b.constructor:\n        # object type mismatch\n        return False\n\n    if Array.isArray(a):\n        # arrays\n        if a.length is not b.length: return False\n        for i in range(a.length):\n            if not ՐՏ_eq(a[i], b[i]):\n                return False\n        return True\n    elif a.constructor is Object:\n        # hashes\n        # compare individual properties (order doesn\'t matter if it\'s a hash)\n        if Object.keys(a).length is not Object.keys(b).length: return False\n        for i in a:\n            # recursively test equality of object children\n            if not ՐՏ_eq(a[i], b[i]):\n                return False\n        return True\n    elif (Set and a.constructor is Set) or (Map and a.constructor is Map):\n        # sets and maps\n        if a.size is not b.size: return False\n        for v\'i of a\':\n            if not b.has(i):\n                return False\n        return True\n    elif (a.constructor is Date):\n        # dates\n        return a.getTime() is b.getTime()\n    elif v\'typeof a.__eq__\' is \'function\':\n        # everything else that implements __eq__ method\n        return a.__eq__(b)\n    return False\n,\n"kwargs": def():\n    # WARNING: when using this function decorator, you will not be able to use obfuscators that rename local variables\n    def kwargs(f):\n        argNames = f.toString().match(/\\(([^\\)]+)/)[1]\n        if not kwargs.memo[argNames]:\n            kwargs.memo[argNames] = argNames ? argNames.split(\',\').map(def(s): return s.trim();) : []\n        argNames = kwargs.memo[argNames]\n        return def():\n            args = [].slice.call(arguments)\n            if args.length:\n                kw = args[-1]\n                if v\'typeof kw\' is \'object\':\n                    for i in range(argNames.length):\n                        if argNames[i] in kw:\n                            args[i] = kw[argNames[i]]\n                else:\n                    args.push(kw)\n\n            # This logic is very fragile and very subtle, it needs to work both in ES6 and ES5, don\'t try to optimize the\n            # apply away into *args because having it in this format ensures correct \'this\' context, otherwise the function\n            # ends up unbound. Similarly, the fallthrough to except handles class creation in ES6.\n            try:\n                return f.apply(this, args)\n            except as e:\n                if /Class constructor \\w+ cannot be invoked without \'new\'/.test(e):\n                    return new f(*args)\n                raise\n    kwargs.memo = {}\n,\n\n# Errors\n# temporarily implemented via a wrapper pattern since there is no mechanism for assigning\n# classes to dictionary keys yet\n"AssertionError": def():\n    class AssertionError(Error):\n        def __init__(self, message):\n            self.name = "AssertionError"\n            self.message = message\n,\n"IndexError": def():\n    class IndexError(Error):\n        def __init__(self, message):\n            self.name = "IndexError"\n            self.message = message\n,\n"KeyError": def():\n    class KeyError(Error):\n        def __init__(self, message):\n            self.name = "KeyError"\n            self.message = message\n,\n"TypeError": def():\n    class TypeError(Error):\n        def __init__(self, message):\n            self.name = "TypeError"\n            self.message = message\n,\n"ValueError": def():\n    class ValueError(Error):\n        def __init__(self, message):\n            self.name = "ValueError"\n            self.message = message\n,\n}\n';
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:_baselib"];
+    ՐՏ_mod.export("BASELIB", function(){return BASELIB;}, function(ՐՏ_v){if (typeof BASELIB !== "undefined") {BASELIB = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:stream"].body = function(){
     var __name__ = "stream";
 
-    var makePredicate = ՐՏ_modules["utils"].makePredicate;
-    var noop = ՐՏ_modules["utils"].noop;
-    var defaults = ՐՏ_modules["utils"].defaults;
-    var repeat_string = ՐՏ_modules["utils"].repeat_string;
-    var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
-    
+    var makePredicate = ՐՏ_modules["utils"].makePredicate;var noop = ՐՏ_modules["utils"].noop;var defaults = ՐՏ_modules["utils"].defaults;var repeat_string = ՐՏ_modules["utils"].repeat_string;var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
     var is_identifier_char = ՐՏ_modules["tokenizer"].is_identifier_char;
-    
     var ast = ՐՏ_modules["ast"];
-    
     var _baselib = ՐՏ_modules["_baselib"];
-    
     var parser = ՐՏ_modules["parser"];
-    
     function Stream(options) {
         var indentation, current_col, current_line, current_pos, BUFFERS, IMPORTED, might_need_space, might_need_semicolon, last, requireSemicolonChars, space, indent, with_indent, newline, semicolon, add_mapping, tmpIndex, stack, baselibCache;
         options = defaults(options, {
@@ -7291,17 +7230,18 @@ var ՐՏ_modules = {};
         }
         requireSemicolonChars = makePredicate("( [ + * / - , .");
         function print_(str_) {
+            var ՐՏ_407, ՐՏ_408, ՐՏ_409, ՐՏ_410, ՐՏ_411, ՐՏ_412, ՐՏ_413, ՐՏ_414, ՐՏ_415;
             var ch, target_line, prev, a, n;
             str_ = String(str_);
             ch = str_.charAt(0);
             if (might_need_semicolon) {
                 if ((!ch || !(ՐՏ_in(ch, ";}"))) && !/[;]$/.test(last)) {
                     if (options.semicolons || requireSemicolonChars(ch)) {
-                        BUFFERS[BUFFERS.length-1].output += ";";
+                        (ՐՏ_407 = BUFFERS)[ՐՏ_407.length-1].output += ";";
                         ++current_col;
                         ++current_pos;
                     } else {
-                        BUFFERS[BUFFERS.length-1].output += "\n";
+                        (ՐՏ_408 = BUFFERS)[ՐՏ_408.length-1].output += "\n";
                         ++current_pos;
                         ++current_line;
                         current_col = 0;
@@ -7313,10 +7253,10 @@ var ՐՏ_modules = {};
                 might_need_semicolon = false;
                 maybe_newline();
             }
-            if (!options.beautify && options.preserve_line && stack[stack.length - 1]) {
-                target_line = stack[stack.length - 1].start.line;
+            if (!options.beautify && options.preserve_line && (ՐՏ_409 = stack)[stack.length - 1]) {
+                target_line = (ՐՏ_410 = stack)[stack.length - 1].start.line;
                 while (current_line < target_line) {
-                    BUFFERS[BUFFERS.length-1].output += "\n";
+                    (ՐՏ_411 = BUFFERS)[ՐՏ_411.length-1].output += "\n";
                     ++current_pos;
                     ++current_line;
                     current_col = 0;
@@ -7326,7 +7266,7 @@ var ՐՏ_modules = {};
             if (might_need_space) {
                 prev = last_char();
                 if (is_identifier_char(prev) && (is_identifier_char(ch) || ch === "\\") || /^[\+\-\/]$/.test(ch) && ch === prev) {
-                    BUFFERS[BUFFERS.length-1].output += " ";
+                    (ՐՏ_412 = BUFFERS)[ՐՏ_412.length-1].output += " ";
                     ++current_col;
                     ++current_pos;
                 }
@@ -7336,13 +7276,13 @@ var ՐՏ_modules = {};
             n = a.length - 1;
             current_line += n;
             if (n === 0) {
-                current_col += a[n].length;
+                current_col += (ՐՏ_413 = a)[n].length;
             } else {
-                current_col = a[n].length;
+                current_col = (ՐՏ_414 = a)[n].length;
             }
             current_pos += str_.length;
             last = str_;
-            BUFFERS[BUFFERS.length-1].output += str_;
+            (ՐՏ_415 = BUFFERS)[ՐՏ_415.length-1].output += str_;
         }
         space = options.beautify ? function() {
             print_(" ");
@@ -7383,11 +7323,11 @@ var ՐՏ_modules = {};
             return indentation + options.indent_level;
         }
         function spaced() {
-            var ՐՏitr68, ՐՏidx68, ՐՏupk9;
+            var ՐՏitr71, ՐՏidx71, ՐՏupk9;
             var i, x;
-            ՐՏitr68 = ՐՏ_Iterable(enumerate(arguments));
-            for (ՐՏidx68 = 0; ՐՏidx68 < ՐՏitr68.length; ՐՏidx68++) {
-                ՐՏupk9 = ՐՏitr68[ՐՏidx68];
+            ՐՏitr71 = ՐՏ_Iterable(enumerate(arguments));
+            for (ՐՏidx71 = 0; ՐՏidx71 < ՐՏitr71.length; ՐՏidx71++) {
+                ՐՏupk9 = ՐՏitr71[ՐՏidx71];
                 i = ՐՏupk9[0];
                 x = ՐՏupk9[1];
                 if (i > 0) {
@@ -7431,7 +7371,7 @@ var ՐՏ_modules = {};
                 output.comma();
                 output.with_block(function() {
                     Object.keys(props).forEach(function(key, i) {
-                        var ՐՏitr69, ՐՏidx69;
+                        var ՐՏ_416, ՐՏ_417, ՐՏitr72, ՐՏidx72, ՐՏ_418, ՐՏ_419, ՐՏ_420, ՐՏ_421, ՐՏ_422, ՐՏ_423, ՐՏ_424, ՐՏ_425;
                         var print_name, prop_keys, prop_attrs, k;
                         print_name = function() {
                             output.print(key);
@@ -7442,18 +7382,19 @@ var ՐՏ_modules = {};
                                 "enumerable": "true",
                                 "writable": "true"
                             };
-                            prop_keys["value"] = props[key];
+                            (ՐՏ_416 = prop_keys)["value"] = (ՐՏ_417 = props)[key];
                         } else {
-                            ՐՏitr69 = ՐՏ_Iterable([ "get", "set", "value" ]);
-                            for (ՐՏidx69 = 0; ՐՏidx69 < ՐՏitr69.length; ՐՏidx69++) {
-                                k = ՐՏitr69[ՐՏidx69];
-                                if (props[key][k]) {
-                                    prop_keys[k] = props[key][k];
+                            ՐՏitr72 = ՐՏ_Iterable([ "get", "set", "value" ]);
+                            for (ՐՏidx72 = 0; ՐՏidx72 < ՐՏitr72.length; ՐՏidx72++) {
+                                k = ՐՏitr72[ՐՏidx72];
+                                if ((ՐՏ_418 = (ՐՏ_419 = props)[key])[k]) {
+                                    (ՐՏ_420 = prop_keys)[k] = (ՐՏ_421 = (ՐՏ_422 = props)[key])[k];
                                 }
                             }
-                            prop_attrs = props[key].attrs || {};
-                            print_name = props[key].name && props[key].name.print ? function() {
-                                props[key].name.print(output);
+                            prop_attrs = (ՐՏ_423 = props)[key].attrs || {};
+                            print_name = (ՐՏ_424 = props)[key].name && (ՐՏ_425 = props)[key].name.print ? function() {
+                                var ՐՏ_426;
+                                (ՐՏ_426 = props)[key].name.print(output);
                             } : print_name;
                         }
                         if (i) {
@@ -7464,22 +7405,22 @@ var ՐՏ_modules = {};
                         print_name();
                         output.colon();
                         output.with_block(function() {
-                            var ՐՏitr70, ՐՏidx70, ՐՏitr71, ՐՏidx71;
+                            var ՐՏitr73, ՐՏidx73, ՐՏ_427, ՐՏitr74, ՐՏidx74, ՐՏ_428;
                             var attr, i, k;
-                            ՐՏitr70 = ՐՏ_Iterable(prop_keys.value ? [ "enumerable", "writable" ] : [ "enumerable", "configurable" ]);
-                            for (ՐՏidx70 = 0; ՐՏidx70 < ՐՏitr70.length; ՐՏidx70++) {
-                                attr = ՐՏitr70[ՐՏidx70];
+                            ՐՏitr73 = ՐՏ_Iterable(prop_keys.value ? [ "enumerable", "writable" ] : [ "enumerable", "configurable" ]);
+                            for (ՐՏidx73 = 0; ՐՏidx73 < ՐՏitr73.length; ՐՏidx73++) {
+                                attr = ՐՏitr73[ՐՏidx73];
                                 output.indent();
                                 output.print(attr);
                                 output.colon();
-                                output.print(prop_attrs[attr] || "true");
+                                output.print((ՐՏ_427 = prop_attrs)[attr] || "true");
                                 output.comma();
                                 output.newline();
                             }
                             i = 0;
-                            ՐՏitr71 = ՐՏ_Iterable(prop_keys);
-                            for (ՐՏidx71 = 0; ՐՏidx71 < ՐՏitr71.length; ՐՏidx71++) {
-                                k = ՐՏitr71[ՐՏidx71];
+                            ՐՏitr74 = ՐՏ_Iterable(prop_keys);
+                            for (ՐՏidx74 = 0; ՐՏidx74 < ՐՏitr74.length; ՐՏidx74++) {
+                                k = ՐՏitr74[ՐՏidx74];
                                 if (i) {
                                     output.comma();
                                     output.newline();
@@ -7488,7 +7429,7 @@ var ՐՏ_modules = {};
                                 output.indent();
                                 output.print(k);
                                 output.colon();
-                                prop_keys[k](output);
+                                (ՐՏ_428 = prop_keys)[k](output);
                             }
                             output.newline();
                         });
@@ -7576,20 +7517,21 @@ var ՐՏ_modules = {};
             }
         } : noop;
         function get_() {
+            var ՐՏ_429, ՐՏ_430, ՐՏ_431, ՐՏ_432;
             var output, out;
             if (BUFFERS.len > 1) {
                 throw new Error("Something went wrong, output generator didn't exit all of its scopes properly.");
             }
             output = this;
-            if (BUFFERS[0].vars.length) {
+            if ((ՐՏ_429 = BUFFERS)[0].vars.length) {
                 BUFFERS.unshift({
                     vars: [],
                     output: ""
                 });
                 endLocalBuffer();
             }
-            out = BUFFERS[0].output;
-            BUFFERS[0].output = "";
+            out = (ՐՏ_430 = BUFFERS)[0].output;
+            (ՐՏ_431 = BUFFERS)[0].output = "";
             if (options.private_scope) {
                 output.with_parens(function() {
                     output.print("function()");
@@ -7604,7 +7546,7 @@ var ՐՏ_modules = {};
             } else {
                 output.print(out);
             }
-            return BUFFERS[BUFFERS.length-1].output;
+            return (ՐՏ_432 = BUFFERS)[ՐՏ_432.length-1].output;
         }
         function assign_var(name) {
             if (typeof name === "string") {
@@ -7623,19 +7565,21 @@ var ՐՏ_modules = {};
             "_": 0
         };
         function newTemp(subtype, buffer) {
+            var ՐՏ_433, ՐՏ_434, ՐՏ_435;
             subtype = subtype === void 0 ? "_" : subtype;
             buffer = buffer === void 0 ? true : buffer;
             var tmp;
-            ++tmpIndex[subtype];
-            tmp = RAPYD_PREFIX + subtype + tmpIndex[subtype];
+            ++(ՐՏ_433 = tmpIndex)[subtype];
+            tmp = RAPYD_PREFIX + subtype + (ՐՏ_434 = tmpIndex)[subtype];
             if (buffer) {
-                BUFFERS[BUFFERS.length-1].vars.push(tmp);
+                (ՐՏ_435 = BUFFERS)[ՐՏ_435.length-1].vars.push(tmp);
             }
             return tmp;
         }
         function prevTemp(subtype) {
+            var ՐՏ_436;
             subtype = subtype === void 0 ? "_" : subtype;
-            return RAPYD_PREFIX + subtype + tmpIndex[subtype];
+            return RAPYD_PREFIX + subtype + (ՐՏ_436 = tmpIndex)[subtype];
         }
         function startLocalBuffer() {
             BUFFERS.push({
@@ -7644,6 +7588,7 @@ var ՐՏ_modules = {};
             });
         }
         function endLocalBuffer(baselib) {
+            var ՐՏ_437, ՐՏ_438, ՐՏ_439;
             baselib = baselib === void 0 ? false : baselib;
             var localBuffer;
             localBuffer = BUFFERS.pop();
@@ -7660,15 +7605,15 @@ var ՐՏ_modules = {};
                 newline();
             }
             if (baselib) {
-                BUFFERS[BUFFERS.length-1].output = localBuffer.output + BUFFERS[BUFFERS.length-1].output;
+                (ՐՏ_437 = BUFFERS)[ՐՏ_437.length-1].output = localBuffer.output + (ՐՏ_438 = BUFFERS)[ՐՏ_438.length-1].output;
             } else {
-                BUFFERS[BUFFERS.length-1].output += localBuffer.output;
+                (ՐՏ_439 = BUFFERS)[ՐՏ_439.length-1].output += localBuffer.output;
             }
         }
         stack = [];
         baselibCache = {};
         function print_baselib(key) {
-            var ՐՏitr72, ՐՏidx72;
+            var ՐՏ_440, ՐՏitr75, ՐՏidx75, ՐՏ_441, ՐՏ_442;
             var baselibAst, hash, data, item, key_, value;
             if (!options.omit_baselib) {
                 if (!Object.keys(baselibCache).length) {
@@ -7677,23 +7622,24 @@ var ՐՏ_modules = {};
                         dropDocstrings: true,
                         filename: "_baselib.pyj"
                     });
-                    hash = baselibAst.body[baselibAst.body.length-1];
+                    hash = (ՐՏ_440 = baselibAst.body)[ՐՏ_440.length-1];
                     data = hash.body.properties;
-                    ՐՏitr72 = ՐՏ_Iterable(data);
-                    for (ՐՏidx72 = 0; ՐՏidx72 < ՐՏitr72.length; ՐՏidx72++) {
-                        item = ՐՏitr72[ՐՏidx72];
+                    ՐՏitr75 = ՐՏ_Iterable(data);
+                    for (ՐՏidx75 = 0; ՐՏidx75 < ՐՏitr75.length; ՐՏidx75++) {
+                        item = ՐՏitr75[ՐՏidx75];
                         key_ = item.key.value;
                         value = item.value.name ? [ item.value ] : item.value.body;
-                        baselibCache[key_] = splatBaselib(key_, value);
+                        (ՐՏ_441 = baselibCache)[key_] = splatBaselib(key_, value);
                     }
                 }
-                baselibCache[key].print(this);
+                (ՐՏ_442 = baselibCache)[key].print(this);
             }
             return null;
         }
         function import_(key) {
+            var ՐՏ_443;
             if (!IMPORTED.hasOwnProperty(key)) {
-                IMPORTED[key] = key;
+                (ՐՏ_443 = IMPORTED)[key] = key;
                 return true;
             }
             return false;
@@ -7747,10 +7693,12 @@ var ՐՏ_modules = {};
             print_baselib: print_baselib,
             import: import_,
             is_main: function() {
-                return BUFFERS.length === 1 && BUFFERS[BUFFERS.length-1].output.length === 0;
+                var ՐՏ_444;
+                return BUFFERS.length === 1 && (ՐՏ_444 = BUFFERS)[ՐՏ_444.length-1].output.length === 0;
             },
             option: function(opt) {
-                return options[opt];
+                var ՐՏ_445;
+                return (ՐՏ_445 = options)[opt];
             },
             line: function() {
                 return current_line;
@@ -7773,26 +7721,29 @@ var ՐՏ_modules = {};
             newTemp: newTemp,
             prevTemp: prevTemp,
             parent: function(n) {
-                return stack[stack.length - 2 - (n || 0)];
+                var ՐՏ_446;
+                return (ՐՏ_446 = stack)[stack.length - 2 - (n || 0)];
             }
         };
     }
-    ՐՏ_modules["stream"]["Stream"] = Stream;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:stream"];
+    ՐՏ_mod.export("Stream", function(){return Stream;}, function(ՐՏ_v){if (typeof Stream !== "undefined") {Stream = ՐՏ_v;};});
+    ՐՏ_mod.export("RAPYD_PREFIX", function(){return RAPYD_PREFIX;}, function(ՐՏ_v){if (typeof RAPYD_PREFIX !== "undefined") {RAPYD_PREFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("is_identifier_char", function(){return is_identifier_char;}, function(ՐՏ_v){if (typeof is_identifier_char !== "undefined") {is_identifier_char = ՐՏ_v;};});
+    ՐՏ_mod.export("ast", function(){return ast;}, function(ՐՏ_v){if (typeof ast !== "undefined") {ast = ՐՏ_v;};});
+    ՐՏ_mod.export("_baselib", function(){return _baselib;}, function(ՐՏ_v){if (typeof _baselib !== "undefined") {_baselib = ՐՏ_v;};});
+    ՐՏ_mod.export("parser", function(){return parser;}, function(ՐՏ_v){if (typeof parser !== "undefined") {parser = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 
-(function(){
+ՐՏ_modules["ՐՏ:output"].body = function(){
     var __name__ = "output";
 
     var Stream;
-    var noop = ՐՏ_modules["utils"].noop;
-    var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
-    
+    var noop = ՐՏ_modules["utils"].noop;var RAPYD_PREFIX = ՐՏ_modules["utils"].RAPYD_PREFIX;
     var PRECEDENCE = ՐՏ_modules["tokenizer"].PRECEDENCE;
-    
     var stream = ՐՏ_modules["stream"];
-    
     var ast = ՐՏ_modules["ast"];
-    
     Stream = stream.Stream;
     (function() {
         var SPECIAL_METHODS, BASELIB, CREATION;
@@ -7823,14 +7774,14 @@ var ՐՏ_modules = {};
                             output.assign(assign);
                         }
                         output.with_parens(function() {
-                            var ՐՏitr73, ՐՏidx73;
+                            var ՐՏitr76, ՐՏidx76;
                             var arg;
                             output.assign(tmp);
                             baseFn();
                             output.comma();
-                            ՐՏitr73 = ՐՏ_Iterable(args);
-                            for (ՐՏidx73 = 0; ՐՏidx73 < ՐՏitr73.length; ՐՏidx73++) {
-                                arg = ՐՏitr73[ՐՏidx73];
+                            ՐՏitr76 = ՐՏ_Iterable(args);
+                            for (ՐՏidx76 = 0; ՐՏidx76 < ՐՏitr76.length; ՐՏidx76++) {
+                                arg = ՐՏitr76[ՐՏidx76];
                                 if (!(ՐՏ_in(arg, [ null, void 0 ]))) {
                                     arg.call(output, tmp);
                                     output.comma();
@@ -7877,7 +7828,7 @@ var ՐՏ_modules = {};
             return s.get();
         };
         ast.Node.prototype.add_comments = function(output) {
-            var ՐՏitr74, ՐՏidx74;
+            var ՐՏitr77, ՐՏidx77;
             var c, self, start, comments;
             c = output.option("comments");
             self = this;
@@ -7899,9 +7850,9 @@ var ՐՏ_modules = {};
                             return c(self, comment);
                         });
                     }
-                    ՐՏitr74 = ՐՏ_Iterable(comments);
-                    for (ՐՏidx74 = 0; ՐՏidx74 < ՐՏitr74.length; ՐՏidx74++) {
-                        c = ՐՏitr74[ՐՏidx74];
+                    ՐՏitr77 = ՐՏ_Iterable(comments);
+                    for (ՐՏidx77 = 0; ՐՏidx77 < ՐՏitr77.length; ՐՏidx77++) {
+                        c = ՐՏitr77[ՐՏidx77];
                         if (c.subtype === "line") {
                             output.print("//" + c.value + "\n");
                             output.indent();
@@ -7944,6 +7895,7 @@ var ՐՏ_modules = {};
             return false;
         });
         PARENS(ast.Binary, function(output) {
+            var ՐՏ_447, ՐՏ_448;
             var p, po, pp, so, sp;
             p = output.parent();
             if (p instanceof ast.BaseCall && p.expression === this) {
@@ -7957,9 +7909,9 @@ var ՐՏ_modules = {};
             }
             if (p instanceof ast.Binary) {
                 po = p.operator;
-                pp = PRECEDENCE[po];
+                pp = (ՐՏ_447 = PRECEDENCE)[po];
                 so = this.operator;
-                sp = PRECEDENCE[so];
+                sp = (ՐՏ_448 = PRECEDENCE)[so];
                 if (pp > sp || pp === sp && this === p.right && !(so === po && (so === "*" || so === "&&" || so === "||"))) {
                     return true;
                 }
@@ -8043,12 +7995,13 @@ var ՐՏ_modules = {};
             output.semicolon();
         });
         function display_body(body, is_toplevel, output, with_return) {
+            var ՐՏ_449;
             var last;
             if (with_return) {
                 output.indent();
                 output.print("return");
                 output.space();
-                body[0].print(output);
+                (ՐՏ_449 = body)[0].print(output);
                 output.newline();
                 return;
             }
@@ -8079,42 +8032,49 @@ var ՐՏ_modules = {};
             }
         }
         function write_imports(module_, output) {
-            var ՐՏitr75, ՐՏidx75, ՐՏitr76, ՐՏidx76, ՐՏitr77, ՐՏidx77, ՐՏitr78, ՐՏidx78;
+            var ՐՏ_462, ՐՏitr78, ՐՏidx78, ՐՏitr79, ՐՏidx79, ՐՏ_463, ՐՏitr80, ՐՏidx80, ՐՏitr81, ՐՏidx81;
             var imports, nonlocalvars, name;
             function sort_imports(mod, imp_sorted, importing, done) {
+                var ՐՏ_454, ՐՏ_455, ՐՏ_456;
                 var imp_keys;
+                if (mod.async) {
+                    return imp_sorted;
+                }
                 imp_sorted = imp_sorted || [];
                 importing = importing || {};
                 done = done || {};
                 function push_key(k) {
-                    if (!done[k]) {
+                    var ՐՏ_450, ՐՏ_451;
+                    if (!(ՐՏ_450 = done)[k]) {
                         imp_sorted.push(k);
-                        done[k] = true;
+                        (ՐՏ_451 = done)[k] = true;
                     }
                 }
                 function sort_imp(a, b) {
-                    a = module_.imports[a].import_order;
-                    b = module_.imports[b].import_order;
+                    var ՐՏ_452, ՐՏ_453;
+                    a = (ՐՏ_452 = module_.imports)[a].import_order;
+                    b = (ՐՏ_453 = module_.imports)[b].import_order;
                     return a < b ? -1 : a > b ? 1 : 0;
                 }
-                if (importing[mod.module_id] || done[mod.module_id]) {
+                if ((ՐՏ_454 = importing)[mod.module_id] || (ՐՏ_455 = done)[mod.module_id]) {
                     return;
                 }
-                importing[mod.module_id] = true;
+                (ՐՏ_456 = importing)[mod.module_id] = true;
                 imp_keys = Object.keys(mod.depends_on).sort(sort_imp);
                 imp_keys.forEach(function(mod_id) {
-                    var ՐՏ_122;
+                    var ՐՏ_457, ՐՏ_458, ՐՏ_459;
                     var pack_id;
-                    pack_id = mod_id.split(".")[0];
-                    if ((pack_id !== (ՐՏ_122 = mod.module_id) && (typeof pack_id !== "object" || !ՐՏ_eq(pack_id, ՐՏ_122)))) {
-                        sort_imports(module_.imports[pack_id], imp_sorted, importing, done);
+                    pack_id = (ՐՏ_457 = mod_id.split("."))[0];
+                    if ((pack_id !== (ՐՏ_458 = mod.module_id) && (typeof pack_id !== "object" || !ՐՏ_eq(pack_id, ՐՏ_458)))) {
+                        sort_imports((ՐՏ_459 = module_.imports)[pack_id], imp_sorted, importing, done);
                         push_key(mod_id);
                     }
                 });
                 if (mod.submodules.length) {
                     mod.submodules.sort(sort_imp);
                     mod.submodules.forEach(function(sub_key) {
-                        sort_imports(module_.imports[sub_key], imp_sorted, importing, done);
+                        var ՐՏ_460;
+                        sort_imports((ՐՏ_460 = module_.imports)[sub_key], imp_sorted, importing, done);
                         push_key(sub_key);
                     });
                     push_key(mod.module_id);
@@ -8122,22 +8082,26 @@ var ՐՏ_modules = {};
                 return imp_sorted;
             }
             imports = sort_imports(module_).map(function(mid) {
-                return module_.imports[mid];
+                var ՐՏ_461;
+                return (ՐՏ_461 = module_.imports)[mid];
             });
-            imports.push(module_.imports["__main__"]);
+            imports.push((ՐՏ_462 = module_.imports)["__main__"]);
             if (imports.length > 1) {
                 output.indent();
-                output.spaced("var ՐՏ_modules", "=", "{};");
+                output.spaced("var ՐՏ_modules", "=", "ՐՏ_def_modules();");
                 output.newline();
             }
             nonlocalvars = {};
-            ՐՏitr75 = ՐՏ_Iterable(imports);
-            for (ՐՏidx75 = 0; ՐՏidx75 < ՐՏitr75.length; ՐՏidx75++) {
-                module_ = ՐՏitr75[ՐՏidx75];
-                ՐՏitr76 = ՐՏ_Iterable(module_.nonlocalvars);
-                for (ՐՏidx76 = 0; ՐՏidx76 < ՐՏitr76.length; ՐՏidx76++) {
-                    name = ՐՏitr76[ՐՏidx76];
-                    nonlocalvars[name] = true;
+            ՐՏitr78 = ՐՏ_Iterable(imports);
+            for (ՐՏidx78 = 0; ՐՏidx78 < ՐՏitr78.length; ՐՏidx78++) {
+                module_ = ՐՏitr78[ՐՏidx78];
+                if (module_.async) {
+                    continue;
+                }
+                ՐՏitr79 = ՐՏ_Iterable(module_.nonlocalvars);
+                for (ՐՏidx79 = 0; ՐՏidx79 < ՐՏitr79.length; ՐՏidx79++) {
+                    name = ՐՏitr79[ՐՏidx79];
+                    (ՐՏ_463 = nonlocalvars)[name] = true;
                 }
             }
             nonlocalvars = Object.getOwnPropertyNames(nonlocalvars).join(", ");
@@ -8146,20 +8110,19 @@ var ՐՏ_modules = {};
                 output.print("var " + nonlocalvars);
                 output.end_statement();
             }
-            ՐՏitr77 = ՐՏ_Iterable(imports);
-            for (ՐՏidx77 = 0; ՐՏidx77 < ՐՏitr77.length; ՐՏidx77++) {
-                module_ = ՐՏitr77[ՐՏidx77];
+            ՐՏitr80 = ՐՏ_Iterable(imports);
+            for (ՐՏidx80 = 0; ՐՏidx80 < ՐՏitr80.length; ՐՏidx80++) {
+                module_ = ՐՏitr80[ՐՏidx80];
                 if (module_.module_id !== "__main__") {
                     output.indent();
-                    output.assign('ՐՏ_modules["' + module_.module_id + '"]');
-                    output.print("{}");
+                    output.print('ՐՏ_modules.ՐՏ_def("' + module_.module_id + '")');
                     output.end_statement();
                 }
             }
-            ՐՏitr78 = ՐՏ_Iterable(imports);
-            for (ՐՏidx78 = 0; ՐՏidx78 < ՐՏitr78.length; ՐՏidx78++) {
-                module_ = ՐՏitr78[ՐՏidx78];
-                if (module_.module_id !== "__main__") {
+            ՐՏitr81 = ՐՏ_Iterable(imports);
+            for (ՐՏidx81 = 0; ՐՏidx81 < ՐՏitr81.length; ՐՏidx81++) {
+                module_ = ՐՏitr81[ՐՏidx81];
+                if (!module_.async && module_.module_id !== "__main__") {
                     print_module(module_, output);
                 }
             }
@@ -8173,6 +8136,7 @@ var ՐՏ_modules = {};
             }
         }
         function display_complex_body(node, is_toplevel, output) {
+            var ՐՏ_464, ՐՏ_465, ՐՏ_466, ՐՏ_467, ՐՏ_468, ՐՏ_469, ՐՏ_470, ՐՏ_471, ՐՏ_472, ՐՏ_473;
             var offset, needsSuper, delaySelfAssignment, arg, stmt, with_return;
             output.startLocalBuffer();
             offset = 0;
@@ -8194,7 +8158,7 @@ var ՐՏ_modules = {};
                         output.end_statement();
                     }
                     output.indent();
-                    output.spaced("var", node.argnames[0], "=", "this");
+                    output.spaced("var", (ՐՏ_464 = node.argnames)[0], "=", "this");
                     output.end_statement();
                 }
             }
@@ -8215,7 +8179,7 @@ var ՐՏ_modules = {};
                             output.indent();
                             output.spaced(arg, "=", arg, "===", "void 0", "?");
                             output.space();
-                            force_statement(node.argnames.defaults[arg], output);
+                            force_statement((ՐՏ_465 = node.argnames.defaults)[arg], output);
                             output.space();
                             output.colon();
                             output.print(arg);
@@ -8244,8 +8208,8 @@ var ՐՏ_modules = {};
                     output.end_statement();
                 }
             }
-            stmt = node instanceof ast.Lambda && node.body.length === 1 && !node.body[0].start.newline_before && node.body[0] instanceof ast.SimpleStatement && node.body[0].body;
-            with_return = stmt && (node.body[0].start.value === "(" || node.body[0].body instanceof ast.Array || node.body[0].body instanceof ast.ObjectLiteral || node.body[0].body instanceof ast.Dot || node.body[0].body instanceof ast.PropAccess);
+            stmt = node instanceof ast.Lambda && node.body.length === 1 && !(ՐՏ_466 = node.body)[0].start.newline_before && (ՐՏ_467 = node.body)[0] instanceof ast.SimpleStatement && (ՐՏ_468 = node.body)[0].body;
+            with_return = stmt && ((ՐՏ_469 = node.body)[0].start.value === "(" || (ՐՏ_470 = node.body)[0].body instanceof ast.Array || (ՐՏ_471 = node.body)[0].body instanceof ast.ObjectLiteral || (ՐՏ_472 = node.body)[0].body instanceof ast.Dot || (ՐՏ_473 = node.body)[0].body instanceof ast.PropAccess);
             display_body(node.body, is_toplevel, output, with_return);
             output.endLocalBuffer();
         }
@@ -8263,39 +8227,45 @@ var ՐՏ_modules = {};
             }
         }
         function declare_submodules(module_id, submodules, output) {
-            var ՐՏitr79, ՐՏidx79;
-            var seen, sub_module_id, key;
+            var ՐՏitr82, ՐՏidx82, ՐՏ_474, ՐՏ_475;
+            var seen, sub_module_id, key, sub_mod;
             seen = {};
             output.newline();
-            ՐՏitr79 = ՐՏ_Iterable(submodules);
-            for (ՐՏidx79 = 0; ՐՏidx79 < ՐՏitr79.length; ՐՏidx79++) {
-                sub_module_id = ՐՏitr79[ՐՏidx79];
+            ՐՏitr82 = ՐՏ_Iterable(submodules);
+            for (ՐՏidx82 = 0; ՐՏidx82 < ՐՏitr82.length; ՐՏidx82++) {
+                sub_module_id = ՐՏitr82[ՐՏidx82];
                 if (!seen.hasOwnProperty(sub_module_id)) {
-                    seen[sub_module_id] = true;
-                    key = sub_module_id.split(".")[sub_module_id.split(".").length-1];
+                    (ՐՏ_474 = seen)[sub_module_id] = true;
+                    key = (ՐՏ_475 = sub_module_id.split("."))[ՐՏ_475.length-1];
                     output.indent();
-                    output.print('ՐՏ_modules["' + module_id + '"]["' + key + '"] = ');
-                    output.print('ՐՏ_modules["' + sub_module_id + '"]');
+                    sub_mod = 'ՐՏ_modules["' + sub_module_id + '"]';
+                    output.print('ՐՏ_modules["ՐՏ:' + module_id + '"].export("' + key + '", function(){return ' + sub_mod + ';}, function(){throw new Error("use Object.defineProperty!");})');
                     output.end_statement();
                 }
             }
         }
         function declare_exports(module_id, exports, output) {
-            var ՐՏitr80, ՐՏidx80;
-            var seen, symbol;
+            var ՐՏitr83, ՐՏidx83, ՐՏ_476, ՐՏ_477;
+            var seen, rs_mod, symbol;
             output.newline();
             seen = {};
-            ՐՏitr80 = ՐՏ_Iterable(exports);
-            for (ՐՏidx80 = 0; ՐՏidx80 < ՐՏitr80.length; ՐՏidx80++) {
-                symbol = ՐՏitr80[ՐՏidx80];
-                if (!seen[symbol.name]) {
-                    seen[symbol.name] = true;
+            output.indent();
+            rs_mod = 'ՐՏ_modules["ՐՏ:' + module_id + '"]';
+            output.print('var ՐՏ_mod = ՐՏ_modules["ՐՏ:' + module_id + '"]');
+            output.end_statement();
+            ՐՏitr83 = ՐՏ_Iterable(exports);
+            for (ՐՏidx83 = 0; ՐՏidx83 < ՐՏitr83.length; ՐՏidx83++) {
+                symbol = ՐՏitr83[ՐՏidx83];
+                if (!(ՐՏ_476 = seen)[symbol.name]) {
+                    (ՐՏ_477 = seen)[symbol.name] = true;
                     output.indent();
-                    output.assign('ՐՏ_modules["' + module_id + '"]["' + symbol.name + '"]');
-                    output.print(symbol.name);
+                    output.print('ՐՏ_mod.export("' + symbol.name + '", function(){return ' + symbol.name + ";}, function(ՐՏ_v){if (typeof " + symbol.name + ' !== "undefined") {' + symbol.name + " = ՐՏ_v;};})");
                     output.end_statement();
                 }
             }
+            output.indent();
+            output.print('return ՐՏ_mod["exports"]');
+            output.end_statement();
         }
         function unpack_tuple(tuple, output, in_statement) {
             tuple.elements.forEach(function(elem, i) {
@@ -8365,30 +8335,32 @@ var ՐՏ_modules = {};
             if (is_main) {
                 output.startLocalBuffer();
                 Object.keys(BASELIB).filter(function(a) {
-                    return self.baselib[a] > 0;
+                    var ՐՏ_478;
+                    return (ՐՏ_478 = self.baselib)[a] > 0;
                 }).forEach(function(key) {
                     output.print_baselib(key);
                 });
+                if (Object.keys(self.imports).length > 1) {
+                    output.print_baselib("def_modules");
+                }
                 output.endLocalBuffer(true);
             }
         });
         function print_module(self, output) {
             output.newline();
             output.indent();
-            output.with_parens(function() {
-                output.print("function()");
-                output.with_block(function() {
-                    output.indent();
-                    output.assign("var __name__");
-                    output.print('"' + self.module_id + '"');
-                    output.end_statement();
-                    declare_submodules(self.module_id, self.submodules, output);
-                    declare_vars(self.localvars, output);
-                    display_body(self.body, true, output);
-                    declare_exports(self.module_id, self.exports, output);
-                });
+            output.assign('ՐՏ_modules["ՐՏ:' + self.module_id + '"].body');
+            output.print("function()");
+            output.with_block(function() {
+                output.indent();
+                output.assign("var __name__");
+                output.print('"' + self.module_id + '"');
+                output.end_statement();
+                declare_submodules(self.module_id, self.submodules, output);
+                declare_vars(self.localvars, output);
+                display_body(self.body, true, output);
+                declare_exports(self.module_id, self.exports, output);
             });
-            output.print("()");
             output.end_statement();
         }
         DEFPRINT(ast.Splat, function(self, output) {
@@ -8398,40 +8370,45 @@ var ՐՏ_modules = {};
             }
         });
         DEFPRINT(ast.Imports, function(container, output) {
-            var ՐՏitr81, ՐՏidx81, ՐՏitr82, ՐՏidx82;
-            var seen, self, argname, alias, bound_name;
+            var ՐՏitr84, ՐՏidx84, ՐՏitr85, ՐՏidx85, ՐՏ_484;
+            var seen, i, self, argname, alias, bound_name;
             seen = {};
+            i = 0;
             function add_aname(aname, key, from_import) {
-                var ՐՏ_123;
+                var ՐՏ_479, ՐՏ_480, ՐՏ_481, ՐՏ_482, ՐՏ_483;
                 var seen_key, tmp;
                 seen_key = key + (from_import ? "." + from_import : "");
-                if (seen[aname]) {
-                    if (((ՐՏ_123 = seen[aname]) === seen_key || typeof ՐՏ_123 === "object" && ՐՏ_eq(ՐՏ_123, seen_key))) {
+                if ((ՐՏ_479 = seen)[aname]) {
+                    if (((ՐՏ_480 = (ՐՏ_481 = seen)[aname]) === seen_key || typeof ՐՏ_480 === "object" && ՐՏ_eq(ՐՏ_480, seen_key))) {
                         return;
                     } else {
-                        tmp = aname + " : " + [ seen[aname], seen_key ].join(", ");
+                        tmp = aname + " : " + [ (ՐՏ_482 = seen)[aname], seen_key ].join(", ");
                         throw new Error("Something went wrong, 2 imports with the same name detected: " + tmp);
                     }
                 }
-                seen[aname] = seen_key;
+                (ՐՏ_483 = seen)[aname] = seen_key;
+                if (i) {
+                    output.newline();
+                    output.indent();
+                    ++i;
+                }
                 output.assign("var " + aname);
                 output.print('ՐՏ_modules["' + key + '"]');
                 if (from_import) {
                     output.print("." + from_import);
                 }
-                output.end_statement();
-                output.indent();
+                output.semicolon();
             }
-            ՐՏitr81 = ՐՏ_Iterable(container.imports);
-            for (ՐՏidx81 = 0; ՐՏidx81 < ՐՏitr81.length; ՐՏidx81++) {
-                self = ՐՏitr81[ՐՏidx81];
+            ՐՏitr84 = ՐՏ_Iterable(container.imports);
+            for (ՐՏidx84 = 0; ՐՏidx84 < ՐՏitr84.length; ՐՏidx84++) {
+                self = ՐՏitr84[ՐՏidx84];
                 if (self instanceof ast.Splat) {
                     output.import(self.module.name);
                 }
                 if (self.argnames) {
-                    ՐՏitr82 = ՐՏ_Iterable(self.argnames);
-                    for (ՐՏidx82 = 0; ՐՏidx82 < ՐՏitr82.length; ՐՏidx82++) {
-                        argname = ՐՏitr82[ՐՏidx82];
+                    ՐՏitr85 = ՐՏ_Iterable(self.argnames);
+                    for (ՐՏidx85 = 0; ՐՏidx85 < ՐՏitr85.length; ՐՏidx85++) {
+                        argname = ՐՏitr85[ՐՏidx85];
                         alias = argname.alias ? argname.alias.name : argname.name;
                         add_aname(alias, self.key, argname.name);
                     }
@@ -8439,7 +8416,7 @@ var ՐՏ_modules = {};
                     if (self.alias) {
                         add_aname(self.alias.name, self.key, false);
                     } else {
-                        bound_name = self.key.split(".", 1)[0];
+                        bound_name = (ՐՏ_484 = self.key.split(".", 1))[0];
                         add_aname(bound_name, bound_name, false);
                     }
                 }
@@ -8502,7 +8479,8 @@ var ՐՏ_modules = {};
             return false;
         }
         function is_simple_for(self) {
-            if (self.object instanceof ast.BaseCall && self.object.expression instanceof ast.SymbolRef && self.object.expression.name === "range" && !(self.init instanceof ast.Array) && (self.object.args.length < 3 || self.object.args[self.object.args.length-1][0] instanceof ast.Number || self.object.args[self.object.args.length-1][0] instanceof ast.Unary && self.object.args[self.object.args.length-1][0].operator === "-" && self.object.args[self.object.args.length-1][0].expression instanceof ast.Number)) {
+            var ՐՏ_485, ՐՏ_486, ՐՏ_487, ՐՏ_488, ՐՏ_489, ՐՏ_490, ՐՏ_491, ՐՏ_492;
+            if (self.object instanceof ast.BaseCall && self.object.expression instanceof ast.SymbolRef && self.object.expression.name === "range" && !(self.init instanceof ast.Array) && (self.object.args.length < 3 || (ՐՏ_485 = (ՐՏ_486 = self.object.args)[ՐՏ_486.length-1])[0] instanceof ast.Number || (ՐՏ_487 = (ՐՏ_488 = self.object.args)[ՐՏ_488.length-1])[0] instanceof ast.Unary && (ՐՏ_489 = (ՐՏ_490 = self.object.args)[ՐՏ_490.length-1])[0].operator === "-" && (ՐՏ_491 = (ՐՏ_492 = self.object.args)[ՐՏ_492.length-1])[0].expression instanceof ast.Number)) {
                 return true;
             }
             return false;
@@ -8552,6 +8530,7 @@ var ՐՏ_modules = {};
             });
         };
         DEFPRINT(ast.ForIn, function(self, output) {
+            var ՐՏ_493, ՐՏ_494, ՐՏ_495, ՐՏ_496, ՐՏ_497, ՐՏ_498;
             var increment, args, tmp_, start, end, iterator;
             if (is_simple_for(self)) {
                 increment = null;
@@ -8559,14 +8538,14 @@ var ՐՏ_modules = {};
                 tmp_ = args.length;
                 if (tmp_ === 1) {
                     start = 0;
-                    end = args[0];
+                    end = (ՐՏ_493 = args)[0];
                 } else if (tmp_ === 2) {
-                    start = args[0];
-                    end = args[1];
+                    start = (ՐՏ_494 = args)[0];
+                    end = (ՐՏ_495 = args)[1];
                 } else if (tmp_ === 3) {
-                    start = args[0];
-                    end = args[1];
-                    increment = args[2];
+                    start = (ՐՏ_496 = args)[0];
+                    end = (ՐՏ_497 = args)[1];
+                    increment = (ՐՏ_498 = args)[2];
                 }
                 output.print("for");
                 output.space();
@@ -8603,7 +8582,8 @@ var ՐՏ_modules = {};
                 output.print("for");
                 output.space();
                 output.with_parens(function() {
-                    output.spaced(self.init, "in", self.object.args[0]);
+                    var ՐՏ_499;
+                    output.spaced(self.init, "in", (ՐՏ_499 = self.object.args)[0]);
                 });
             } else {
                 iterator = output.newTemp("itr");
@@ -8653,11 +8633,12 @@ var ՐՏ_modules = {};
             self._do_print_body(output);
         });
         DEFPRINT(ast.ListComprehension, function(self, output) {
+            var ՐՏ_500;
             var constructor, iterator, index, result, add_entry;
-            constructor = {
+            constructor = (ՐՏ_500 = {
                 ListComprehension: "[]",
                 DictComprehension: "{}"
-            }[ՐՏ_type(self)];
+            })[ՐՏ_type(self)];
             iterator = output.newTemp("itr", false);
             index = output.newTemp("idx", false);
             result = RAPYD_PREFIX + "res";
@@ -8787,8 +8768,9 @@ var ՐՏ_modules = {};
             var pos, wrap;
             pos = 0;
             wrap = function() {
+                var ՐՏ_501;
                 if (pos < decorators.length) {
-                    decorators[pos].expression.print(output);
+                    (ՐՏ_501 = decorators)[pos].expression.print(output);
                     ++pos;
                     output.with_parens(function() {
                         wrap();
@@ -8807,7 +8789,7 @@ var ՐՏ_modules = {};
             };
         }
         ast.Lambda.prototype._do_print = function(output) {
-            var ՐՏ_124;
+            var ՐՏ_502;
             var self, name, is_like_method;
             self = this;
             function addDecorators() {
@@ -8856,7 +8838,7 @@ var ՐՏ_modules = {};
             }
             
             
-            var internalsub = (ՐՏ_124 = function internalsub(print_name) {
+            var internalsub = (ՐՏ_502 = function internalsub(print_name) {
                 print_name = print_name === void 0 ? true : print_name;
                 output.print("function");
                 if (self.generator) {
@@ -8868,6 +8850,7 @@ var ՐՏ_modules = {};
                 }
                 output.with_parens(function() {
                     self.argnames.forEach(function(arg, i) {
+                        var ՐՏ_503, ՐՏ_504;
                         if (is_like_method) {
                             if (i === 0) {
                                 return;
@@ -8878,9 +8861,9 @@ var ՐՏ_modules = {};
                             output.comma();
                         }
                         arg.print(output);
-                        if (output.option("es6") && self.argnames.defaults[arg.name]) {
+                        if (output.option("es6") && (ՐՏ_503 = self.argnames.defaults)[arg.name]) {
                             output.print("=");
-                            self.argnames.defaults[arg.name].print(output);
+                            (ՐՏ_504 = self.argnames.defaults)[arg.name].print(output);
                         }
                     });
                     if (self.kwargs) {
@@ -8892,7 +8875,7 @@ var ՐՏ_modules = {};
                 });
                 output.space();
                 print_bracketed(self, output, true);
-            }, ՐՏ_124 = unify(output, name, addDecorators(), addDocstring())(maybe_weird_name(ՐՏ_124)), ՐՏ_124);
+            }, ՐՏ_502 = unify(output, name, addDecorators(), addDocstring())(maybe_weird_name(ՐՏ_502)), ՐՏ_502);
             internalsub();
         };
         DEFPRINT(ast.Lambda, function(self, output) {
@@ -8918,12 +8901,12 @@ var ՐՏ_modules = {};
                 return null;
             }
             function getES6DecoratedMethods() {
-                var ՐՏitr83, ՐՏidx83;
+                var ՐՏitr86, ՐՏidx86;
                 var decorated_methods, stmt;
                 decorated_methods = [];
-                ՐՏitr83 = ՐՏ_Iterable(self.body);
-                for (ՐՏidx83 = 0; ՐՏidx83 < ՐՏitr83.length; ՐՏidx83++) {
-                    stmt = ՐՏitr83[ՐՏidx83];
+                ՐՏitr86 = ՐՏ_Iterable(self.body);
+                for (ՐՏidx86 = 0; ՐՏidx86 < ՐՏitr86.length; ՐՏidx86++) {
+                    stmt = ՐՏitr86[ՐՏidx86];
                     if (stmt instanceof ast.Lambda && stmt.decorators && stmt.decorators.length) {
                         decorated_methods.push(stmt);
                     }
@@ -8938,19 +8921,21 @@ var ՐՏ_modules = {};
                 name = "var " + self.name.name;
             }
             function outputEs6() {
-                var ՐՏ_125;
+                var ՐՏ_509;
                 function addClassVariablesAndMethDecorators(decorated_methods) {
+                    var ՐՏ_505;
                     var properties, class_vars, def_class_vars_and_decorators;
                     properties = {};
                     class_vars = [];
                     if (self.docstring) {
-                        properties["__doc__"] = function(output) {
+                        (ՐՏ_505 = properties)["__doc__"] = function(output) {
                             output.print_string(self.docstring);
                         };
                     }
                     self.body.forEach(function(stmt, i) {
+                        var ՐՏ_506;
                         if (stmt instanceof ast.SimpleStatement && stmt.body instanceof ast.Assign && stmt.body.operator === "=") {
-                            properties[stmt.body.left.name] = function(output) {
+                            (ՐՏ_506 = properties)[stmt.body.left.name] = function(output) {
                                 output.print(stmt.body.left.name);
                                 output.newline();
                             };
@@ -8964,14 +8949,14 @@ var ՐՏ_modules = {};
                     });
                     if (Object.keys(properties).length || decorated_methods && decorated_methods.length) {
                         def_class_vars_and_decorators = function(obj) {
-                            var ՐՏitr84, ՐՏidx84;
+                            var ՐՏitr87, ՐՏidx87, ՐՏ_507, ՐՏ_508;
                             var output, static_decorations, stmt, decoration;
                             output = this;
                             static_decorations = {};
                             if (decorated_methods) {
-                                ՐՏitr84 = ՐՏ_Iterable(decorated_methods);
-                                for (ՐՏidx84 = 0; ՐՏidx84 < ՐՏitr84.length; ՐՏidx84++) {
-                                    stmt = ՐՏitr84[ՐՏidx84];
+                                ՐՏitr87 = ՐՏ_Iterable(decorated_methods);
+                                for (ՐՏidx87 = 0; ՐՏidx87 < ՐՏitr87.length; ՐՏidx87++) {
+                                    stmt = ՐՏitr87[ՐՏidx87];
                                     function print_name(output, stmt_) {
                                         var pref;
                                         pref = obj + (stmt_.static ? "" : ".prototype");
@@ -8998,9 +8983,9 @@ var ՐՏ_modules = {};
                                         "name": stmt.name
                                     };
                                     if (stmt.static) {
-                                        static_decorations[stmt.name.name] = decoration;
+                                        (ՐՏ_507 = static_decorations)[stmt.name.name] = decoration;
                                     } else {
-                                        properties[stmt.name.name] = decoration;
+                                        (ՐՏ_508 = properties)[stmt.name.name] = decoration;
                                     }
                                 }
                             }
@@ -9020,7 +9005,7 @@ var ՐՏ_modules = {};
                     return null;
                 }
                 
-                var generateClass = (ՐՏ_125 = function generateClass() {
+                var generateClass = (ՐՏ_509 = function generateClass() {
                     output.print("class");
                     if (self.name) {
                         output.space();
@@ -9057,6 +9042,7 @@ var ՐՏ_modules = {};
                                 output.space();
                                 output.with_parens(function() {
                                     stmt.argnames.forEach(function(arg, i) {
+                                        var ՐՏ_510, ՐՏ_511;
                                         if (ՐՏ_in(stmt.name.name, self.static)) {
                                             ++i;
                                         }
@@ -9066,9 +9052,9 @@ var ՐՏ_modules = {};
                                         if (i) {
                                             arg.print(output);
                                         }
-                                        if (stmt.argnames.defaults[arg.name]) {
+                                        if ((ՐՏ_510 = stmt.argnames.defaults)[arg.name]) {
                                             output.print("=");
-                                            stmt.argnames.defaults[arg.name].print(output);
+                                            (ՐՏ_511 = stmt.argnames.defaults)[arg.name].print(output);
                                         }
                                     });
                                     if (self.kwargs) {
@@ -9084,11 +9070,11 @@ var ՐՏ_modules = {};
                             }
                         });
                     });
-                }, ՐՏ_125 = unify(output, name, addDecorators(), addClassVariablesAndMethDecorators(getES6DecoratedMethods()))(ՐՏ_125), ՐՏ_125);
+                }, ՐՏ_509 = unify(output, name, addDecorators(), addClassVariablesAndMethDecorators(getES6DecoratedMethods()))(ՐՏ_509), ՐՏ_509);
                 return generateClass;
             }
             function outputEs5() {
-                var ՐՏupk10, ՐՏ_126;
+                var ՐՏupk10, ՐՏ_515;
                 var methodsAndVars, staticmethods;
                 function define_method(stmt) {
                     return function(output) {
@@ -9157,25 +9143,27 @@ var ՐՏ_modules = {};
                     return null;
                 }
                 function addMethods() {
+                    var ՐՏ_512;
                     var methodsAndVars, staticMethods, class_vars, methodAndOutput, methodAndVarOutput, staticMethodOutput;
                     methodsAndVars = {};
                     staticMethods = {};
                     class_vars = [];
                     if (self.docstring) {
-                        methodsAndVars["__doc__"] = function(output) {
+                        (ՐՏ_512 = methodsAndVars)["__doc__"] = function(output) {
                             output.print_string(self.docstring);
                         };
                     }
                     self.body.forEach(function(stmt, i) {
+                        var ՐՏ_513, ՐՏ_514;
                         var meth_hash;
                         if (stmt instanceof ast.Method) {
                             meth_hash = stmt.static ? staticMethods : methodsAndVars;
-                            meth_hash[stmt.name.name] = {
+                            (ՐՏ_513 = meth_hash)[stmt.name.name] = {
                                 value: define_method(stmt),
                                 name: stmt.name
                             };
                         } else if (stmt instanceof ast.SimpleStatement && stmt.body instanceof ast.Assign && stmt.body.operator === "=") {
-                            methodsAndVars[stmt.body.left.name] = function(output) {
+                            (ՐՏ_514 = methodsAndVars)[stmt.body.left.name] = function(output) {
                                 output.print(stmt.body.left.name);
                             };
                             class_vars.push({
@@ -9205,7 +9193,7 @@ var ՐՏ_modules = {};
                 methodsAndVars = ՐՏupk10[0];
                 staticmethods = ՐՏupk10[1];
                 
-                var generateClass = (ՐՏ_126 = function generateClass() {
+                var generateClass = (ՐՏ_515 = function generateClass() {
                     if (self.init || self.parent || self.statements.length) {
                         output.print("function");
                         output.space();
@@ -9238,7 +9226,7 @@ var ՐՏ_modules = {};
                             bind_methods(self.bound, output);
                         });
                     }
-                }, ՐՏ_126 = unify(output, name, addInheritance(), addDecorators(), methodsAndVars, staticmethods)(ՐՏ_126), ՐՏ_126);
+                }, ՐՏ_515 = unify(output, name, addInheritance(), addDecorators(), methodsAndVars, staticmethods)(ՐՏ_515), ՐՏ_515);
                 return generateClass;
             }
             if (output.option("es6")) {
@@ -9393,13 +9381,14 @@ var ՐՏ_modules = {};
             }
         });
         DEFPRINT(ast.Catch, function(self, output) {
+            var ՐՏ_516, ՐՏ_517;
             output.print("catch");
             output.space();
             output.with_parens(function() {
                 output.print("ՐՏ_Exception");
             });
             output.space();
-            if (self.body.length > 1 || self.body[0].errors.length) {
+            if (self.body.length > 1 || (ՐՏ_516 = self.body)[0].errors.length) {
                 output.with_block(function() {
                     var no_default;
                     output.indent();
@@ -9442,7 +9431,7 @@ var ՐՏ_modules = {};
                     output.newline();
                 });
             } else {
-                print_bracketed(self.body[0], output, true);
+                print_bracketed((ՐՏ_517 = self.body)[0], output, true);
             }
         });
         DEFPRINT(ast.Finally, function(self, output) {
@@ -9505,6 +9494,7 @@ var ՐՏ_modules = {};
             var selfArg, object, has_kwarg_items, has_kwarg_formals, has_kwargs, obj, output_kwargs;
             selfArg = null;
             function call_format() {
+                var ՐՏ_518;
                 var rename;
                 if (self instanceof ast.ClassCall) {
                     if (self.static) {
@@ -9521,7 +9511,7 @@ var ՐՏ_modules = {};
                         output.print(".prototype." + self.method + ".call");
                     }
                 } else {
-                    rename = ՐՏ_in(self.expression.name, SPECIAL_METHODS) ? SPECIAL_METHODS[self.expression.name] : void 0;
+                    rename = ՐՏ_in(self.expression.name, SPECIAL_METHODS) ? (ՐՏ_518 = SPECIAL_METHODS)[self.expression.name] : void 0;
                     if (rename) {
                         output.print(rename);
                     } else {
@@ -9595,13 +9585,14 @@ var ՐՏ_modules = {};
                 if (has_kwarg_formals) {
                     output.print("{");
                     self.args.kwargs.forEach(function(pair, i) {
+                        var ՐՏ_519, ՐՏ_520;
                         if (i) {
                             output.comma();
                         }
-                        pair[0].print(output);
+                        (ՐՏ_519 = pair)[0].print(output);
                         output.print(":");
                         output.space();
-                        pair[1].print(output);
+                        (ՐՏ_520 = pair)[1].print(output);
                     });
                     output.print("}");
                 }
@@ -9621,6 +9612,7 @@ var ՐՏ_modules = {};
             } else if (self.args.starargs) {
                 output.print(".apply");
                 output.with_parens(function() {
+                    var ՐՏ_521;
                     obj.print(output);
                     output.comma();
                     if (self.args.length > 1) {
@@ -9633,13 +9625,14 @@ var ՐՏ_modules = {};
                             });
                         });
                     } else {
-                        self.args[0].print(output);
+                        (ՐՏ_521 = self.args)[0].print(output);
                     }
                     if (has_kwargs || self.args.length > 1) {
                         output.print(".concat");
                         output.with_parens(function() {
+                            var ՐՏ_522;
                             if (self.args.length > 1) {
-                                self.args[self.args.length-1].print(output);
+                                (ՐՏ_522 = self.args)[ՐՏ_522.length-1].print(output);
                                 if (has_kwargs) {
                                     output.comma();
                                 }
@@ -9651,12 +9644,12 @@ var ՐՏ_modules = {};
             } else if (has_kwargs && (self instanceof ast.New || self.expression && self.expression.expression)) {
                 output.print(".call");
                 output.with_parens(function() {
-                    var ՐՏitr85, ՐՏidx85;
+                    var ՐՏitr88, ՐՏidx88;
                     var arg;
                     obj.print(output);
-                    ՐՏitr85 = ՐՏ_Iterable(self.args);
-                    for (ՐՏidx85 = 0; ՐՏidx85 < ՐՏitr85.length; ՐՏidx85++) {
-                        arg = ՐՏitr85[ՐՏidx85];
+                    ՐՏitr88 = ՐՏ_Iterable(self.args);
+                    for (ՐՏidx88 = 0; ՐՏidx88 < ՐՏitr88.length; ՐՏidx88++) {
+                        arg = ՐՏitr88[ՐՏidx88];
                         output.comma();
                         arg.print(output);
                     }
@@ -9728,10 +9721,26 @@ var ՐՏ_modules = {};
             output.print_name(self.property);
         });
         DEFPRINT(ast.Sub, function(self, output) {
-            self.expression.print(output);
+            var exp_print, tmp;
+            if (self.expression instanceof ast.SymbolVar) {
+                self.expression.print(output);
+                exp_print = function() {
+                    self.expression.print(output);
+                };
+            } else {
+                tmp = null;
+                output.with_parens(function() {
+                    tmp = output.newTemp();
+                    output.assign(tmp);
+                    self.expression.print(output);
+                });
+                exp_print = function() {
+                    output.print(tmp);
+                };
+            }
             output.print("[");
             if (self.property instanceof ast.Unary && self.property.operator === "-" && self.property.expression instanceof ast.Number) {
-                self.expression.print(output);
+                exp_print();
                 output.print(".length");
             }
             self.property.print(output);
@@ -9776,6 +9785,7 @@ var ՐՏ_modules = {};
             output.print(self.operator);
         });
         DEFPRINT(ast.Binary, function(self, output) {
+            var ՐՏ_523, ՐՏ_524, ՐՏ_525;
             var comparators, function_ops, normalize, operator, leftvar;
             comparators = {
                 "<": true,
@@ -9799,7 +9809,7 @@ var ՐՏ_modules = {};
                 return op;
             };
             if (ՐՏ_in(self.operator, function_ops)) {
-                output.print(function_ops[self.operator]);
+                output.print((ՐՏ_523 = function_ops)[self.operator]);
                 output.with_parens(function() {
                     self.left.print(output);
                     if (self.operator === "//") {
@@ -9811,7 +9821,7 @@ var ՐՏ_modules = {};
                     }
                     self.right.print(output);
                 });
-            } else if (comparators[self.operator] && self.left instanceof ast.Binary && comparators[self.left.operator]) {
+            } else if ((ՐՏ_524 = comparators)[self.operator] && self.left instanceof ast.Binary && (ՐՏ_525 = comparators)[self.left.operator]) {
                 operator = normalize(self.operator);
                 if (self.left.right instanceof ast.Symbol) {
                     self.left.print(output);
@@ -9964,12 +9974,12 @@ var ՐՏ_modules = {};
             });
         });
         DEFPRINT(ast.Range, function(self, output) {
-            var ՐՏitr86, ՐՏidx86;
+            var ՐՏitr89, ՐՏidx89, ՐՏ_526, ՐՏ_527, ՐՏ_528, ՐՏ_529, ՐՏ_530, ՐՏ_531;
             var indexes, element, start, end, step;
             indexes = [];
-            ՐՏitr86 = ՐՏ_Iterable([ self.left, self.right ]);
-            for (ՐՏidx86 = 0; ՐՏidx86 < ՐՏitr86.length; ՐՏidx86++) {
-                element = ՐՏitr86[ՐՏidx86];
+            ՐՏitr89 = ՐՏ_Iterable([ self.left, self.right ]);
+            for (ՐՏidx89 = 0; ՐՏidx89 < ՐՏitr89.length; ՐՏidx89++) {
+                element = ՐՏitr89[ՐՏidx89];
                 if (element instanceof ast.UnaryPrefix && element.operator === "-" && element.expression instanceof ast.Number) {
                     indexes.push(parseFloat("-" + element.expression.value));
                 } else if (element instanceof ast.Number) {
@@ -9978,19 +9988,19 @@ var ՐՏ_modules = {};
                     indexes.push(null);
                 }
             }
-            if (indexes[0] && indexes[1] && Math.abs(indexes[1] - indexes[0]) < 50) {
-                start = indexes[0];
-                end = indexes[1];
+            if ((ՐՏ_526 = indexes)[0] && (ՐՏ_527 = indexes)[1] && Math.abs((ՐՏ_528 = indexes)[1] - (ՐՏ_529 = indexes)[0]) < 50) {
+                start = (ՐՏ_530 = indexes)[0];
+                end = (ՐՏ_531 = indexes)[1];
                 step = start < end ? 1 : -1;
                 if (self.operator === "to") {
                     end += step / 1e6;
                 }
                 output.with_square(function() {
-                    var ՐՏitr87, ՐՏidx87;
+                    var ՐՏitr90, ՐՏidx90;
                     var i;
-                    ՐՏitr87 = ՐՏ_Iterable(range(start, end, step));
-                    for (ՐՏidx87 = 0; ՐՏidx87 < ՐՏitr87.length; ՐՏidx87++) {
-                        i = ՐՏitr87[ՐՏidx87];
+                    ՐՏitr90 = ՐՏ_Iterable(range(start, end, step));
+                    for (ՐՏidx90 = 0; ՐՏidx90 < ՐՏitr90.length; ՐՏidx90++) {
+                        i = ՐՏitr90[ՐՏidx90];
                         if (i !== start) {
                             output.comma();
                         }
@@ -10013,13 +10023,13 @@ var ՐՏ_modules = {};
             }
         });
         DEFPRINT(ast.ObjectLiteral, function(self, output) {
-            var ՐՏitr88, ՐՏidx88, ՐՏ_127;
+            var ՐՏitr91, ՐՏidx91, ՐՏ_532, ՐՏ_533, ՐՏ_534, ՐՏ_535;
             var properties, p, v, key, v_key, h_, props, add_props;
             if (self.properties.length > 0) {
                 properties = {};
-                ՐՏitr88 = ՐՏ_Iterable(self.properties);
-                for (ՐՏidx88 = 0; ՐՏidx88 < ՐՏitr88.length; ՐՏidx88++) {
-                    p = ՐՏitr88[ՐՏidx88];
+                ՐՏitr91 = ՐՏ_Iterable(self.properties);
+                for (ՐՏidx91 = 0; ՐՏidx91 < ՐՏitr91.length; ՐՏidx91++) {
+                    p = ՐՏitr91[ՐՏidx91];
                     v = p.value;
                     key = p.key;
                     if (v_key = v instanceof ast.ObjectGetter ? "get" : v instanceof ast.ObjectSetter ? "set" : false) {
@@ -10028,15 +10038,15 @@ var ՐՏ_modules = {};
                                 v.print(output);
                             };
                         };
-                        if (!(props = properties[key.name])) {
-                            props = properties[key.name] = {
+                        if (!(props = (ՐՏ_532 = properties)[key.name])) {
+                            props = (ՐՏ_533 = properties)[key.name] = {
                                 "name": key,
                                 "attrs": {
                                     "enumerable": "true"
                                 }
                             };
                         }
-                        props[v_key] = h_(v);
+                        (ՐՏ_534 = props)[v_key] = h_(v);
                     }
                 }
                 add_props = null;
@@ -10048,7 +10058,7 @@ var ՐՏ_modules = {};
                     add_props = output.with_class_vars_init([], add_props);
                 }
                 
-                var inner = (ՐՏ_127 = function inner() {
+                var inner = (ՐՏ_535 = function inner() {
                     output.with_block(function() {
                         var j;
                         j = 0;
@@ -10065,7 +10075,7 @@ var ՐՏ_modules = {};
                         });
                         output.newline();
                     });
-                }, ՐՏ_127 = unify(output, null, add_props)(ՐՏ_127), ՐՏ_127);
+                }, ՐՏ_535 = unify(output, null, add_props)(ՐՏ_535), ՐՏ_535);
                 inner();
             } else {
                 output.print("{}");
@@ -10159,18 +10169,19 @@ var ՐՏ_modules = {};
             }
         }
         function first_in_statement(output) {
+            var ՐՏ_536, ՐՏ_537, ՐՏ_538;
             var processed, i, node, prev;
             processed = output.stack();
             i = processed.length;
-            node = processed[--i];
-            prev = processed[--i];
+            node = (ՐՏ_536 = processed)[--i];
+            prev = (ՐՏ_537 = processed)[--i];
             while (i > 0) {
                 if (prev instanceof ast.Statement && prev.body === node) {
                     return true;
                 }
                 if (prev instanceof ast.Seq && prev.car === node || prev instanceof ast.BaseCall && prev.expression === node || prev instanceof ast.Dot && prev.expression === node || prev instanceof ast.Sub && prev.expression === node || prev instanceof ast.Conditional && prev.condition === node || prev instanceof ast.Binary && prev.left === node || prev instanceof ast.UnaryPostfix && prev.expression === node) {
                     node = prev;
-                    prev = processed[--i];
+                    prev = (ՐՏ_538 = processed)[--i];
                 } else {
                     return false;
                 }
@@ -10180,18 +10191,20 @@ var ՐՏ_modules = {};
             return self.args.length === 0 && !output.option("beautify");
         }
         function best_of(choices) {
+            var ՐՏ_539, ՐՏ_540, ՐՏ_541;
             var best, len_, i;
-            best = choices[0];
+            best = (ՐՏ_539 = choices)[0];
             len_ = best.length;
             for (i = 1; i < choices.length; i++) {
-                if (choices[i].length < len_) {
-                    best = choices[i];
+                if ((ՐՏ_540 = choices)[i].length < len_) {
+                    best = (ՐՏ_541 = choices)[i];
                     len_ = best.length;
                 }
             }
             return best;
         }
         function make_num(num) {
+            var ՐՏ_542, ՐՏ_543, ՐՏ_544, ՐՏ_545, ՐՏ_546;
             var str_, choices, match;
             str_ = num.toString(10);
             choices = [ str_.replace(/^0\./, ".").replace("e+", "e") ];
@@ -10203,10 +10216,10 @@ var ՐՏ_modules = {};
                     choices.push("-0x" + (-num).toString(16).toLowerCase(), "-0" + (-num).toString(8));
                 }
                 if (match = /^(.*?)(0+)$/.exec(num)) {
-                    choices.push(match[1] + "e" + match[2].length);
+                    choices.push((ՐՏ_542 = match)[1] + "e" + (ՐՏ_543 = match)[2].length);
                 }
             } else if (match = /^0?\.(0+)(.*)$/.exec(num)) {
-                choices.push(match[2] + "e-" + (match[1].length + match[2].length), str_.substr(str_.indexOf(".")));
+                choices.push((ՐՏ_544 = match)[2] + "e-" + ((ՐՏ_545 = match)[1].length + (ՐՏ_546 = match)[2].length), str_.substr(str_.indexOf(".")));
             }
             return best_of(choices);
         }
@@ -10251,32 +10264,34 @@ var ՐՏ_modules = {};
             output.add_mapping(self.start, self.key);
         });
     })();
-    ՐՏ_modules["output"]["Stream"] = Stream;
-})();
+    var ՐՏ_mod = ՐՏ_modules["ՐՏ:output"];
+    ՐՏ_mod.export("Stream", function(){return Stream;}, function(ՐՏ_v){if (typeof Stream !== "undefined") {Stream = ՐՏ_v;};});
+    ՐՏ_mod.export("RAPYD_PREFIX", function(){return RAPYD_PREFIX;}, function(ՐՏ_v){if (typeof RAPYD_PREFIX !== "undefined") {RAPYD_PREFIX = ՐՏ_v;};});
+    ՐՏ_mod.export("PRECEDENCE", function(){return PRECEDENCE;}, function(ՐՏ_v){if (typeof PRECEDENCE !== "undefined") {PRECEDENCE = ՐՏ_v;};});
+    ՐՏ_mod.export("stream", function(){return stream;}, function(ՐՏ_v){if (typeof stream !== "undefined") {stream = ՐՏ_v;};});
+    ՐՏ_mod.export("ast", function(){return ast;}, function(ՐՏ_v){if (typeof ast !== "undefined") {ast = ՐՏ_v;};});
+    return ՐՏ_mod["exports"];
+};
 var browser_env, exports, rapydscript, compile;
 var utils = ՐՏ_modules["utils"];
-
 var ast = ՐՏ_modules["ast"];
-
 var tokenizer = ՐՏ_modules["tokenizer"];
-
 var parser = ՐՏ_modules["parser"];
-
 var output = ՐՏ_modules["output"];
-
 ast.Node.warn_function = function(txt) {
     console.error(txt);
 };
 function splatBaselib(key, value) {
+    var ՐՏ_547, ՐՏ_548;
     return new ast.Splat({
         module: new ast.SymbolVar({
             name: key
         }),
         body: new ast.TopLevel({
-            start: value[0].start,
+            start: (ՐՏ_547 = value)[0].start,
             body: value,
             strict: true,
-            end: value[value.length-1].end
+            end: (ՐՏ_548 = value)[ՐՏ_548.length-1].end
         })
     });
 }
@@ -10284,8 +10299,8 @@ browser_env = !exports;
 if (browser_env) {
     rapydscript = exports = {};
 }
-exports.parse_baselib = exports.parseBaselib = function(srcPath, beautify) {
-    var ՐՏitr89, ՐՏidx89;
+exports.parse_baselib = exports.parseBaselib = function(srcPath, es6) {
+    var ՐՏ_549, ՐՏitr92, ՐՏidx92, ՐՏ_550;
     var fs, baselibPath, baselibAst, hash, data, baselibList, item, key, value;
     try {
         fs = require("fs");
@@ -10293,7 +10308,8 @@ exports.parse_baselib = exports.parseBaselib = function(srcPath, beautify) {
         baselibAst = parser.parse(fs.readFileSync(baselibPath, "utf8"), {
             readfile: fs.readFileSync,
             dropDocstrings: true,
-            filename: "baselib.pyj"
+            filename: "baselib.pyj",
+            es6: es6
         });
     } catch (ՐՏ_Exception) {
         var e = ՐՏ_Exception;
@@ -10303,15 +10319,15 @@ exports.parse_baselib = exports.parseBaselib = function(srcPath, beautify) {
             throw ՐՏ_Exception;
         }
     }
-    hash = baselibAst.body[baselibAst.body.length-1];
+    hash = (ՐՏ_549 = baselibAst.body)[ՐՏ_549.length-1];
     data = hash.body.properties;
     baselibList = {};
-    ՐՏitr89 = ՐՏ_Iterable(data);
-    for (ՐՏidx89 = 0; ՐՏidx89 < ՐՏitr89.length; ՐՏidx89++) {
-        item = ՐՏitr89[ՐՏidx89];
+    ՐՏitr92 = ՐՏ_Iterable(data);
+    for (ՐՏidx92 = 0; ՐՏidx92 < ՐՏitr92.length; ՐՏidx92++) {
+        item = ՐՏitr92[ՐՏidx92];
         key = item.key.value;
         value = item.value.name ? [ item.value ] : item.value.body;
-        baselibList[key] = splatBaselib(key, value);
+        (ՐՏ_550 = baselibList)[key] = splatBaselib(key, value);
     }
     return baselibList;
 };
@@ -10333,63 +10349,40 @@ exports.get_import_dirs = function(paths_string, ignore_env) {
     return paths;
 };
 exports.compile = compile = function(code, options) {
-    var toplevel, stream;
-    if (browser_env) {
-        parser.init_mod();
-    }
+    var ՐՏitr93, ՐՏidx93, ՐՏitr94, ՐՏidx94, ՐՏ_552;
+    var toplevel, baselib_dep_map, fun, rex_key, rex, stream;
+    parser.init_mod();
     toplevel = parser.parse(code, utils.defaults(options, {
         toplevel: toplevel,
         output: {}
     }));
-    if (!options.omit_baselib && !browser_env) {
-        if (!toplevel.baselib["AssertionError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["IndexError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["KeyError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["TypeError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["ValueError"]) {
-            --toplevel.baselib["extends"];
-        }
-        if (!toplevel.baselib["kwargs"]) {
-            --toplevel.baselib["in"];
-            --toplevel.baselib["iterator"];
-            --toplevel.baselib["range"];
-            --toplevel.baselib["dir"];
-        }
-        if (!toplevel.baselib["eq"]) {
-            toplevel.baselib["iterator"] -= 2;
-            --toplevel.baselib["range"];
-        }
-        if (!toplevel.baselib["merge"]) {
-            --toplevel.baselib["iterator"];
-        }
-        if (!toplevel.baselib["mixin"]) {
-            --toplevel.baselib["in"];
-            toplevel.baselib["iterator"] -= 2;
-        }
-        if (!toplevel.baselib["enumerate"]) {
-            --toplevel.baselib["iterator"];
-            --toplevel.baselib["range"];
-        }
-        if (!toplevel.baselib["all"]) {
-            --toplevel.baselib["iterator"];
-        }
-        if (!toplevel.baselib["any"]) {
-            --toplevel.baselib["iterator"];
-        }
-        if (!toplevel.baselib["zip"]) {
-            --toplevel.baselib["iterator"];
-            --toplevel.baselib["range"];
-        }
-        if (!toplevel.baselib["rebind_all"]) {
-            --toplevel.baselib["bind"];
+    if (!options.omit_baselib) {
+        baselib_dep_map = {
+            ".+Error": [ "extends" ],
+            "all|any|zip|iterable|kwargs|eq|merge|mixin|enumerate": [ "iterable" ],
+            "kwargs": [ "in", "range", "merge", "dir" ],
+            "eq": [ "range" ],
+            "mixin": [ "in" ],
+            "zip": [ "range" ],
+            "rebind_all": [ "bind" ]
+        };
+        ՐՏitr93 = ՐՏ_Iterable(Object.keys(toplevel.baselib).filter(function(f) {
+            var ՐՏ_551;
+            return (ՐՏ_551 = toplevel.baselib)[f];
+        }));
+        for (ՐՏidx93 = 0; ՐՏidx93 < ՐՏitr93.length; ՐՏidx93++) {
+            fun = ՐՏitr93[ՐՏidx93];
+            ՐՏitr94 = ՐՏ_Iterable(baselib_dep_map);
+            for (ՐՏidx94 = 0; ՐՏidx94 < ՐՏitr94.length; ՐՏidx94++) {
+                rex_key = ՐՏitr94[ՐՏidx94];
+                rex = new RegExp("^(" + rex_key + ")$");
+                if (rex.test(fun)) {
+                    (ՐՏ_552 = baselib_dep_map)[rex_key].forEach(function(k) {
+                        var ՐՏ_553;
+                        (ՐՏ_553 = toplevel.baselib)[k] = 1;
+                    });
+                }
+            }
         }
     }
     stream = output.Stream(options);
@@ -10397,7 +10390,7 @@ exports.compile = compile = function(code, options) {
     return stream.toString();
 };
 exports.minify = function(files, options) {
-    var ՐՏitr90, ՐՏidx90;
+    var ՐՏitr95, ՐՏidx95;
     var file, code;
     options = utils.defaults(options, {
         fromString: false,
@@ -10406,9 +10399,9 @@ exports.minify = function(files, options) {
     if (typeof files === "string") {
         files = [ files ];
     }
-    ՐՏitr90 = ՐՏ_Iterable(files);
-    for (ՐՏidx90 = 0; ՐՏidx90 < ՐՏitr90.length; ՐՏidx90++) {
-        file = ՐՏitr90[ՐՏidx90];
+    ՐՏitr95 = ՐՏ_Iterable(files);
+    for (ՐՏidx95 = 0; ՐՏidx95 < ՐՏitr95.length; ՐՏidx95++) {
+        file = ՐՏitr95[ՐՏidx95];
         options.filename = options.fromString ? "?" : file;
         code = options.fromString ? file : require("fs").readFileSync(file, "utf8");
         return {
@@ -10431,8 +10424,7 @@ exports.ParseError = utils.ParseError;
 exports.ImportError = utils.ImportError;
 exports.ALL_KEYWORDS = tokenizer.ALL_KEYWORDS;
 exports.IDENTIFIER_PAT = tokenizer.IDENTIFIER_PAT;
-exports.colored = utils.colored;var ՐՏ_128, ՐՏ_129, ՐՏ_130, ՐՏ_131, ՐՏ_132;
-
+exports.colored = utils.colored;
         exports.factory = factory;
         return exports;
     };

--- a/lib/self.js
+++ b/lib/self.js
@@ -1,133 +1,3 @@
-function abs(n) {
-    return Math.abs(n);
-}
-function all(a) {
-    var ՐՏitr4, ՐՏidx4;
-    var e;
-    ՐՏitr4 = ՐՏ_Iterable(a);
-    for (ՐՏidx4 = 0; ՐՏidx4 < ՐՏitr4.length; ՐՏidx4++) {
-        e = ՐՏitr4[ՐՏidx4];
-        if (!e) {
-            return false;
-        }
-    }
-    return true;
-}
-function any(a) {
-    var ՐՏitr5, ՐՏidx5;
-    var e;
-    ՐՏitr5 = ՐՏ_Iterable(a);
-    for (ՐՏidx5 = 0; ՐՏidx5 < ՐՏitr5.length; ՐՏidx5++) {
-        e = ՐՏitr5[ՐՏidx5];
-        if (e) {
-            return true;
-        }
-    }
-    return false;
-}
-function bin(a) {
-    return "0b" + (a >>> 0).toString(2);
-}
-function ՐՏ_bind(fn, thisArg) {
-    var ret;
-    if (fn.orig) {
-        fn = fn.orig;
-    }
-    if (thisArg === false) {
-        return fn;
-    }
-    ret = function() {
-        return fn.apply(thisArg, arguments);
-    };
-    ret.orig = fn;
-    return ret;
-}
-function ՐՏ_rebindAll(thisArg, rebind) {
-    if (rebind === void 0) {
-        rebind = true;
-    }
-    for (var p in thisArg) {
-        if (thisArg[p] && thisArg[p].orig) {
-            if (rebind) {
-                thisArg[p] = ՐՏ_bind(thisArg[p], thisArg);
-            } else {
-                thisArg[p] = thisArg[p].orig;
-            }
-        }
-    }
-}
-function ՐՏ_with__name__(fn, name) {
-    fn.__name__ = name;
-    return fn;
-}
-function cmp(a, b) {
-    return a < b ? -1 : a > b ? 1 : 0;
-}
-var chr = String.fromCharCode;
-function dir(item) {
-    var arr;
-    arr = [];
-    for (var i in item) {
-        arr.push(i);
-    }
-    return arr;
-}
-function enumerate(item) {
-    var arr, iter, i;
-    arr = [];
-    iter = ՐՏ_Iterable(item);
-    for (i = 0; i < iter.length; i++) {
-        arr[arr.length] = [ i, item[i] ];
-    }
-    return arr;
-}
-function ՐՏ_eslice(arr, step, start, end) {
-    var isString;
-    arr = arr.slice(0);
-    if (typeof arr === "string" || arr instanceof String) {
-        isString = true;
-        arr = arr.split("");
-    }
-    if (step < 0) {
-        step = -step;
-        arr.reverse();
-        if (typeof start !== "undefined") {
-            start = arr.length - start - 1;
-        }
-        if (typeof end !== "undefined") {
-            end = arr.length - end - 1;
-        }
-    }
-    if (typeof start === "undefined") {
-        start = 0;
-    }
-    if (typeof end === "undefined") {
-        end = arr.length;
-    }
-    arr = arr.slice(start, end).filter(function(e, i) {
-        return i % step === 0;
-    });
-    return isString ? arr.join("") : arr;
-}
-function ՐՏ_extends(child, parent) {
-    child.prototype = Object.create(parent.prototype);
-    child.prototype.__base__ = parent;
-    child.prototype.constructor = child;
-}
-function filter(oper, arr) {
-    return arr.filter(oper);
-}
-function hex(a) {
-    return "0x" + (a >>> 0).toString(16);
-}
-function ՐՏ_in(val, arr) {
-    if (typeof arr.indexOf === "function") {
-        return arr.indexOf(val) !== -1;
-    } else if (typeof arr.has === "function") {
-        return arr.has(val);
-    }
-    return arr.hasOwnProperty(val);
-}
 function ՐՏ_Iterable(iterable) {
     var tmp;
     if (iterable.constructor === [].constructor || iterable.constructor === "".constructor || (tmp = Array.prototype.slice.call(iterable)).length) {
@@ -138,286 +8,12 @@ function ՐՏ_Iterable(iterable) {
     }
     return Object.keys(iterable);
 }
-function len(obj) {
-    var tmp;
-    if (obj.constructor === [].constructor || obj.constructor === "".constructor || (tmp = Array.prototype.slice.call(obj)).length) {
-        return (tmp || obj).length;
-    }
-    if (Set && obj.constructor === Set) {
-        return obj.size;
-    }
-    return Object.keys(obj).length;
-}
-function map(oper, arr) {
-    return arr.map(oper);
-}
-function max(a) {
-    return Math.max.apply(null, Array.isArray(a) ? a : arguments);
-}
-function min(a) {
-    return Math.min.apply(null, Array.isArray(a) ? a : arguments);
-}
-function ՐՏ_merge(target, source, overwrite) {
-    var ՐՏitr6, ՐՏidx6;
-    var prop;
-    for (var i in source) {
-        if (source.hasOwnProperty(i) && (overwrite || typeof target[i] === "undefined")) {
-            target[i] = source[i];
-        }
-    }
-    ՐՏitr6 = ՐՏ_Iterable(Object.getOwnPropertyNames(source.prototype));
-    for (ՐՏidx6 = 0; ՐՏidx6 < ՐՏitr6.length; ՐՏidx6++) {
-        prop = ՐՏitr6[ՐՏidx6];
-        if (overwrite || typeof target.prototype[prop] === "undefined") {
-            Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop));
-        }
-    }
-}
-function ՐՏ_mixin() {
-    var classes = [].slice.call(arguments, 0);
-    return function(baseClass) {
-        var ՐՏitr7, ՐՏidx7, ՐՏitr8, ՐՏidx8;
-        var cls, key;
-        ՐՏitr7 = ՐՏ_Iterable(classes);
-        for (ՐՏidx7 = 0; ՐՏidx7 < ՐՏitr7.length; ՐՏidx7++) {
-            cls = ՐՏitr7[ՐՏidx7];
-            ՐՏitr8 = ՐՏ_Iterable(Object.getOwnPropertyNames(cls.prototype));
-            for (ՐՏidx8 = 0; ՐՏidx8 < ՐՏitr8.length; ՐՏidx8++) {
-                key = ՐՏitr8[ՐՏidx8];
-                if (!(ՐՏ_in(key, baseClass.prototype))) {
-                    Object.defineProperty(baseClass.prototype, key, Object.getOwnPropertyDescriptor(cls.prototype, key));
-                }
-            }
-        }
-        return baseClass;
-    };
-}
-function ՐՏ_print() {
-    if (typeof console === "object") {
-        console.log.apply(console, arguments);
-    }
-}
-function range(start, stop, step) {
-    var length, idx, range;
-    if (arguments.length <= 1) {
-        stop = start || 0;
-        start = 0;
-    }
-    step = arguments[2] || 1;
-    length = Math.max(Math.ceil((stop - start) / step), 0);
-    idx = 0;
-    range = new Array(length);
-    while (idx < length) {
-        range[idx++] = start;
-        start += step;
-    }
-    return range;
-}
-function reduce(f, a) {
-    return Array.prototype.reduce.call(a, f);
-}
-function reversed(arr) {
-    var tmp;
-    tmp = arr.slice(0);
-    return tmp.reverse();
-}
-function sorted(arr) {
-    var tmp;
-    tmp = arr.slice(0);
-    return tmp.sort();
-}
-function sum(arr, start) {
-    start = start === void 0 ? 0 : start;
-    return arr.reduce(function(prev, cur) {
-        return prev + cur;
-    }, start);
-}
-function ՐՏ_type(obj) {
-    return obj && obj.constructor && obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1);
-}
-function zip(a, b) {
-    var i;
-    return (function() {
-        var ՐՏidx9, ՐՏitr9 = ՐՏ_Iterable(range(Math.min(a.length, b.length))), ՐՏres = [], i;
-        for (ՐՏidx9 = 0; ՐՏidx9 < ՐՏitr9.length; ՐՏidx9++) {
-            i = ՐՏitr9[ՐՏidx9];
-            ՐՏres.push([ a[i], b[i] ]);
-        }
-        return ՐՏres;
-    })();
-}
-function getattr(obj, name) {
-    return obj[name];
-}
-function setattr(obj, name, value) {
-    obj[name] = value;
-}
-function hasattr(obj, name) {
-    return name in obj;
-}
-function ՐՏ_eq(a, b) {
-    var ՐՏitr10, ՐՏidx10;
-    var i;
-    if (a === b) {
-        return true;
-    }
-    if (a === void 0 || b === void 0 || a === null || b === null) {
-        return false;
-    }
-    if (a.constructor !== b.constructor) {
-        return false;
-    }
-    if (Array.isArray(a)) {
-        if (a.length !== b.length) {
-            return false;
-        }
-        for (i = 0; i < a.length; i++) {
-            if (!ՐՏ_eq(a[i], b[i])) {
-                return false;
-            }
-        }
-        return true;
-    } else if (a.constructor === Object) {
-        if (Object.keys(a).length !== Object.keys(b).length) {
-            return false;
-        }
-        ՐՏitr10 = ՐՏ_Iterable(a);
-        for (ՐՏidx10 = 0; ՐՏidx10 < ՐՏitr10.length; ՐՏidx10++) {
-            i = ՐՏitr10[ՐՏidx10];
-            if (!ՐՏ_eq(a[i], b[i])) {
-                return false;
-            }
-        }
-        return true;
-    } else if (Set && a.constructor === Set || Map && a.constructor === Map) {
-        if (a.size !== b.size) {
-            return false;
-        }
-        for (i of a) {
-            if (!b.has(i)) {
-                return false;
-            }
-        }
-        return true;
-    } else if (a.constructor === Date) {
-        return a.getTime() === b.getTime();
-    } else if (typeof a.__eq__ === "function") {
-        return a.__eq__(b);
-    }
-    return false;
-}
-function kwargs(f) {
-    var argNames;
-    argNames = f.toString().match(/\(([^\)]+)/)[1];
-    if (!kwargs.memo[argNames]) {
-        kwargs.memo[argNames] = argNames ? argNames.split(",").map(function(s) {
-            return s.trim();
-        }) : [];
-    }
-    argNames = kwargs.memo[argNames];
-    return function() {
-        var args, kw, i;
-        args = [].slice.call(arguments);
-        if (args.length) {
-            kw = args[args.length-1];
-            if (typeof kw === "object") {
-                for (i = 0; i < argNames.length; i++) {
-                    if (ՐՏ_in(argNames[i], kw)) {
-                        args[i] = kw[argNames[i]];
-                    }
-                }
-            } else {
-                args.push(kw);
-            }
-        }
-        try {
-            return f.apply(this, args);
-        } catch (ՐՏ_Exception) {
-            var e = ՐՏ_Exception;
-            if (/Class constructor \w+ cannot be invoked without 'new'/.test(e)) {
-                return new f(args);
-            }
-            throw ՐՏ_Exception;
-        }
-    };
-}
-kwargs.memo = {};
-var AssertionError = (ՐՏ_1 = function AssertionError() {
-    AssertionError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_1, Error), Object.defineProperties(ՐՏ_1.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "AssertionError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_1);
-var IndexError = (ՐՏ_2 = function IndexError() {
-    IndexError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_2, Error), Object.defineProperties(ՐՏ_2.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "IndexError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_2);
-var KeyError = (ՐՏ_3 = function KeyError() {
-    KeyError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_3, Error), Object.defineProperties(ՐՏ_3.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "KeyError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_3);
-var TypeError = (ՐՏ_4 = function TypeError() {
-    TypeError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_4, Error), Object.defineProperties(ՐՏ_4.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "TypeError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_4);
-var ValueError = (ՐՏ_5 = function ValueError() {
-    ValueError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_5, Error), Object.defineProperties(ՐՏ_5.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "ValueError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_5);
 var path, fs, rapydscript;
 path = require("path");
 fs = require("fs");
 rapydscript = require("../lib/rapydscript");
 module.exports = function compile_self(base_path, src_path, lib_path, start_time) {
-    var ՐՏitr1, ՐՏidx1, ՐՏitr2, ՐՏidx2, ՐՏitr3, ՐՏidx3;
+    var ՐՏitr1, ՐՏidx1, ՐՏ_1, ՐՏitr2, ՐՏidx2, ՐՏitr3, ՐՏidx3, ՐՏ_3, ՐՏ_4;
     var compiled, baselib, options, src, ast, key, output, file, filename, factory, wrapped;
     compiled = {};
     baselib = rapydscript.parse_baselib(src_path, true);
@@ -439,16 +35,17 @@ module.exports = function compile_self(base_path, src_path, lib_path, start_time
     ՐՏitr1 = ՐՏ_Iterable(baselib);
     for (ՐՏidx1 = 0; ՐՏidx1 < ՐՏitr1.length; ՐՏidx1++) {
         key = ՐՏitr1[ՐՏidx1];
-        ++ast.baselib[key];
+        ++(ՐՏ_1 = ast.baselib)[key];
     }
     output = rapydscript.output(ast, options);
     compiled.baselib = output.toString();
     fs.writeFileSync(path.join(src_path, "_baselib.pyj"), "BASELIB = '''" + src.replace(/\\/g, "\\\\") + "'''", "utf8");
     function compile(file) {
+        var ՐՏ_2;
         var filepath;
         filepath = path.join(src_path, file + ".pyj");
         options.filename = file + ".pyj";
-        compiled[file] = rapydscript.compile(fs.readFileSync(filepath, "utf8"), options);
+        (ՐՏ_2 = compiled)[file] = rapydscript.compile(fs.readFileSync(filepath, "utf8"), options);
     }
     ՐՏitr2 = ՐՏ_Iterable([ "rapydscript", "self", "compile", "test" ]);
     for (ՐՏidx2 = 0; ՐՏidx2 < ՐՏitr2.length; ՐՏidx2++) {
@@ -460,10 +57,10 @@ module.exports = function compile_self(base_path, src_path, lib_path, start_time
     ՐՏitr3 = ՐՏ_Iterable(compiled);
     for (ՐՏidx3 = 0; ՐՏidx3 < ՐՏitr3.length; ՐՏidx3++) {
         filename = ՐՏitr3[ՐՏidx3];
-        fs.writeFileSync(path.join(lib_path, filename + ".js"), compiled[filename], "utf8");
+        fs.writeFileSync(path.join(lib_path, filename + ".js"), (ՐՏ_3 = compiled)[filename], "utf8");
     }
     factory = '\n    function factory(){\n        "use strict";\n        <compiled_rapydscript>\n        exports.factory = factory;\n        return exports;\n    };\n    if ((typeof define == "function") && define.amd) define([], factory)\n    else window.rapydscript = factory();\n    ';
-    factory = factory.replace("<compiled_rapydscript>", compiled["rapydscript"]);
+    factory = factory.replace("<compiled_rapydscript>", (ՐՏ_4 = compiled)["rapydscript"]);
     wrapped = '(function(){\n"use strict";\n' + factory + "\n})();";
     fs.writeFileSync(path.join(lib_path, "rapydscript_web.js"), wrapped, "utf8");
-};var ՐՏ_1, ՐՏ_2, ՐՏ_3, ՐՏ_4, ՐՏ_5;
+};

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,133 +1,3 @@
-function abs(n) {
-    return Math.abs(n);
-}
-function all(a) {
-    var ՐՏitr5, ՐՏidx5;
-    var e;
-    ՐՏitr5 = ՐՏ_Iterable(a);
-    for (ՐՏidx5 = 0; ՐՏidx5 < ՐՏitr5.length; ՐՏidx5++) {
-        e = ՐՏitr5[ՐՏidx5];
-        if (!e) {
-            return false;
-        }
-    }
-    return true;
-}
-function any(a) {
-    var ՐՏitr6, ՐՏidx6;
-    var e;
-    ՐՏitr6 = ՐՏ_Iterable(a);
-    for (ՐՏidx6 = 0; ՐՏidx6 < ՐՏitr6.length; ՐՏidx6++) {
-        e = ՐՏitr6[ՐՏidx6];
-        if (e) {
-            return true;
-        }
-    }
-    return false;
-}
-function bin(a) {
-    return "0b" + (a >>> 0).toString(2);
-}
-function ՐՏ_bind(fn, thisArg) {
-    var ret;
-    if (fn.orig) {
-        fn = fn.orig;
-    }
-    if (thisArg === false) {
-        return fn;
-    }
-    ret = function() {
-        return fn.apply(thisArg, arguments);
-    };
-    ret.orig = fn;
-    return ret;
-}
-function ՐՏ_rebindAll(thisArg, rebind) {
-    if (rebind === void 0) {
-        rebind = true;
-    }
-    for (var p in thisArg) {
-        if (thisArg[p] && thisArg[p].orig) {
-            if (rebind) {
-                thisArg[p] = ՐՏ_bind(thisArg[p], thisArg);
-            } else {
-                thisArg[p] = thisArg[p].orig;
-            }
-        }
-    }
-}
-function ՐՏ_with__name__(fn, name) {
-    fn.__name__ = name;
-    return fn;
-}
-function cmp(a, b) {
-    return a < b ? -1 : a > b ? 1 : 0;
-}
-var chr = String.fromCharCode;
-function dir(item) {
-    var arr;
-    arr = [];
-    for (var i in item) {
-        arr.push(i);
-    }
-    return arr;
-}
-function enumerate(item) {
-    var arr, iter, i;
-    arr = [];
-    iter = ՐՏ_Iterable(item);
-    for (i = 0; i < iter.length; i++) {
-        arr[arr.length] = [ i, item[i] ];
-    }
-    return arr;
-}
-function ՐՏ_eslice(arr, step, start, end) {
-    var isString;
-    arr = arr.slice(0);
-    if (typeof arr === "string" || arr instanceof String) {
-        isString = true;
-        arr = arr.split("");
-    }
-    if (step < 0) {
-        step = -step;
-        arr.reverse();
-        if (typeof start !== "undefined") {
-            start = arr.length - start - 1;
-        }
-        if (typeof end !== "undefined") {
-            end = arr.length - end - 1;
-        }
-    }
-    if (typeof start === "undefined") {
-        start = 0;
-    }
-    if (typeof end === "undefined") {
-        end = arr.length;
-    }
-    arr = arr.slice(start, end).filter(function(e, i) {
-        return i % step === 0;
-    });
-    return isString ? arr.join("") : arr;
-}
-function ՐՏ_extends(child, parent) {
-    child.prototype = Object.create(parent.prototype);
-    child.prototype.__base__ = parent;
-    child.prototype.constructor = child;
-}
-function filter(oper, arr) {
-    return arr.filter(oper);
-}
-function hex(a) {
-    return "0x" + (a >>> 0).toString(16);
-}
-function ՐՏ_in(val, arr) {
-    if (typeof arr.indexOf === "function") {
-        return arr.indexOf(val) !== -1;
-    } else if (typeof arr.has === "function") {
-        return arr.has(val);
-    }
-    return arr.hasOwnProperty(val);
-}
 function ՐՏ_Iterable(iterable) {
     var tmp;
     if (iterable.constructor === [].constructor || iterable.constructor === "".constructor || (tmp = Array.prototype.slice.call(iterable)).length) {
@@ -138,286 +8,12 @@ function ՐՏ_Iterable(iterable) {
     }
     return Object.keys(iterable);
 }
-function len(obj) {
-    var tmp;
-    if (obj.constructor === [].constructor || obj.constructor === "".constructor || (tmp = Array.prototype.slice.call(obj)).length) {
-        return (tmp || obj).length;
-    }
-    if (Set && obj.constructor === Set) {
-        return obj.size;
-    }
-    return Object.keys(obj).length;
-}
-function map(oper, arr) {
-    return arr.map(oper);
-}
-function max(a) {
-    return Math.max.apply(null, Array.isArray(a) ? a : arguments);
-}
-function min(a) {
-    return Math.min.apply(null, Array.isArray(a) ? a : arguments);
-}
-function ՐՏ_merge(target, source, overwrite) {
-    var ՐՏitr7, ՐՏidx7;
-    var prop;
-    for (var i in source) {
-        if (source.hasOwnProperty(i) && (overwrite || typeof target[i] === "undefined")) {
-            target[i] = source[i];
-        }
-    }
-    ՐՏitr7 = ՐՏ_Iterable(Object.getOwnPropertyNames(source.prototype));
-    for (ՐՏidx7 = 0; ՐՏidx7 < ՐՏitr7.length; ՐՏidx7++) {
-        prop = ՐՏitr7[ՐՏidx7];
-        if (overwrite || typeof target.prototype[prop] === "undefined") {
-            Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop));
-        }
-    }
-}
-function ՐՏ_mixin() {
-    var classes = [].slice.call(arguments, 0);
-    return function(baseClass) {
-        var ՐՏitr8, ՐՏidx8, ՐՏitr9, ՐՏidx9;
-        var cls, key;
-        ՐՏitr8 = ՐՏ_Iterable(classes);
-        for (ՐՏidx8 = 0; ՐՏidx8 < ՐՏitr8.length; ՐՏidx8++) {
-            cls = ՐՏitr8[ՐՏidx8];
-            ՐՏitr9 = ՐՏ_Iterable(Object.getOwnPropertyNames(cls.prototype));
-            for (ՐՏidx9 = 0; ՐՏidx9 < ՐՏitr9.length; ՐՏidx9++) {
-                key = ՐՏitr9[ՐՏidx9];
-                if (!(ՐՏ_in(key, baseClass.prototype))) {
-                    Object.defineProperty(baseClass.prototype, key, Object.getOwnPropertyDescriptor(cls.prototype, key));
-                }
-            }
-        }
-        return baseClass;
-    };
-}
-function ՐՏ_print() {
-    if (typeof console === "object") {
-        console.log.apply(console, arguments);
-    }
-}
-function range(start, stop, step) {
-    var length, idx, range;
-    if (arguments.length <= 1) {
-        stop = start || 0;
-        start = 0;
-    }
-    step = arguments[2] || 1;
-    length = Math.max(Math.ceil((stop - start) / step), 0);
-    idx = 0;
-    range = new Array(length);
-    while (idx < length) {
-        range[idx++] = start;
-        start += step;
-    }
-    return range;
-}
-function reduce(f, a) {
-    return Array.prototype.reduce.call(a, f);
-}
-function reversed(arr) {
-    var tmp;
-    tmp = arr.slice(0);
-    return tmp.reverse();
-}
-function sorted(arr) {
-    var tmp;
-    tmp = arr.slice(0);
-    return tmp.sort();
-}
-function sum(arr, start) {
-    start = start === void 0 ? 0 : start;
-    return arr.reduce(function(prev, cur) {
-        return prev + cur;
-    }, start);
-}
-function ՐՏ_type(obj) {
-    return obj && obj.constructor && obj.constructor.name ? obj.constructor.name : Object.prototype.toString.call(obj).slice(8, -1);
-}
-function zip(a, b) {
-    var i;
-    return (function() {
-        var ՐՏidx10, ՐՏitr10 = ՐՏ_Iterable(range(Math.min(a.length, b.length))), ՐՏres = [], i;
-        for (ՐՏidx10 = 0; ՐՏidx10 < ՐՏitr10.length; ՐՏidx10++) {
-            i = ՐՏitr10[ՐՏidx10];
-            ՐՏres.push([ a[i], b[i] ]);
-        }
-        return ՐՏres;
-    })();
-}
-function getattr(obj, name) {
-    return obj[name];
-}
-function setattr(obj, name, value) {
-    obj[name] = value;
-}
-function hasattr(obj, name) {
-    return name in obj;
-}
-function ՐՏ_eq(a, b) {
-    var ՐՏitr11, ՐՏidx11;
-    var i;
-    if (a === b) {
-        return true;
-    }
-    if (a === void 0 || b === void 0 || a === null || b === null) {
-        return false;
-    }
-    if (a.constructor !== b.constructor) {
-        return false;
-    }
-    if (Array.isArray(a)) {
-        if (a.length !== b.length) {
-            return false;
-        }
-        for (i = 0; i < a.length; i++) {
-            if (!ՐՏ_eq(a[i], b[i])) {
-                return false;
-            }
-        }
-        return true;
-    } else if (a.constructor === Object) {
-        if (Object.keys(a).length !== Object.keys(b).length) {
-            return false;
-        }
-        ՐՏitr11 = ՐՏ_Iterable(a);
-        for (ՐՏidx11 = 0; ՐՏidx11 < ՐՏitr11.length; ՐՏidx11++) {
-            i = ՐՏitr11[ՐՏidx11];
-            if (!ՐՏ_eq(a[i], b[i])) {
-                return false;
-            }
-        }
-        return true;
-    } else if (Set && a.constructor === Set || Map && a.constructor === Map) {
-        if (a.size !== b.size) {
-            return false;
-        }
-        for (i of a) {
-            if (!b.has(i)) {
-                return false;
-            }
-        }
-        return true;
-    } else if (a.constructor === Date) {
-        return a.getTime() === b.getTime();
-    } else if (typeof a.__eq__ === "function") {
-        return a.__eq__(b);
-    }
-    return false;
-}
-function kwargs(f) {
-    var argNames;
-    argNames = f.toString().match(/\(([^\)]+)/)[1];
-    if (!kwargs.memo[argNames]) {
-        kwargs.memo[argNames] = argNames ? argNames.split(",").map(function(s) {
-            return s.trim();
-        }) : [];
-    }
-    argNames = kwargs.memo[argNames];
-    return function() {
-        var args, kw, i;
-        args = [].slice.call(arguments);
-        if (args.length) {
-            kw = args[args.length-1];
-            if (typeof kw === "object") {
-                for (i = 0; i < argNames.length; i++) {
-                    if (ՐՏ_in(argNames[i], kw)) {
-                        args[i] = kw[argNames[i]];
-                    }
-                }
-            } else {
-                args.push(kw);
-            }
-        }
-        try {
-            return f.apply(this, args);
-        } catch (ՐՏ_Exception) {
-            var e = ՐՏ_Exception;
-            if (/Class constructor \w+ cannot be invoked without 'new'/.test(e)) {
-                return new f(args);
-            }
-            throw ՐՏ_Exception;
-        }
-    };
-}
-kwargs.memo = {};
-var AssertionError = (ՐՏ_1 = function AssertionError() {
-    AssertionError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_1, Error), Object.defineProperties(ՐՏ_1.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "AssertionError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_1);
-var IndexError = (ՐՏ_2 = function IndexError() {
-    IndexError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_2, Error), Object.defineProperties(ՐՏ_2.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "IndexError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_2);
-var KeyError = (ՐՏ_3 = function KeyError() {
-    KeyError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_3, Error), Object.defineProperties(ՐՏ_3.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "KeyError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_3);
-var TypeError = (ՐՏ_4 = function TypeError() {
-    TypeError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_4, Error), Object.defineProperties(ՐՏ_4.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "TypeError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_4);
-var ValueError = (ՐՏ_5 = function ValueError() {
-    ValueError.prototype.__init__.apply(this, arguments);
-}, ՐՏ_extends(ՐՏ_5, Error), Object.defineProperties(ՐՏ_5.prototype, {
-    __init__: {
-        enumerable: true, 
-        writable: true, 
-        value: function __init__(message){
-            var self = this;
-            self.name = "ValueError";
-            self.message = message;
-        }
-
-    }
-}), ՐՏ_5);
 var path, fs, rapydscript;
 path = require("path");
 fs = require("fs");
 rapydscript = require("../lib/rapydscript");
 module.exports = function(argv, base_path, src_path, lib_path, test_type) {
-    var ՐՏitr1, ՐՏidx1, ՐՏitr2, ՐՏidx2, ՐՏitr3, ՐՏidx3, ՐՏitr4, ՐՏidx4;
+    var ՐՏ_1, ՐՏ_2, ՐՏ_3, ՐՏitr1, ՐՏidx1, ՐՏitr2, ՐՏidx2, ՐՏitr3, ՐՏidx3, ՐՏitr4, ՐՏidx4;
     var assert, os, all_ok, vm, test_dir, error_dir, web_dir, perf_dir, baselib, v8Version, files, fname, file, output, code, jsfile, ok, filepath, Browser, browser, Benchmark;
     assert = require("assert");
     os = require("os");
@@ -432,7 +28,7 @@ module.exports = function(argv, base_path, src_path, lib_path, test_type) {
     if (argv.ecmascript6) {
         console.log("Running in ES6 mode!\n");
         v8Version = process.versions.v8.split(".");
-        if (parseInt(v8Version[0]) < 4 || parseInt(v8Version[0]) <= 4 && parseInt(v8Version[1]) <= 9) {
+        if (parseInt((ՐՏ_1 = v8Version)[0]) < 4 || parseInt((ՐՏ_2 = v8Version)[0]) <= 4 && parseInt((ՐՏ_3 = v8Version)[1]) <= 9) {
             console.log("Your V8 engine is too old to support ES6 features, skipping ES6 tests...");
             return;
         }
@@ -521,8 +117,9 @@ module.exports = function(argv, base_path, src_path, lib_path, test_type) {
             code = fs.readFileSync(filepath, "utf-8").split("\n");
             ok = true;
             code.forEach(function(line) {
+                var ՐՏ_4;
                 var ast, ok;
-                if (line[0] === "#" || !line.trim().length) {
+                if ((ՐՏ_4 = line)[0] === "#" || !line.trim().length) {
                     return;
                 }
                 try {
@@ -584,8 +181,9 @@ module.exports = function(argv, base_path, src_path, lib_path, test_type) {
             code = output.toString();
             eval(code);
             bench.on("complete", function() {
+                var ՐՏ_5;
                 var baseline, s;
-                baseline = this[0].hz;
+                baseline = (ՐՏ_5 = this)[0].hz;
                 console.log(file + ":");
                 s = function(num) {
                     if (num > 1e3) {
@@ -606,4 +204,4 @@ module.exports = function(argv, base_path, src_path, lib_path, test_type) {
         console.log("There were some test failures!");
     }
     process.exit(all_ok ? 0 : 1);
-};var ՐՏ_1, ՐՏ_2, ՐՏ_3, ՐՏ_4, ՐՏ_5;
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postversion": "git push && npm publish",
     "build-self": "bin/rapydscript --self"
   },
-  "version": "0.5.63",
+  "version": "0.6.00",
   "license": "BSD-2-Clause",
   "engines": {
     "node": ">=0.12.0"

--- a/src/ast.pyj
+++ b/src/ast.pyj
@@ -326,6 +326,7 @@ class Scope(Block):
 class TopLevel(Scope):
     "The toplevel scope"
     properties = {
+        async: "[boolean] if True this is async (external) module should be set at runtime",
         globals: "[Object/S] a map of name -> SymbolDef for all undeclared names",
         baselib: "[Object/s] a collection of used parts of baselib",
         imports: "[Object/S] a map of module_id->TopLevel for all imported modules",
@@ -356,7 +357,7 @@ class Import(Statement):
         key: "[string] The key by which this module is stored in the global modules mapping",
         alias: "[SymbolAlias] The name this module is imported as, can be None. For import x as y statements.",
         argnames: "[ImportedVar*] names of objects to be imported",
-        body: "[TopLevel] parsed contents of the imported file",
+        body: "[Function -> TopLevel] returns parsed contents of the imported file",
     }
     def _walk(self, visitor):
         return visitor._visit(self, def():

--- a/src/baselib.pyj
+++ b/src/baselib.pyj
@@ -51,7 +51,7 @@
 ,
 "rebind_all": def ՐՏ_rebindAll(thisArg, rebind):
     if rebind is undefined: rebind = True
-    for JS('var p in thisArg'):
+    for v'var p in thisArg':
         if thisArg[p] and thisArg[p].orig:
             if rebind: thisArg[p] = bind(thisArg[p], thisArg)
             else: thisArg[p] = thisArg[p].orig
@@ -60,16 +60,48 @@
     fn.__name__ = name
     return fn
 ,
+"def_modules": def ՐՏ_def_modules():
+    modules = {}
+    def mounter(mod_id):
+        rs_mod_id = "ՐՏ:"+ mod_id
+        rs_mod = modules[rs_mod_id] = {
+            "body": None,
+            "exports":None,
+        }
+        rs_mod["export"] = def(prop, get, set):
+            if not rs_mod["exports"]: rs_mod["exports"] = {}
+            Object.defineProperty( rs_mod["exports"], prop, {
+                configurable: True,
+                enumerable: True,
+                get: get,
+                set: set,
+            })
+        Object.defineProperty( modules,  mod_id, {
+            enumerable: True,
+            get: def():
+                return (mod = modules[rs_mod_id])["exports"] or mod["body"]()
+            , set: def(v):
+                modules[rs_mod_id]["exports"] = v
+        })
+        return rs_mod
+
+    Object.defineProperty( modules, 'ՐՏ_def', {
+        configurable: False,
+        enumerable: False,
+        value: mounter
+    })
+    return modules
+,
 "cmp": def cmp(a, b): return a < b ? -1 : a > b ? 1 : 0
 ,
-"chr": def(): JS('var chr = String.fromCharCode')
+"chr": def(): v'var chr = String.fromCharCode'
 ,
 "dir": def dir(item):
     # TODO: this isn't really representative of real Python's dir(), nor is it
     # an intuitive replacement for "for ... in" loop, need to update this logic
     # and introduce a different way of achieving "for ... in"
     arr = []
-    for JS('var i in item'): arr.push(i)
+    for v'var i in item': arr.push(i)
     return arr
 ,
 "enumerate": def enumerate(item):
@@ -81,17 +113,17 @@
 ,
 "eslice": def ՐՏ_eslice(arr, step, start, end):
     arr = arr[:]
-    if JS('typeof arr') is 'string' or isinstance(arr, String):
+    if v'typeof arr' is 'string' or isinstance(arr, String):
         isString = True
         arr = arr.split('')
 
     if step < 0:
         step = -step
         arr.reverse()
-        if JS('typeof start') is not "undefined": start = arr.length - start - 1
-        if JS('typeof end') is not "undefined": end = arr.length - end - 1
-    if JS('typeof start') is "undefined": start = 0
-    if JS('typeof end') is "undefined": end = arr.length
+        if v'typeof start' is not "undefined": start = arr.length - start - 1
+        if v'typeof end' is not "undefined": end = arr.length - end - 1
+    if v'typeof start' is "undefined": start = 0
+    if v'typeof end' is "undefined": end = arr.length
 
     arr = arr.slice(start, end).filter(def(e, i): return i % step is 0;)
     return isString ? arr.join('') : arr
@@ -107,8 +139,8 @@
 "hex": def hex(a): return '0x' + (a >>> 0).toString(16)
 ,
 "in": def ՐՏ_in(val, arr):
-    if JS('typeof arr.indexOf') is 'function': return arr.indexOf(val) is not -1
-    elif JS('typeof arr.has') is 'function': return arr.has(val)
+    if v'typeof arr.indexOf' is 'function': return arr.indexOf(val) is not -1
+    elif v'typeof arr.has' is 'function': return arr.has(val)
     return arr.hasOwnProperty(val)
 ,
 "iterable": def ՐՏ_Iterable(iterable):
@@ -141,12 +173,12 @@
     return Math.min.apply(None, Array.isArray(a) ? a : arguments)
 ,
 "merge": def ՐՏ_merge(target, source, overwrite):
-    for JS('var i in source'):
+    for v'var i in source':
         # instance variables
-        if source.hasOwnProperty(i) and (overwrite or JS('typeof target[i]') is 'undefined'): target[i] = source[i]
+        if source.hasOwnProperty(i) and (overwrite or v'typeof target[i]' is 'undefined'): target[i] = source[i]
     for prop in Object.getOwnPropertyNames(source.prototype):
         # methods
-        if overwrite or JS('typeof target.prototype[prop]') is 'undefined':
+        if overwrite or v'typeof target.prototype[prop]' is 'undefined':
             Object.defineProperty(target.prototype, prop, Object.getOwnPropertyDescriptor(source.prototype, prop))
 ,
 "mixin": def ՐՏ_mixin(*classes):
@@ -159,7 +191,7 @@
 
 ,
 "print": def ՐՏ_print():
-    if JS('typeof console') is 'object': console.log.apply(console, arguments)
+    if v'typeof console' is 'object': console.log.apply(console, arguments)
 ,
 "range": def range(start, stop, step):
     if arguments.length <= 1:
@@ -172,7 +204,7 @@
     range = Array(length)
 
     while idx < length:
-        range[JS('idx++')] = start
+        range[v'idx++'] = start
         start += step
     return range
 ,
@@ -206,7 +238,7 @@
     obj[name] = value
 ,
 "hasattr": def hasattr(obj, name):
-    return JS('name in obj')
+    return v'name in obj'
 ,
 "eq": def ՐՏ_eq(a, b):
     """
@@ -247,14 +279,14 @@
     elif (Set and a.constructor is Set) or (Map and a.constructor is Map):
         # sets and maps
         if a.size is not b.size: return False
-        for JS('i of a'):
+        for v'i of a':
             if not b.has(i):
                 return False
         return True
     elif (a.constructor is Date):
         # dates
         return a.getTime() is b.getTime()
-    elif JS('typeof a.__eq__') is 'function':
+    elif v'typeof a.__eq__' is 'function':
         # everything else that implements __eq__ method
         return a.__eq__(b)
     return False
@@ -270,7 +302,7 @@
             args = [].slice.call(arguments)
             if args.length:
                 kw = args[-1]
-                if JS('typeof kw') is 'object':
+                if v'typeof kw' is 'object':
                     for i in range(argNames.length):
                         if argNames[i] in kw:
                             args[i] = kw[argNames[i]]

--- a/src/compile.pyj
+++ b/src/compile.pyj
@@ -56,7 +56,7 @@ module.exports = def(start_time, argv, base_path, src_path, lib_path):
         strict_names: argv.strict_names
     }
     if not argv.omit_baselib:
-        parseOpts.baselib = rapydscript.parse_baselib(src_path, parseOpts.beautify)
+        parseOpts.baselib = rapydscript.parse_baselib(src_path, parseOpts.es6)
     if argv.comments:
         if /^\//.test(argv.comments):
             parseOpts.comments = Function("return(" + argv.comments + ")")()

--- a/src/lib/mechanic.pyj
+++ b/src/lib/mechanic.pyj
@@ -1,0 +1,77 @@
+
+
+def module(mod_id): # -> Module[mod_id] | Module[]
+    if mod_id:
+        return ՐՏ_modules[mod_id]
+    def all_():
+        ret = {}
+        for v'var k in ՐՏ_modules':
+            if not k.startsWith('ՐՏ:'):
+                ret[k] = ՐՏ_modules[k]
+        return ret
+    def keys():
+        ret = []
+        for v'var k in ՐՏ_modules':
+            if not k.startsWith('ՐՏ:'):
+                ret.push(k)
+        return ret
+    return {'all':all_, keys}
+
+
+def module_spec(mod_id): # # ->  ModuleSpec[mod_id] | {all(), undefined(), defined()}.() -> ModuleSpec[]
+    if mod_id:
+        return ՐՏ_modules['ՐՏ:'+ mod_id ]
+    return {
+        'all': def():
+            ret = {}
+            module().keys().forEach(def(k):
+                    ret[k] = module_spec(k)
+                    pass;
+            )
+            return ret;
+
+        'undefined': def():
+            ret = {}
+            module().keys().forEach(def(k):
+                    ms = module_spec(k)
+                    if not (ms.exports or ms.body):
+                        ret[k] = ms
+                    pass;
+            )
+            return ret;
+
+        'defined': def():
+            ret = {}
+            module().keys().forEach(def(k):
+                    ms = module_spec(k)
+                    if (ms.exports or ms.body):
+                        ret[k] = ms
+                    pass;
+            )
+            return ret;
+    }
+
+def create_module(mod_name, pack_id):
+    mod_id = pack_id ? pack_id + '.' + mod_name : mod_name
+    if module_spec(mod_id):
+        raise KeyError('Module exists: ' + mod_id)
+    if pack_id:
+        pack = module_spec(pack_id)
+        if not pack:
+            raise KeyError('Package doesn\'t exists: ' + pack_id)
+    else: pack = None
+    ՐՏ_modules.ՐՏ_def_mod(mod_id)
+    if pack:
+        rs_mod_id = 'ՐՏ:'+ mod_id
+        pack.export(mod_name,
+            def(): return ՐՏ_modules[rs_mod_id].exports;,
+            def(v): replace_module(mod_id, v);
+        )
+
+def replace_module(mod_id, new_exp):
+    if not (mod_spec = module_spec(mod_id)):
+        raise KeyError('Module doesn\'t exist: ' + mod_id)
+    for p in (exp = mod_spec.exports):
+        del exp[p]
+    Object.defineProperties(exp, Object.getOwnPropertyDescriptors(new_exp))
+

--- a/src/output.pyj
+++ b/src/output.pyj
@@ -290,6 +290,8 @@ Stream = stream.Stream
     def write_imports(module_, output):
 
         def sort_imports(mod, imp_sorted, importing, done):
+            if mod.async:
+                return imp_sorted
             # returns sorted array of  module_ids
             imp_sorted = imp_sorted  or []
             importing = importing or  {}
@@ -333,12 +335,14 @@ Stream = stream.Stream
 
         if imports.length > 1:
             output.indent()
-            output.spaced('var ՐՏ_modules', '=', '{};')
+            output.spaced('var ՐՏ_modules', '=', 'ՐՏ_def_modules();')
             output.newline()
 
         # Declare all variable names exported from the modules as global symbols
         nonlocalvars = {}
         for module_ in imports:
+            if module_.async:
+                continue
             for name in module_.nonlocalvars:
                 nonlocalvars[name] = True
         nonlocalvars = Object.getOwnPropertyNames(nonlocalvars).join(', ')
@@ -351,13 +355,12 @@ Stream = stream.Stream
         for module_ in imports:
             if module_.module_id is not '__main__':
                 output.indent()
-                output.assign('ՐՏ_modules["' + module_.module_id + '"]')
-                output.print('{}')
+                output.print('ՐՏ_modules.ՐՏ_def("' + module_.module_id + '")')
                 output.end_statement()
 
         # Output module code
         for module_ in imports:
-            if module_.module_id is not '__main__':
+            if not module_.async and module_.module_id is not '__main__':
                 print_module(module_, output)
 
     def write_main_name(output):
@@ -485,20 +488,29 @@ Stream = stream.Stream
                 seen[sub_module_id] = True
                 key = sub_module_id.split('.')[-1]
                 output.indent()
-                output.print('ՐՏ_modules["' + module_id + '"]["' + key + '"] = ')
-                output.print('ՐՏ_modules["' + sub_module_id + '"]')
+                sub_mod = 'ՐՏ_modules["' + sub_module_id + '"]'
+                output.print( 'ՐՏ_modules["ՐՏ:' + module_id + '"].export("' + key + '", function(){return ' + sub_mod + ';}, function(){throw new Error("use Object.defineProperty!");})')
+                #output.print('ՐՏ_modules["' + module_id + '"]["' + key + '"] = ')
+                #output.print('ՐՏ_modules["' + sub_module_id + '"]')
                 output.end_statement()
 
     def declare_exports(module_id, exports, output):
         output.newline()
         seen = {}
+        output.indent()
+        rs_mod = 'ՐՏ_modules["ՐՏ:' + module_id + '"]'
+        output.print('var ՐՏ_mod = ՐՏ_modules["ՐՏ:' + module_id + '"]')
+        output.end_statement()
+        # set eхports
         for symbol in exports:
             if not seen[symbol.name]:
                 seen[symbol.name] = True
                 output.indent()
-                output.assign('ՐՏ_modules["' + module_id + '"]["' + symbol.name + '"]')
-                output.print(symbol.name)
+                output.print( 'ՐՏ_mod.export("' + symbol.name + '", function(){return ' + symbol.name + ';}, function(ՐՏ_v){if (typeof ' + symbol.name + ' !== "undefined") {'+ symbol.name  +' = ՐՏ_v;};})')
                 output.end_statement()
+        output.indent()
+        output.print('return ՐՏ_mod["exports"]')
+        output.end_statement()
 
     def unpack_tuple(tuple, output, in_statement):
         tuple.elements.forEach(def(elem, i):
@@ -569,27 +581,27 @@ Stream = stream.Stream
             Object.keys(BASELIB).filter(def(a): return self.baselib[a] > 0;).forEach(def(key):
                 output.print_baselib(key)
             )
+            if Object.keys(self.imports).length > 1: # except imports['__main__']
+                output.print_baselib("def_modules")
             output.endLocalBuffer(True)
 
     )
     def print_module(self, output):
         output.newline()
         output.indent()
-        output.with_parens(def():
-            output.print("function()")
-            output.with_block(def():
-                # dump the logic of this module
-                output.indent()
-                output.assign('var __name__')
-                output.print('"' + self.module_id + '"')
-                output.end_statement()
-                declare_submodules(self.module_id, self.submodules, output)
-                declare_vars(self.localvars, output)
-                display_body(self.body, True, output)
-                declare_exports(self.module_id, self.exports, output)
-            )
+        output.assign('ՐՏ_modules["ՐՏ:' + self.module_id + '"].body')
+        output.print("function()")
+        output.with_block(def():
+            # dump the logic of this module
+            output.indent()
+            output.assign('var __name__')
+            output.print('"' + self.module_id + '"')
+            output.end_statement()
+            declare_submodules(self.module_id, self.submodules, output)
+            declare_vars(self.localvars, output)
+            display_body(self.body, True, output)
+            declare_exports(self.module_id, self.exports, output)
         )
-        output.print("()")
         output.end_statement()
 
     DEFPRINT(ast.Splat, def(self, output):
@@ -600,7 +612,9 @@ Stream = stream.Stream
 
     DEFPRINT(ast.Imports, def(container, output):
         seen = {}
+        i = 0
         def add_aname(aname, key, from_import):
+            nonlocal i
             seen_key = key + (from_import ? '.' + from_import : '')
             if seen[aname]:
                 if seen[aname] == seen_key:
@@ -609,12 +623,15 @@ Stream = stream.Stream
                     tmp = aname  + ' : '  + [seen[aname], seen_key].join(', ')
                     raise Error('Something went wrong, 2 imports with the same name detected: ' + tmp)
             seen[aname] = seen_key
+            if i:
+                output.newline()
+                output.indent()
+                i+=1
             output.assign('var ' + aname)
             output.print('ՐՏ_modules["' + key + '"]')
             if from_import:
                 output.print('.' + from_import)
-            output.end_statement()
-            output.indent()
+            output.semicolon()
 
         for self in container.imports:
             if isinstance(self, ast.Splat):

--- a/src/output.pyj
+++ b/src/output.pyj
@@ -1906,19 +1906,24 @@ Stream = stream.Stream
         output.print_name(self.property)
     )
     DEFPRINT(ast.Sub, def(self, output):
-        self.expression.print(output)
+        if isinstance(self.expression, ast.SymbolVar):
+            self.expression.print(output)
+            exp_print = def(): self.expression.print(output);
+        else:
+            tmp = None
+            output.with_parens(def():
+                nonlocal tmp
+                tmp = output.newTemp()
+                output.assign(tmp)
+                self.expression.print(output)
+            )
+            exp_print = def(): output.print(tmp);
         output.print("[")
         # parse negative constants into len-constant
         if isinstance(self.property, ast.Unary) and self.property.operator is "-"
         and isinstance(self.property.expression, ast.Number):
-            # TODO: this might parse incorrectly if expression is a
-            # function call that might not return the same result
-            # when called repeatedly. We might eventually want to
-            # save the return to a temporary variable and use that
-            # instead if expression is a function. Or we could just
-            # throw an error if negative indices are used with a
-            # type that's not ast.SymbolVar
-            self.expression.print(output)
+            # TODO: Why are only ast.Number negative indices allowed?
+            exp_print()
             output.print(".length")
 
         self.property.print(output)

--- a/src/parser.pyj
+++ b/src/parser.pyj
@@ -119,6 +119,7 @@ def init_mod():
         "bind",
         "rebind_all",
         "with__name__",
+        "def_modules",
         "cmp",
         "chr",
         "dir",
@@ -407,6 +408,39 @@ def parse($TEXT, options):
         else:
             return False
 
+    def scan_for_top_level_imports(body):
+        self_fun = scan_for_top_level_imports
+        ans = []
+        # Get imports names
+        if Array.isArray(body):
+            for name in dir(body):
+                obj = body[name]
+                if isinstance(obj, ast.Imports):
+                    for imp in obj.imports:
+                        if imp.argnames: # from import ...
+                            for argname in imp.argnames:
+                                imp_sym = argname.alias or argname
+                        else:
+                            # in case of 'import pack.sub.mod' we need to declare only 'pack'
+                            imp_sym = imp.alias \
+                                or new_symbol(ast.SymbolVar ,imp.key.split('.', 1)[0])
+                        #console.log(imp.key,':', imp_sym)
+                        ans.push(imp_sym)
+                else:
+                    # skip inner scopes
+                    if isinstance(obj, ast.Scope):
+                        continue
+                    for x in ['body', 'alternative']:
+                        opt = obj[x]
+                        if opt:
+                            ans = ans.concat(self_fun(opt))
+        elif body.body:
+            # recursive descent into wrapper statements that contain body blocks
+            ans = ans.concat(self_fun(body.body))
+            if body.alternative:
+                ans = ans.concat(self_fun(body.alternative))
+        return ans
+
     def scan_for_top_level_callables(body):
         ans = []
         # Get the named functions and classes
@@ -558,6 +592,13 @@ def parse($TEXT, options):
             elif tmp_ is "pass":
                 semicolon()
                 return ast.EmptyStatement()
+            elif tmp_ is "async":
+                is_from = False
+                if S.token.type is 'keyword' \
+                        and (S.token.value is 'import' or (is_from = S.token.value is 'from')):
+                    next()
+                    return import_(is_from, True)
+                unexpected()
             elif tmp_ is "return" or tmp_ is "yield":
                 if S.in_scope[-1].type is not "function":
                     croak("'return' outside of function")
@@ -838,25 +879,26 @@ def parse($TEXT, options):
             if not (key in subs):
                 subs.push(key)
 
-    def import_(from_import):
-        ans = ast.Imports({'imports':[]})
+    def import_(from_import, async_import):
+        ans = ast.Imports({'imports':[], 'async':async_import})
         imp_with = None
         while True:
             package_pref = ''
-            # allow import submodules into __init__.pyj
-            if (options.filename or '').endsWith('/__init__.pyj'):
-                package_pref = options.module_id + '.'
-                if not PRE_IMPORTED[options.module_id]:
-                    PRE_IMPORTED[options.module_id] = {submodules : []}
+            if not async_import:
+                # allow import submodules into __init__.pyj
+                if not async_import and (options.filename or '').endsWith('/__init__.pyj'):
+                    package_pref = options.module_id + '.'
+                    if not PRE_IMPORTED[options.module_id]:
+                        PRE_IMPORTED[options.module_id] = {submodules : []}
 
-            # dot expander: from .module -> from package.module
-            if is_('punc', '.'):
-                if not package_pref:
-                    package_pref = (/^(.+?\.)[^\.]+$/.exec(options.module_id or '') or ['', ''])[1]
-                # FIX: if not package_pref: raise Error
-                next()
-            else:
-                package_pref = ''
+                # dot expander: from .module -> from package.module
+                if is_('punc', '.'):
+                    if not package_pref:
+                        package_pref = (/^(.+?\.)[^\.]+$/.exec(options.module_id or '') or ['', ''])[1]
+                    # FIX: if not package_pref: raise Error
+                    next()
+                else:
+                    package_pref = ''
 
             tmp = name = expression(False)
             key = ''
@@ -891,8 +933,10 @@ def parse($TEXT, options):
                 'key': key,
                 'alias': alias,
                 'argnames':None,
-                'body':def():
-                    return IMPORTED[key]
+                'body': (def(_):
+                    return def():
+                        return IMPORTED[_];
+                )(key)
             })
             ans.imports.push(imp)
             if from_import:
@@ -904,9 +948,30 @@ def parse($TEXT, options):
 
         from_pack_imp = []
         for imp in ans['imports']:
-            do_import(imp.key)
+            if not async_import:
+                do_import(imp.key)
+            else:
+                # async module definition
+                IMPORTED[imp.key] = ast.TopLevel( {
+                    #globals: "[Object/S] a map of name -> SymbolDef for all undeclared names",
+                    #baselib: "[Object/s] a collection of used parts of baselib",
+                    imports: {},
+                    nonlocalvars: [],
+                    module_id: imp.key,
+                    exports: [],
+                    submodules: [],
+                    classes: [],
+                    filename: None,
+                    async: True
+                })
+                IMPORTED[imp.key].localvars = []
+                IMPORTED[imp.key].body = []
+
             depends_on[imp.key] = True
-            cur_imported = IMPORTED[imp.key]
+            cur_imported = async_import \
+                ? None \
+                : IMPORTED[imp.key]
+
             argnames  = []
             if from_import:
                 expect_token("keyword", "import")
@@ -917,7 +982,7 @@ def parse($TEXT, options):
                         unexpected()
                     name =  S.token.value
                     # maybe `from package import module`
-                    if cur_imported.is_package \
+                    if cur_imported and cur_imported.is_package \
                           and not cur_imported.exports.find(def(it): return it.name is name;):
                         key =  imp.key + '.' + name
                         aname = ast.Import({
@@ -945,18 +1010,20 @@ def parse($TEXT, options):
                         break
 
                 # Put imported class names in the outermost scope
-                classes = cur_imported.classes
-                for argvar in argnames:
-                    obj = classes[argvar.name]
-                    if obj:
-                        key = (argvar.alias) ? argvar.alias.name : argvar.name
-                        S.in_scope[-1].classes[key] = { "static": obj.static, "bound": obj.bound }
+                if cur_imported:
+                    classes = cur_imported.classes
+                    for argvar in argnames:
+                        obj = classes[argvar.name]
+                        if obj:
+                            key = (argvar.alias) ? argvar.alias.name : argvar.name
+                            S.in_scope[-1].classes[key] = { "static": obj.static, "bound": obj.bound }
 
                 for mod_name in from_pack_module_names:
                     Object.assign(S.in_scope[S.in_scope.length-1].classes, IMPORTED[mod_name.key].top_classes(mod_name.alias.name))
             else:
-                key = imp.alias ? imp.alias.name : imp.key;
-                Object.assign(S.in_scope[S.in_scope.length-1].classes, cur_imported.top_classes(key))
+                key = imp.alias ? imp.alias.name : imp.key
+                if cur_imported:
+                    Object.assign(S.in_scope[S.in_scope.length-1].classes, cur_imported.top_classes(key))
 
         [].push.apply(ans.imports, from_pack_imp)
         return ans
@@ -2668,11 +2735,14 @@ def parse($TEXT, options):
         toplevel.nonlocalvars = Object.keys(S.in_scope[-1].nonlocal)
         assignments = Object.keys(S.in_scope[-1].vars)
         callables = scan_for_top_level_callables(toplevel.body).filter(uniq)
+        imports = scan_for_top_level_imports(toplevel.body)
         toplevel.localvars = []
         for item in assignments:
             if item not in toplevel.nonlocalvars:
                 toplevel.localvars.push(new_symbol(ast.SymbolVar, item))
-        toplevel.exports = toplevel.localvars.concat(callables).filter(uniq)
+        toplevel.exports = toplevel.localvars \
+            .concat(callables) \
+            .concat(imports).filter(uniq) # unique elements, but not names!
         toplevel.depends_on = depends_on
         toplevel.submodules = []
         toplevel.classes = class_map

--- a/src/rapydscript.pyj
+++ b/src/rapydscript.pyj
@@ -45,14 +45,15 @@ if browser_env:
     # browser environment
     rapydscript = exports = {}
 
-exports.parse_baselib = exports.parseBaselib = def(srcPath, beautify):
+exports.parse_baselib = exports.parseBaselib = def(srcPath, es6):
     try:
         fs = require('fs')
         baselibPath = require('path').join(srcPath, 'baselib.pyj')
         baselibAst = parser.parse(fs.readFileSync(baselibPath, "utf8"), {
             readfile: fs.readFileSync,  # utility for reading files when dealing with nested imports
             dropDocstrings: True,       # drop docstrings in the compiler
-            filename: 'baselib.pyj'
+            filename: 'baselib.pyj',
+            es6: es6
         })
     except as e:
         if e.code is "ENOENT":
@@ -93,51 +94,32 @@ exports.compile = compile = def(code, options):
 
     # because of the use of the same Rapydscript instance,
     # we should re-initialize all static objects between compilations
-    if browser_env:
-        parser.init_mod()
+    parser.init_mod()
 
     toplevel = parser.parse(code, utils.defaults(options, {
         toplevel: toplevel,
         output: {}
     }))
 
-    # account for unused baselib methods
-    if not options.omit_baselib and not browser_env:
-        if not toplevel.baselib['AssertionError']:
-            toplevel.baselib['extends'] -= 1
-        if not toplevel.baselib['IndexError']:
-            toplevel.baselib['extends'] -= 1
-        if not toplevel.baselib['KeyError']:
-            toplevel.baselib['extends'] -= 1
-        if not toplevel.baselib['TypeError']:
-            toplevel.baselib['extends'] -= 1
-        if not toplevel.baselib['ValueError']:
-            toplevel.baselib['extends'] -= 1
-        if not toplevel.baselib['kwargs']:
-            toplevel.baselib['in'] -= 1
-            toplevel.baselib['iterator'] -= 1
-            toplevel.baselib['range'] -= 1
-            toplevel.baselib['dir'] -= 1
-        if not toplevel.baselib['eq']:
-            toplevel.baselib['iterator'] -= 2
-            toplevel.baselib['range'] -= 1
-        if not toplevel.baselib['merge']:
-            toplevel.baselib['iterator'] -= 1
-        if not toplevel.baselib['mixin']:
-            toplevel.baselib['in'] -= 1
-            toplevel.baselib['iterator'] -= 2
-        if not toplevel.baselib['enumerate']:
-            toplevel.baselib['iterator'] -= 1
-            toplevel.baselib['range'] -= 1
-        if not toplevel.baselib['all']:
-            toplevel.baselib['iterator'] -= 1
-        if not toplevel.baselib['any']:
-            toplevel.baselib['iterator'] -= 1
-        if not toplevel.baselib['zip']:
-            toplevel.baselib['iterator'] -= 1
-            toplevel.baselib['range'] -= 1
-        if not toplevel.baselib['rebind_all']:
-            toplevel.baselib['bind'] -= 1
+
+    # add baselib internal deps
+    if not options.omit_baselib:
+        baselib_dep_map = {
+            '.+Error': ['extends'],
+            'all|any|zip|iterable|kwargs|eq|merge|mixin|enumerate': ['iterable'],
+            'kwargs': ['in', 'range', 'merge', 'dir'],
+            'eq': ['range'],
+            'mixin':['in'],
+            'zip':['range'],
+            'rebind_all':['bind'],
+        }
+        for fun in Object.keys(toplevel.baselib).filter(def(f): return toplevel.baselib[f];):
+            for rex_key in baselib_dep_map:
+                rex = RegExp('^(' + rex_key + ')$')
+                if rex.test(fun):
+                    baselib_dep_map[rex_key] \
+                        .forEach(def(k): toplevel.baselib[k] = 1;)
+
 
     # output
     stream = output.Stream(options)
@@ -153,7 +135,7 @@ exports.minify = def(files, options):
         fromString: False,
         warnings: False,
     })
-    if JS('typeof files === "string"'):
+    if v'typeof files === "string"':
         files = [files] # handle single file
     for file in files:
         options.filename = options.fromString ? '?' : file


### PR DESCRIPTION
### Import improvements!:
+ modules do not running at load time until  `import foo`
+ `mod.thing = new_value`  - really changes `thing` inside  `mod`
+ all module-level imports are included  in module exports
+ now, it is possible:
```python
# ------------- [ foo.pyj - some module containing async imports ] ----------------------
import bar   # normal module
async import baz #  module with deferred definition
...

# ------------- [ main.pyj - module that imports foo.pyj ] ----------------------
# before `import foo` we should define all async-modules, that `foo` depends  on 
# to do that there is a new lib - `mechanic.pyj`
import mechanic
mechanic.module_spec('baz').exports = { a_var: "baz a_var value" }

# now we can import foo
import foo
print(foo.baz.ar_var) # 'baz a_var value'
```


### Generic AMD loader
```python
#------------ AMD loader --------------

import mechanic
# useful:
# mechanic.module().keys() -> ['foo', 'bar', 'pack', 'pack.sub_mod' ,  ...]
# mechanic.module_spec('foo') -> {exports{}, body(), export(prop, get(), set()) }
# mechanic.module_spec().all() -> {foo: {exports{}, body(), export(prop, get(), set()) }, ...}
# mechanic.module_spec().defined() -> all().filter by if (body or exports)
# mechanic.module_spec().undefined() -> all().filter by if not (body or exports)

# ---------- [loader body]--------------
# collect all async modules from all modules/packages/submodules used in main-module (see below)
deps = mechanic.module_spec().undefined()
deps_keys = Object.keys(deps)
deps_keys_mapped = deps_keys.map(
    def(mod_name):
        map = {
                Vue: 'path/to/vue',
                axios: "path/to/axios.min",
        }
        return map[mod_name] or mod_name
)

define(deps_keys_mapped, def(*args):
    i = 0
    for dep_key in deps_keys:
       # hydrate async modules   
        mechanic.module_spec(dep_key).exports = args[i]
        i+=1

    # run main module
    import main
    # or even
    return main
)

```

